### PR TITLE
Add release-automation-reusable.yml placeholder

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -1,0 +1,17 @@
+# Release Automation Reusable Workflow (placeholder)
+#
+# This placeholder enables GitHub Actions to resolve workflow_call references
+# to this file. The full implementation lives on the 'release-automation' branch.
+#
+# This file will be replaced when the release-automation branch merges to main.
+
+name: Release Automation
+
+on:
+  workflow_call:
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Placeholder. Full implementation on the release-automation branch."


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Adds a minimal placeholder for `release-automation-reusable.yml` on `main`. GitHub Actions requires reusable workflow files to exist on the default branch to resolve `workflow_call` references. Without this placeholder, callers referencing `@release-automation` cannot invoke the workflow.

The full implementation is in PR #67 (targeting the `release-automation` branch). This placeholder will be replaced when that branch merges to `main`.

#### Which issue(s) this PR fixes:

Prerequisite for #67

#### Special notes for reviewers:

The placeholder is 17 lines — just `workflow_call` trigger and a single echo step. No functional logic.

#### Changelog input

```
release-note
none
```

#### Additional documentation

```
docs
none
```