### PR TITLE
Fix server url validation in API and test definition files

### DIFF
--- a/scripts/api_review_validator_v0_6.py
+++ b/scripts/api_review_validator_v0_6.py
@@ -1481,14 +1481,14 @@ class CAMARAAPIValidator:
                 if server_url.endswith('/wip'):
                     result.issues.append(ValidationIssue(
                         Severity.CRITICAL, "Server URL",
-                        f"Invalid work-in-progress URL suffix `/wip` (should be `/vwip` for WIP versions)",
+                        f"Invalid work-in-progress URL suffix `/wip`",
                         "servers[0].url",
-                        f"For release version `{version}`, use `{expected_suffix}`"
+                        f"For version `{version}`, use `{expected_suffix}`"
                     ))
                 elif server_url.endswith('/vwip'):
                     result.issues.append(ValidationIssue(
                         Severity.CRITICAL, "Server URL",
-                        f"Release version `{version}` cannot use work-in-progress URL suffix `/vwip`",
+                        f"Version `{version}` cannot use work-in-progress URL suffix `/vwip`",
                         "servers[0].url",
                         f"Update server URL to end with `{expected_suffix}`"
                     ))

--- a/scripts/api_review_validator_v0_6.py
+++ b/scripts/api_review_validator_v0_6.py
@@ -2135,7 +2135,12 @@ class CAMARAAPIValidator:
 
     def _validate_test_version_line(self, feature_line: str, api_version: str, api_title: str) -> bool:
         """Check if Feature line contains the API version"""
-        # Look for version pattern in Feature line
+        # Special handling for WIP versions - accept both 'wip' and 'vwip'
+        if api_version == 'wip':
+            feature_lower = feature_line.lower()
+            return 'wip' in feature_lower or 'vwip' in feature_lower
+        
+        # Look for semantic version pattern in Feature line
         version_pattern = r'v?\d+\.\d+\.\d+(?:-rc\.\d+|-alpha\.\d+)?'
         found_versions = re.findall(version_pattern, feature_line)
         

--- a/scripts/api_review_validator_v0_6.py
+++ b/scripts/api_review_validator_v0_6.py
@@ -2067,35 +2067,8 @@ class CAMARAAPIValidator:
         # Process matches - each match is (api_name_part, version_part, rest_of_path)
         found_urls = [(match[0], match[1], match[2] if len(match) > 2 else '') for match in matches]
         
-        # Determine expected URL suffix based on version
-        if api_version == 'wip':
-            expected_suffix = '/vwip'
-        elif api_version and re.match(r'^\d+\.\d+\.\d+(-rc\.\d+|-alpha\.\d+)?
-        
-        # Determine expected URL suffix based on version
-        if api_version == 'wip':
-            expected_suffix = '/vwip'
-        elif api_version and re.match(r'^\d+\.\d+\.\d+(-rc\.\d+|-alpha\.\d+)?$', api_version):
-            # Same logic as in version-URL consistency check
-            version_parts = api_version.split('.')
-            major = int(version_parts[0])
-            minor = int(version_parts[1])
-            
-            if major == 0:
-                base_version = f"v{major}.{minor}"
-            else:
-                base_version = f"v{major}"
-            
-            if '-rc.' in api_version:
-                rc_num = api_version.split('-rc.')[1]
-                expected_suffix = f"/{base_version}rc{rc_num}"
-            elif '-alpha.' in api_version:
-                alpha_num = api_version.split('-alpha.')[1]
-                expected_suffix = f"/{base_version}alpha{alpha_num}"
-            else:
-                expected_suffix = f"/{base_version}"
-        else:
-            return  # Invalid version, skip URL validation
+        # Get expected URL suffix using the helper function
+        expected_suffix = self._get_expected_url_suffix(api_version)
         
         # Check each found URL
         for url_api_name, url_version, rest_of_path in found_urls:


### PR DESCRIPTION
#### What type of PR is this?

bug & enhancement

#### What this PR does / why we need it:

This PR fixes critical issues in the CAMARA API Review Validator v0.6 related to version and URL consistency validation. The validator was incorrectly handling version-to-URL mappings and missing important validation checks for test files.

Key improvements:
1. **Fixed version-URL consistency validation**: The validator now correctly validates that server URLs match the API version format according to CAMARA conventions
2. **Added comprehensive test file URL validation**: Test files are now validated to ensure their resource URLs match the API name and version
3. **Improved error messages**: More specific and actionable error messages for version/URL mismatches
4. **Better handling of WIP versions**: Proper validation of work-in-progress APIs using 'vwip' suffix

#### Which issue(s) this PR fixes:

Fixes validation errors where:
- Server URLs with incorrect version suffixes were not being caught
- Test files with mismatched API versions were passing validation
- WIP version validation was inconsistent between API specs and test files

#### Special notes for reviewers:

The main changes are:
1. Added `_get_expected_url_suffix()` helper method that converts API versions to expected URL suffixes following CAMARA conventions
2. Replaced `_check_work_in_progress_version()` with `_check_version_url_consistency()` for more comprehensive validation
3. Added `_validate_test_file_urls()` to validate resource URLs in test files match the API specification
4. Updated test file validation to check both Feature line versions and resource URL versions

These changes ensure stricter compliance with CAMARA API versioning guidelines and prevent common mistakes in API definitions and test files.

#### Changelog input

```
release-note
Fixed version-URL consistency validation in API Review Validator v0.6
Added test file URL validation to ensure resource paths match API specifications
Improved error messages for version and URL mismatches
```

#### Additional documentation 

```docs
The validator now performs additional checks:
- Validates that server URL suffixes match the API version (e.g., version "0.1.0-rc.1" requires URL ending with "/v0.1rc1")
- Validates that test file resource URLs use the correct API name and version
- Provides specific fix suggestions for common versioning mistakes
```