### PR TITLE
Consistent App bot identity for all workflow activities

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -244,6 +244,14 @@ jobs:
             core.setOutput('should_continue', shouldContinue);
             core.setOutput('confirm_tag', confirmTag);
 
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       # Post early acknowledgment for slash commands (within check-trigger to avoid runner cold-start)
       # This comment is later updated by post-interim (valid) or post-rejection (rejected).
       - name: Post Acknowledgment
@@ -252,6 +260,7 @@ jobs:
         continue-on-error: true
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const command = '${{ steps.detect.outputs.command }}';
             const user = '${{ steps.detect.outputs.user }}';
@@ -345,6 +354,14 @@ jobs:
             echo "action=fail_workflow" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate App Token
+        id: app-token
+        if: steps.decide.outputs.action == 'post_comment' && vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout tooling (for slash command)
         if: steps.decide.outputs.action == 'post_comment'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -361,6 +378,7 @@ jobs:
         if: steps.decide.outputs.action == 'post_comment'
         uses: ./_tooling/shared-actions/post-bot-comment
         with:
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           issue_number: ${{ needs.check-trigger.outputs.issue_number }}
           release_tag: "unknown"
           run_id: ${{ github.run_id }}
@@ -464,6 +482,14 @@ jobs:
     outputs:
       comment_id: ${{ steps.post.outputs.comment_id }}
     steps:
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout tooling
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -479,6 +505,7 @@ jobs:
         id: post
         uses: ./_tooling/shared-actions/post-bot-comment
         with:
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           issue_number: ${{ needs.check-trigger.outputs.issue_number }}
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
@@ -662,6 +689,14 @@ jobs:
       needs.validate-command.outputs.allowed == 'false'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout tooling
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -676,6 +711,7 @@ jobs:
       - name: Post Rejection Comment
         uses: ./_tooling/shared-actions/post-bot-comment
         with:
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           issue_number: ${{ needs.check-trigger.outputs.issue_number }}
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
@@ -1017,6 +1053,14 @@ jobs:
       needs.check-trigger.outputs.confirm_tag == ''
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout tooling
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -1039,6 +1083,7 @@ jobs:
       - name: Post confirmation message
         uses: ./_tooling/shared-actions/post-bot-comment
         with:
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           issue_number: ${{ needs.check-trigger.outputs.issue_number }}
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
@@ -1220,6 +1265,14 @@ jobs:
             release_automation
             shared-actions
 
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Setup Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
@@ -1231,7 +1284,7 @@ jobs:
       - name: Read release metadata from tag
         id: metadata
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           RELEASE_TAG: ${{ needs.derive-state.outputs.release_tag }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
@@ -1256,7 +1309,7 @@ jobs:
       - name: Determine release state and build data
         id: release-data
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           METADATA_YAML: ${{ steps.metadata.outputs.metadata_yaml }}
           RELEASE_TAG: ${{ needs.derive-state.outputs.release_tag }}
         shell: python
@@ -1382,7 +1435,7 @@ jobs:
       - name: Copy CHANGELOG from release tag
         id: changelog
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           RELEASE_TAG: ${{ needs.derive-state.outputs.release_tag }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
@@ -1425,10 +1478,26 @@ jobs:
               core.setOutput('synced', 'false');
             }
 
+      - name: Resolve Bot Identity
+        id: bot-identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          if [ -n "${{ vars.RELEASE_APP_SLUG }}" ] && [ -n "${{ steps.app-token.outputs.token }}" ]; then
+            BOT_LOGIN="${{ vars.RELEASE_APP_SLUG }}[bot]"
+          else
+            BOT_LOGIN="github-actions[bot]"
+          fi
+          BOT_INFO=$(gh api "/users/$BOT_LOGIN" --jq '{id: .id, login: .login}')
+          BOT_NAME=$(echo "$BOT_INFO" | jq -r '.login')
+          BOT_ID=$(echo "$BOT_INFO" | jq -r '.id')
+          echo "bot_name=$BOT_NAME" >> $GITHUB_OUTPUT
+          echo "bot_email=${BOT_ID}+${BOT_NAME}@users.noreply.github.com" >> $GITHUB_OUTPUT
+
       - name: Create sync PR
         id: sync
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           RELEASE_TAG: ${{ needs.derive-state.outputs.release_tag }}
           README_CHANGED: ${{ steps.readme.outputs.changed }}
           CHANGELOG_SYNCED: ${{ steps.changelog.outputs.synced }}
@@ -1457,12 +1526,8 @@ jobs:
             exit 0
           }
 
-          # Derive git user from github-actions bot (sync PR uses GITHUB_TOKEN)
-          BOT_INFO=$(gh api "/users/github-actions[bot]" --jq '{id: .id, login: .login}')
-          BOT_NAME=$(echo "$BOT_INFO" | jq -r '.login')
-          BOT_ID=$(echo "$BOT_INFO" | jq -r '.id')
-          git config user.name "$BOT_NAME"
-          git config user.email "${BOT_ID}+${BOT_NAME}@users.noreply.github.com"
+          git config user.name "${{ steps.bot-identity.outputs.bot_name }}"
+          git config user.email "${{ steps.bot-identity.outputs.bot_email }}"
           git commit -m "chore: post-release sync for ${RELEASE_TAG}"
           git push origin "$SYNC_BRANCH"
 
@@ -1501,6 +1566,14 @@ jobs:
       draft_release_url: ${{ steps.create-draft.outputs.draft_release_url }}
       error_message: ${{ steps.create-draft.outputs.error_message }}
     steps:
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Extract CHANGELOG release notes
         id: changelog
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
@@ -1591,6 +1664,7 @@ jobs:
         env:
           RELEASE_NOTES: ${{ steps.changelog.outputs.release_notes }}
         with:
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const releaseTag = '${{ needs.derive-state.outputs.release_tag }}';
             const snapshotBranch = '${{ needs.derive-state.outputs.snapshot_branch }}';
