### PR TITLE
Update api-review-trigger.yml - fix "Check Comment Trigger" with single quotes

### DIFF
--- a/api-review/workflows/api-review-trigger.yml
+++ b/api-review/workflows/api-review-trigger.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - name: Check Comment Trigger
         id: check
+        env:
+          COMMENT_BODY: ${{ toJSON(github.event.comment.body) }}
         run: |
           # Check if this is a comment event
           if [[ "${{ github.event_name }}" != "issue_comment" ]]; then
@@ -81,7 +83,7 @@ jobs:
           fi
           
           # Use jq to safely extract comment body and get first line only
-          COMMENT_FIRST_LINE=$(echo '${{ toJSON(github.event.comment.body) }}' | jq -r '. | split("\n")[0]')
+          COMMENT_FIRST_LINE=$(echo "$COMMENT_BODY" | jq -r '. | split("\n")[0]')
           
           echo "💬 Comment first line: '$COMMENT_FIRST_LINE'"
           


### PR DESCRIPTION


#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:

1. Added an env section to the step that sets COMMENT_BODY as an environment variable 
2. Changed the bash script to use this environment variable instead of the inline substitution

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #32 

#### Special notes for reviewers:

api-review-trigger.yml need to be deployed within ReleaseManagement to fix the issue there.

