### PR TITLE
Update .gherkin-lintrc to not count examples as separate test scenarios

### DIFF
--- a/linting/config/.gherkin-lintrc
+++ b/linting/config/.gherkin-lintrc
@@ -48,7 +48,7 @@
   ]
  }],
   "file-name": ["off", {"style": "kebab-case"}],
-  "max-scenarios-per-file": ["on", {"maxScenarios": 50, "countOutlineExamples": true}],
+  "max-scenarios-per-file": ["on", {"maxScenarios": 50, "countOutlineExamples": false}],
   "no-restricted-patterns": ["off", {
     "Global": [
       "^globally restricted pattern"


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:

Temporary solution for Fall25 meta-release:
Setting the rule:
"max-scenarios-per-file": ["on", {"maxScenarios": 50, "countOutlineExamples": **false**}]
The final update of Gherkin linting rules is under discussion in https://github.com/camaraproject/Commonalities/issues/520

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:

The rule triggered error only in 1 API test definition - but the test definition is valid and feasible to be used testing API implementations.

#### Changelog input

```
 release-note

```

#### Additional documentation 
https://github.com/camaraproject/Commonalities/discussions/519

