### PR TITLE
Remove 'none' option from release_track in validation schema

### DIFF
--- a/validation/schemas/release-plan-schema.yaml
+++ b/validation/schemas/release-plan-schema.yaml
@@ -22,11 +22,9 @@ properties:
         type: string
         description: |
           Release track determining how the repository participates in CAMARA releases:
-          - none: No release planned, other repository fields can be omitted
-          - independent: Release outside meta-release cycle
+          - independent: Release outside meta-release cycle (default)
           - meta-release: Participating in a CAMARA meta-release cycle (requires meta_release field)
         enum:
-          - "none"
           - "independent"
           - "meta-release"
 

--- a/validation/scripts/validate-release-plan.py
+++ b/validation/scripts/validate-release-plan.py
@@ -114,7 +114,7 @@ class ReleasePlanValidator:
             self.errors.append(
                 "release_track is 'meta-release' but meta_release field is missing"
             )
-        elif release_track in ['none', 'independent'] and meta_release:
+        elif release_track == 'independent' and meta_release:
             self.warnings.append(
                 f"release_track is '{release_track}' but meta_release field is present"
             )


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Aligns the tooling validation schema and script with ReleaseManagement#375 (PR ReleaseManagement#377), which removed the redundant `none` option from `release_track`. The `none` value was behaviorally identical to `independent` and created confusion.

Changes:
- `validation/schemas/release-plan-schema.yaml`: Removed `"none"` from `release_track` enum, updated description to note `independent` as default
- `validation/scripts/validate-release-plan.py`: Updated `_check_track_consistency()` to remove `'none'` from the check

#### Which issue(s) this PR fixes:

Fixes #65

#### Special notes for reviewers:

The authoritative schema change was already merged in ReleaseManagement#377. This PR propagates the same change to the tooling copy.

#### Changelog input

```
 release-note
Remove 'none' option from release_track validation, aligning with ReleaseManagement schema update
```

#### Additional documentation 

This section can be blank.

```
docs

```