### PR TITLE
docs: repository setup for 3-ruleset branch protection design

### DIFF
--- a/release_automation/docs/repository-setup.md
+++ b/release_automation/docs/repository-setup.md
@@ -1,6 +1,6 @@
 # Repository Setup for Release Automation
 
-**Last Updated**: 2026-02-18
+**Last Updated**: 2026-03-01
 
 ## Overview
 
@@ -52,7 +52,7 @@ No ruleset is needed for `release-review/**` branches — codeowners push review
 | **Name** | `release-snapshot-protection` |
 | **Enforcement** | Active |
 | **Target** | Include branches matching: `release-snapshot/**` |
-| **Bypass actors** | `camara-release-automation` GitHub App (always) |
+| **Bypass actors** | `camara-release-automation` GitHub App (always), Organization admins (always) |
 
 **Branch protection rules:**
 - Restrict creations — only bypass actors may create snapshot branches
@@ -346,18 +346,19 @@ Minimum required fields:
 
 ```yaml
 repository:
+  release_track: meta-release          # or: independent
+  meta_release: Sync26                 # required when release_track is meta-release
   target_release_tag: r1.1
   target_release_type: pre-release-rc  # or: pre-release-alpha, public-release, none
-  release_track: meta-release           # independent or meta-release
-  meta_release: Sync26
-
-apis:
-  - api_name: quality-on-demand
-    api_version: 0.11.0
 
 dependencies:
-  commonalities: "0.5"                 # Commonalities version
-  identity-and-consent-management: "0.3"  # ICM version (if applicable)
+  commonalities_release: r4.1
+  identity_consent_management_release: r4.1
+
+apis:
+  - api_name: release-test
+    target_api_version: 1.0.0
+    target_api_status: rc              # or: draft, alpha, public
 ```
 
 Valid `target_release_type` values: `pre-release-alpha`, `pre-release-rc`, `public-release`, `maintenance-release`, `none`


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Updates `repository-setup.md` to document the branch protection ruleset design:

- **`release-snapshot-protection`**: Single consolidated ruleset for snapshot and release-review branches (replaces the earlier 3-ruleset draft design). Bypass actor is `camara-release-automation` GitHub App (with OrganizationAdmin). Includes `required_reviewers` for `release-management_reviewers` team with 2 required approvals. `update` rule removed (blocks PR merges for non-bypass actors).
- **`release-pointer-protection`** and **`pre-release-pointer-protection`**: Rulesets for permanent pointer branches (`release/rX.Y`, `pre-release/rX.Y`)
- Updates CODEOWNERS guidance: legacy `/CHANGELOG.md` lines kept during onboarding, RM reviewer enforcement moves to the ruleset
- Updates `release-plan.yaml` example with current schema field names and Sync26 meta-release
- Updates verification checklist

All three rulesets are created in `Template_API_Repository` and applied to API repositories by the `apply-release-rulesets.sh` onboarding script.

#### Which issue(s) this PR fixes:

Fixes #71 

#### Special notes for reviewers:

The JSON payload in the document was extracted from the actual ruleset in Template_API_Repository. The `required_reviewers` field is a beta feature in the GitHub Rulesets API but is functional and available in the UI.

Related PRs:
- tooling#93 (pointer branch implementation)
- RM#393 / RM#394 (pointer branch design doc and issue)

#### Changelog input

```
 release-note
Define API repository setup documentation for release automation (3 rulesets: snapshot protection with GitHub App bypass and required reviewers, plus release and pre-release pointer branch protection)
```

#### Additional documentation 

This section can be blank.

```
docs

```