### PR TITLE
Update and rename .spectral.yml to .spectral.yaml

### DIFF
--- a/linting/config/.spectral.yaml
+++ b/linting/config/.spectral.yaml
@@ -5,6 +5,7 @@
 # - 19.03.2024: Corrected camara-http-methods rule
 # - 03.12.2024: Corrected camara-path-param-id and camara-discriminator-use to handle null values error in example fields
 # - 09.01.2025: Updated info-contact rule
+# - 03.06.2025: renamed to: .spectral.yaml
 
 
 extends: "spectral:oas"


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:
rename` .spectral.yml` to `.spectral.yaml` as this filename is used in workflows

It breaks the compatibility with Commonalities artifact, but it is recommended extension for YAML files:
https://yaml.org/faq.html

`.spectral.yaml ` is the default Spectral configuration file in Megalinter