### PR TITLE
Use GitHub App identity for bot commits

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -1438,8 +1438,8 @@ jobs:
             exit 0
           }
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "camara-release-automation[bot]"
+          git config user.email "2865881+camara-release-automation[bot]@users.noreply.github.com"
           git commit -m "chore: post-release sync for ${RELEASE_TAG}"
           git push origin "$SYNC_BRANCH"
 

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -104,8 +104,8 @@ class SnapshotCreator:
     SNAPSHOT_BRANCH_PREFIX = "release-snapshot"
     RELEASE_REVIEW_BRANCH_PREFIX = "release-review"
     SHORT_SHA_LENGTH = 7
-    BOT_NAME = "CAMARA Release Bot"
-    BOT_EMAIL = "noreply@camaraproject.org"
+    BOT_NAME = "camara-release-automation[bot]"
+    BOT_EMAIL = "2865881+camara-release-automation[bot]@users.noreply.github.com"
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes #73

Replaces custom/generic git identities with the `camara-release-automation` App's GitHub noreply format so commits are attributed to the bot account. This fixes EasyCLA "unknown commit author" errors on Release PRs.

**Changes:**
- `snapshot_creator.py`: `noreply@camaraproject.org` → App noreply email
- `release-automation-reusable.yml`: `github-actions[bot]` → App identity (post-release sync PR)

**Testing:** 471 unit tests pass. E2E verification on `camaraproject/TestRepo` after merge.