### PR TITLE
Change file naming validation issues to LOW

### DIFF
--- a/scripts/api_review_validator_v0_6.py
+++ b/scripts/api_review_validator_v0_6.py
@@ -1830,10 +1830,10 @@ class CAMARAAPIValidator:
             expected_operation = test_filename.replace(f"{api_name}-", "")
             if expected_operation not in api_operations:
                 result.issues.append(ValidationIssue(
-                    Severity.MEDIUM, "Test File Naming",
+                    Severity.LOW, "Test File Naming",
                     f"Test file suggests operation `{expected_operation}` but it doesn't exist in API",
                     test_file,
-                    f"Use valid operation from: `{', '.join(api_operations)}`"
+                    f"Check if test file naming is as intended, consider to use valid operation from: `{', '.join(api_operations)}`"
                 ))
 
     def _validate_test_version_line(self, feature_line: str, api_version: str, api_title: str) -> bool:


### PR DESCRIPTION
Addresses https://github.com/camaraproject/tooling/issues/29.

#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:

Addresses #29 ... the validation rule is degraded to "LOW" priority and the use of one of the operationIds from the API definition is described as optional consideration if the current file names where chosen intentional.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #29

#### Special notes for reviewers:

Tested on the example of release PR of CallForwardingSignal within this manual run: https://github.com/hdamker/ReleaseManagement/actions/runs/16249967263
