### PR TITLE
Fix: handle 403 gracefully on fork PRs in pr_validation

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -114,15 +114,23 @@ jobs:
             }
 
             // Create separate check status (visible in PR checks list)
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: valid ? 'success' : 'failure',
-              context: '--> Validate: release-plan.yaml',
-              description: description,
-              target_url: runUrl
-            });
+            try {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: context.sha,
+                state: valid ? 'success' : 'failure',
+                context: '--> Validate: release-plan.yaml',
+                description: description,
+                target_url: runUrl
+              });
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning('Cannot post commit status — insufficient permissions (common for fork PRs). Validation result: ' + description);
+              } else {
+                throw error;
+              }
+            }
 
             if (!valid) {
               // Output errors as annotations


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The `pr_validation` workflow crashes when a fork PR changes `release-plan.yaml`. The `createCommitStatus()` API call fails with HTTP 403 because `GITHUB_TOKEN` has insufficient permissions for fork-initiated PRs. The validation itself passes, but the unhandled error causes the job to fail.

This wraps the `createCommitStatus()` call in a try-catch block. On 403, it logs a warning with the validation result instead of crashing. Other errors are re-thrown. MegaLinter in the same workflow already handles 403s gracefully — this aligns the release-plan validation step.

#### Which issue(s) this PR fixes:

Fixes #76

#### Special notes for reviewers:

The fix is minimal: only the `createCommitStatus()` call is wrapped. The rest of the step (error annotations, job summary, `core.setFailed`) writes to workflow logs/summary, not to the repo API, so it works fine with fork PR tokens.

#### Changelog input

```
 release-note
Fix: pr_validation no longer crashes on fork PRs that change release-plan.yaml
```

#### Additional documentation

This section can be blank.

```
docs

```