### PR TITLE
Resolve bot identity via /users/ lookup instead of /user

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -726,6 +726,23 @@ jobs:
             release_automation/config
             shared-actions/create-snapshot
 
+      - name: Resolve Bot Identity
+        id: bot-identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          if [ -n "${{ vars.RELEASE_APP_SLUG }}" ] && [ -n "${{ steps.app-token.outputs.token }}" ]; then
+            BOT_LOGIN="${{ vars.RELEASE_APP_SLUG }}[bot]"
+          else
+            BOT_LOGIN="github-actions[bot]"
+          fi
+          BOT_INFO=$(gh api "/users/$BOT_LOGIN" --jq '{id: .id, login: .login}')
+          BOT_NAME=$(echo "$BOT_INFO" | jq -r '.login')
+          BOT_ID=$(echo "$BOT_INFO" | jq -r '.id')
+          echo "Committing as: $BOT_NAME <${BOT_ID}+${BOT_NAME}@users.noreply.github.com>"
+          echo "bot_name=$BOT_NAME" >> $GITHUB_OUTPUT
+          echo "bot_email=${BOT_ID}+${BOT_NAME}@users.noreply.github.com" >> $GITHUB_OUTPUT
+
       - name: Create Snapshot
         id: create
         uses: ./_tooling/shared-actions/create-snapshot
@@ -733,6 +750,8 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           base_branch: main
           github_token: ${{ steps.app-token.outputs.token || github.token }}
+          bot_name: ${{ steps.bot-identity.outputs.bot_name }}
+          bot_email: ${{ steps.bot-identity.outputs.bot_email }}
 
       - name: Log Result
         if: always()
@@ -1438,12 +1457,12 @@ jobs:
             exit 0
           }
 
-          # Derive git user from token identity
-          TOKEN_INFO=$(gh api user --jq '{login: .login, id: .id}')
-          TOKEN_USER=$(echo "$TOKEN_INFO" | jq -r '.login')
-          TOKEN_ID=$(echo "$TOKEN_INFO" | jq -r '.id')
-          git config user.name "$TOKEN_USER"
-          git config user.email "${TOKEN_ID}+${TOKEN_USER}@users.noreply.github.com"
+          # Derive git user from github-actions bot (sync PR uses GITHUB_TOKEN)
+          BOT_INFO=$(gh api "/users/github-actions[bot]" --jq '{id: .id, login: .login}')
+          BOT_NAME=$(echo "$BOT_INFO" | jq -r '.login')
+          BOT_ID=$(echo "$BOT_INFO" | jq -r '.id')
+          git config user.name "$BOT_NAME"
+          git config user.email "${BOT_ID}+${BOT_NAME}@users.noreply.github.com"
           git commit -m "chore: post-release sync for ${RELEASE_TAG}"
           git push origin "$SYNC_BRANCH"
 

--- a/release_automation/scripts/github_client.py
+++ b/release_automation/scripts/github_client.py
@@ -90,14 +90,20 @@ class GitHubClient:
         except subprocess.CalledProcessError as e:
             raise GitHubClientError(f"gh command failed: {e.stderr}")
 
-    def get_authenticated_user(self) -> Dict[str, Any]:
+    def get_user(self, login: str) -> Dict[str, Any]:
         """
-        Get the authenticated user for the current token.
+        Look up a GitHub user by login name.
+
+        Works with any token type (App installation, GITHUB_TOKEN, PAT)
+        because it uses the public /users/ endpoint.
+
+        Args:
+            login: GitHub user login (e.g., "camara-release-automation[bot]")
 
         Returns:
             Dict with 'id' (int), 'login' (str), and 'type' (str)
         """
-        output = self._run_gh(["api", "/user", "--jq", "{id: .id, login: .login, type: .type}"])
+        output = self._run_gh(["api", f"/users/{login}", "--jq", "{id: .id, login: .login, type: .type}"])
         return json.loads(output.strip())
 
     def tag_exists(self, tag: str) -> bool:

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -112,6 +112,8 @@ class SnapshotCreator:
         transformer: MechanicalTransformer,
         metadata_generator: MetadataGenerator,
         state_manager: ReleaseStateManager,
