### PR TITLE
Raise requests version floor to >=2.32.4

### DIFF
--- a/.github/workflows/api-review-reusable.yml
+++ b/.github/workflows/api-review-reusable.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           echo "📦 Installing Python dependencies..."
           pip install --upgrade pip
-          pip install pyyaml>=6.0 jsonschema>=4.0 openapi-spec-validator>=0.5 requests>=2.28
+          pip install pyyaml>=6.0 jsonschema>=4.0 openapi-spec-validator>=0.5 requests>=2.32.4
 
       - name: Locate Validator Script
         run: |


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Raises the `requests` version floor from `>=2.28` to `>=2.32.4` in `api-review-reusable.yml` to exclude versions affected by:
- CVE-2024-35195 (fixed in 2.32.0): `Session` does not verify certificates after first request with `verify=False`
- CVE-2024-47081 (fixed in 2.32.4): proxy credentials leaked in redirected requests

No functional impact — the `requests` API is stable across these versions.

#### Which issue(s) this PR fixes:

Fixes #61

#### Special notes for reviewers:

Single-line change on line 171. GitHub Actions runners already ship recent `requests` versions, so this is a safety floor adjustment only.

#### Changelog input

```release-note
Raise requests version floor to >=2.32.4 to exclude CVE-affected versions
```

#### Additional documentation

```docs
n/a
```