@@ -1662,6 +1736,7 @@ jobs:
           run_id: ${{ github.run_id }}
           template: draft_created
           base_context: ${{ needs.assemble-context.outputs.base_context }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
               "draft_release_url": "${{ steps.create-draft.outputs.draft_release_url }}",
@@ -1683,6 +1758,14 @@ jobs:
     outputs:
       action_taken: ${{ steps.handle.outputs.action_taken }}
     steps:
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout tooling
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -1698,6 +1781,7 @@ jobs:
         id: handle
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const triggerType = '${{ needs.check-trigger.outputs.trigger_type }}';
             const currentState = '${{ needs.derive-state.outputs.state }}';
@@ -1743,6 +1827,7 @@ jobs:
           run_id: ${{ github.run_id }}
           template: issue_reopened
           base_context: ${{ needs.assemble-context.outputs.base_context }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
               "reason": "Cannot close Release Issue while release is in progress"
@@ -1782,6 +1867,14 @@ jobs:
       issue_action: ${{ steps.sync.outputs.issue_action }}
       issue_url: ${{ steps.sync.outputs.issue_url }}
     steps:
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout tooling
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -1803,7 +1896,7 @@ jobs:
           snapshot_branch: ${{ needs.derive-state.outputs.snapshot_branch }}
           release_pr_number: ${{ needs.derive-state.outputs.release_pr_number }}
           trigger_type: ${{ needs.check-trigger.outputs.trigger_type }}
-          github_token: ${{ github.token }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Log Result
         run: |
@@ -1824,6 +1917,7 @@ jobs:
           run_id: ${{ github.run_id }}
           template: state_not_planned
           base_context: ${{ needs.assemble-context.outputs.base_context }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
               "state": "not-planned"
@@ -1840,6 +1934,7 @@ jobs:
           run_id: ${{ github.run_id }}
           template: issue_created
           base_context: ${{ needs.assemble-context.outputs.base_context }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
               "state": "planned",
@@ -1863,6 +1958,7 @@ jobs:
           run_id: ${{ github.run_id }}
           template: config_drift_warning
           base_context: ${{ needs.assemble-context.outputs.base_context }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
               "trigger_type": "release_plan_change",
@@ -1897,6 +1993,14 @@ jobs:
       needs.publish-confirmation.result != 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout tooling
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -2074,6 +2178,7 @@ jobs:
           template: ${{ steps.template.outputs.template }}
           # Use base_context + delta
           base_context: ${{ needs.assemble-context.outputs.base_context }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: ${{ steps.context.outputs.context }}
           comment_id: ${{ needs.post-interim.outputs.comment_id }}
 
@@ -2090,6 +2195,7 @@ jobs:
           SYNC_PR_URL: ${{ needs.create-sync-pr.outputs.sync_pr_url }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const issueNumber = parseInt(process.env.ISSUE_NUMBER);
             const releaseTag = process.env.RELEASE_TAG;

--- a/shared-actions/post-bot-comment/action.yml
+++ b/shared-actions/post-bot-comment/action.yml
@@ -28,6 +28,10 @@ inputs:
   run_id:
     description: "Workflow run ID for marker uniqueness (preserves comment history across runs)"
     required: true
+  github_token:
+    description: "GitHub token for API authentication (defaults to github.token)"
+    required: false
+    default: ""
 
 outputs:
   comment_id:
@@ -153,6 +157,7 @@ runs:
         RENDERED_CONTENT: ${{ steps.render.outputs.content }}
         MARKER: ${{ steps.render.outputs.marker }}
       with:
+        github-token: ${{ inputs.github_token || github.token }}
         script: |
           const issueNumber = parseInt(process.env.ISSUE_NUMBER);
           const existingCommentId = process.env.EXISTING_COMMENT_ID;


### PR DESCRIPTION
## Summary

- Mint App token in all 10 jobs that perform write operations (comments, draft releases, issue management, sync PRs), so all activities are attributed to `camara-release-automation[bot]`
- Add `github_token` input to `post-bot-comment` shared action (backward-compatible)
- Replace hardcoded `github-actions[bot]` identity in `create-sync-pr` with dynamic resolution via `gh api /users/{login}`
- Repos without the App (`vars.RELEASE_APP_ID` empty) fall back to `github-actions[bot]` via `${{ steps.app-token.outputs.token || github.token }}`

## Details

After PRs #77–#79, the 4 jobs operating on protected branches (create-snapshot, discard-snapshot, delete-draft, publish-release) already mint an App token. This PR extends the same pattern to the remaining 10 jobs:

| Job | Write operations |
|-----|-----------------|
| `check-trigger` | Ack comment |
| `handle-config-error` | Config error comment |
| `post-interim` | Interim comment |
| `post-rejection` | Rejection comment |
| `publish-confirmation` | Confirmation comment |
| `handle-pr-merge` | Draft release + comment |
| `handle-issue-event` | Issue reopen + comment |
| `update-issue` | sync-release-issue + 3 comments |
| `post-result` | Result comment + close issue |
| `create-sync-pr` | Git push + PR creation |

Read-only jobs (derive-state, assemble-context, validate-command) are unchanged.

## Test plan

- [ ] Run `/create-snapshot` on test repo — verify ack, interim, result comments all from App bot
- [ ] Merge Release PR — verify draft_created comment and draft release from App bot
- [ ] Run `/publish-release --confirm` — verify result comment, issue close, sync PR commit + PR all from App bot
- [ ] Test on repo without `vars.RELEASE_APP_ID` — all operations fall back to `github-actions[bot]`