+        bot_name: str = "github-actions[bot]",
+        bot_email: str = "41898282+github-actions[bot]@users.noreply.github.com",
     ):
         """
         Initialize snapshot creator with dependencies.
@@ -122,17 +124,16 @@ class SnapshotCreator:
             transformer: MechanicalTransformer for placeholder replacements
             metadata_generator: MetadataGenerator for release-metadata.yaml
             state_manager: ReleaseStateManager for state validation
+            bot_name: Git committer name for snapshot commits
+            bot_email: Git committer email for snapshot commits
         """
         self.gh = github_client
         self.version_calc = version_calculator
         self.transformer = transformer
         self.metadata_gen = metadata_generator
         self.state_manager = state_manager
-
-        # Derive bot identity from the authenticated token
-        user_info = github_client.get_authenticated_user()
-        self.bot_name = user_info["login"]
-        self.bot_email = f"{user_info['id']}+{user_info['login']}@users.noreply.github.com"
+        self.bot_name = bot_name
+        self.bot_email = bot_email
 
     def create_snapshot(
         self,

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -38,9 +38,6 @@ def mock_github_client():
     client.list_branches.return_value = [
         Mock(name="main", sha="abc1234567890abcdef1234567890abcdef12345678")
     ]
-    client.get_authenticated_user.return_value = {
-        "id": 12345, "login": "test-bot[bot]", "type": "Bot"
-    }
     return client
 
 

--- a/shared-actions/create-snapshot/action.yml
+++ b/shared-actions/create-snapshot/action.yml
@@ -25,6 +25,14 @@ inputs:
   github_token:
     description: 'GitHub token with repo and PR write permissions'
     required: true
+  bot_name:
+    description: 'Git committer name for snapshot commits'
+    required: false
+    default: 'github-actions[bot]'
+  bot_email:
+    description: 'Git committer email for snapshot commits'
+    required: false
+    default: '41898282+github-actions[bot]@users.noreply.github.com'
 
 outputs:
   success:
@@ -74,6 +82,8 @@ runs:
         DRY_RUN: ${{ inputs.dry_run }}
         REPO: ${{ github.repository }}
         SCRIPTS_PATH: ${{ github.action_path }}/../../release_automation/scripts
+        BOT_NAME: ${{ inputs.bot_name }}
+        BOT_EMAIL: ${{ inputs.bot_email }}
       run: |
         import os
         import sys
@@ -142,6 +152,8 @@ runs:
                 transformer=transformer,
                 metadata_generator=metadata_gen,
                 state_manager=state_manager,
+                bot_name=os.environ.get('BOT_NAME', 'github-actions[bot]'),
+                bot_email=os.environ.get('BOT_EMAIL', '41898282+github-actions[bot]@users.noreply.github.com'),
             )
         except Exception as e:
             print(f"::error::Failed to initialize components: {e}")


### PR DESCRIPTION
## Summary

- App installation tokens and `GITHUB_TOKEN` cannot call `/user` (HTTP 403)
- Instead, resolve the bot login from `vars.RELEASE_APP_SLUG` (for App tokens) or default to `github-actions[bot]`, then look up the user ID via the public `/users/{login}` endpoint
- Workflow passes `bot_name` and `bot_email` to the `create-snapshot` composite action, which forwards them to `SnapshotCreator`
- Requires new org variable `RELEASE_APP_SLUG` (value: `camara-release-automation`)

## Changes

- `release-automation-reusable.yml`: Add bot identity resolution step in create-snapshot job; fix sync PR job to use `/users/` lookup
- `github_client.py`: Replace `get_authenticated_user()` with `get_user(login)` using public `/users/` endpoint
- `snapshot_creator.py`: Accept `bot_name`/`bot_email` as constructor parameters instead of deriving from token
- `create-snapshot/action.yml`: Add `bot_name`/`bot_email` inputs, pass as env vars to Python script

Fixes #73