### PR TITLE
Derive bot identity from token instead of hardcoding

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -1438,8 +1438,12 @@ jobs:
             exit 0
           }
 
-          git config user.name "camara-release-automation[bot]"
-          git config user.email "2865881+camara-release-automation[bot]@users.noreply.github.com"
+          # Derive git user from token identity
+          TOKEN_INFO=$(gh api user --jq '{login: .login, id: .id}')
+          TOKEN_USER=$(echo "$TOKEN_INFO" | jq -r '.login')
+          TOKEN_ID=$(echo "$TOKEN_INFO" | jq -r '.id')
+          git config user.name "$TOKEN_USER"
+          git config user.email "${TOKEN_ID}+${TOKEN_USER}@users.noreply.github.com"
           git commit -m "chore: post-release sync for ${RELEASE_TAG}"
           git push origin "$SYNC_BRANCH"
 

--- a/release_automation/scripts/github_client.py
+++ b/release_automation/scripts/github_client.py
@@ -90,6 +90,16 @@ class GitHubClient:
         except subprocess.CalledProcessError as e:
             raise GitHubClientError(f"gh command failed: {e.stderr}")
 
+    def get_authenticated_user(self) -> Dict[str, Any]:
+        """
+        Get the authenticated user for the current token.
+
+        Returns:
+            Dict with 'id' (int), 'login' (str), and 'type' (str)
+        """
+        output = self._run_gh(["api", "/user", "--jq", "{id: .id, login: .login, type: .type}"])
+        return json.loads(output.strip())
+
     def tag_exists(self, tag: str) -> bool:
         """
         Check if a tag exists in the repository.

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -104,8 +104,6 @@ class SnapshotCreator:
     SNAPSHOT_BRANCH_PREFIX = "release-snapshot"
     RELEASE_REVIEW_BRANCH_PREFIX = "release-review"
     SHORT_SHA_LENGTH = 7
-    BOT_NAME = "camara-release-automation[bot]"
-    BOT_EMAIL = "2865881+camara-release-automation[bot]@users.noreply.github.com"
 
     def __init__(
         self,
@@ -130,6 +128,11 @@ class SnapshotCreator:
         self.transformer = transformer
         self.metadata_gen = metadata_generator
         self.state_manager = state_manager
+
+        # Derive bot identity from the authenticated token
+        user_info = github_client.get_authenticated_user()
+        self.bot_name = user_info["login"]
+        self.bot_email = f"{user_info['id']}+{user_info['login']}@users.noreply.github.com"
 
     def create_snapshot(
         self,
@@ -201,7 +204,7 @@ class SnapshotCreator:
             )
 
             git_ops.clone(branch=config.base_branch)
-            git_ops.configure_user(self.BOT_NAME, self.BOT_EMAIL)
+            git_ops.configure_user(self.bot_name, self.bot_email)
 
             # Step 7: Create snapshot branch
             git_ops.create_branch(snapshot_branch)

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -38,6 +38,9 @@ def mock_github_client():
     client.list_branches.return_value = [
         Mock(name="main", sha="abc1234567890abcdef1234567890abcdef12345678")
     ]
+    client.get_authenticated_user.return_value = {
+        "id": 12345, "login": "test-bot[bot]", "type": "Bot"
+    }
     return client
 
 


### PR DESCRIPTION
## Summary

- Derive bot commit identity dynamically via `gh api user` instead of hardcoding
- Previous fix (PR #77) used the App ID instead of the bot user ID in the noreply email, so GitHub couldn't link commits to the bot account and EasyCLA still failed
- Matches the pattern already used in `campaign-finalize-per-repo/action.yml`

## Changes

- `github_client.py`: Add `get_authenticated_user()` method
- `snapshot_creator.py`: Replace hardcoded class constants with token-derived identity
- `release-automation-reusable.yml`: Sync PR job derives identity from token
- `test_snapshot_creator.py`: Update mock fixture

Fixes #73