### PR TITLE
fix: always refresh Release Issue body in PLANNED state

### DIFF
--- a/release_automation/scripts/issue_sync.py
+++ b/release_automation/scripts/issue_sync.py
@@ -296,6 +296,12 @@ class IssueSyncManager:
         if self.issue_manager.should_update_title(current_title, release_plan):
             return True
 
+        # In PLANNED state, always refresh the issue body. This is the state
+        # where release-plan.yaml is actively edited (APIs added/renamed,
+        # dependencies changed, release type updated). The update is idempotent.
+        if state == ReleaseState.PLANNED:
+            return True
+
         return False
 
     def _update_release_issue(

--- a/release_automation/tests/test_issue_sync.py
+++ b/release_automation/tests/test_issue_sync.py
@@ -192,8 +192,8 @@ class TestSyncReleaseIssue:
         assert result.issue is not None
         gh.create_issue.assert_called_once()
 
-    def test_no_action_when_issue_exists_and_up_to_date(self):
-        """Test no action when issue exists and is up to date."""
+    def test_always_updates_issue_in_planned_state(self):
+        """Test that PLANNED state always triggers update to refresh CONFIG from release-plan.yaml."""
         manager, gh, state_manager, issue_manager, _ = self._create_manager()
 
         release_plan = {
@@ -212,12 +212,15 @@ class TestSyncReleaseIssue:
                 "labels": [{"name": "release-state:planned"}]
             }
         ]
+        gh.get_issue.return_value = {"number": 1, "title": "Release r4.1 (RC)"}
         issue_manager.should_update_title.return_value = False
+        issue_manager.generate_state_section.return_value = "**State**: planned"
+        issue_manager.update_section.return_value = "updated body"
 
         result = manager.sync_release_issue(release_plan)
 
-        assert result.action == "none"
-        assert result.reason == "up_to_date"
+        assert result.action == "updated"
+        assert result.issue is not None
 
     def test_updates_issue_when_state_changes(self):
         """Test issue update when state changes."""
@@ -350,8 +353,27 @@ class TestNeedsUpdate:
         result = manager._needs_update(issue, ReleaseState.SNAPSHOT_ACTIVE, {})
         assert result is True
 
-    def test_no_update_when_state_matches(self):
-        """Test returns False when state label matches."""
+    def test_no_update_when_non_planned_state_matches(self):
+        """Test returns False when non-PLANNED state label matches and title unchanged."""
+        issue_manager = MagicMock()
+        issue_manager.should_update_title.return_value = False
+
+        manager = IssueSyncManager(MagicMock(), MagicMock(), issue_manager, MagicMock())
+
+        issue = {
+            "labels": [{"name": "release-state:snapshot-active"}]
+        }
+
+        result = manager._needs_update(issue, ReleaseState.SNAPSHOT_ACTIVE, {})
+        assert result is False
+
+    def test_always_needs_update_in_planned_state(self):
+        """Test returns True in PLANNED state even when label and title match.
+
+        PLANNED is the state where release-plan.yaml is actively edited,
+        so the issue body should always be refreshed to reflect changes
+        in APIs, dependencies, or release type.
+        """
         issue_manager = MagicMock()
         issue_manager.should_update_title.return_value = False
 
@@ -362,7 +384,7 @@ class TestNeedsUpdate:
         }
 
         result = manager._needs_update(issue, ReleaseState.PLANNED, {})
-        assert result is False
+        assert result is True
 
     def test_needs_update_when_title_changed(self):
         """Test returns True when title needs updating."""
@@ -373,10 +395,10 @@ class TestNeedsUpdate:
 
         issue = {
             "title": "Old title",
-            "labels": [{"name": "release-state:planned"}]
+            "labels": [{"name": "release-state:snapshot-active"}]
         }
 
-        result = manager._needs_update(issue, ReleaseState.PLANNED, {"repository": {}})
+        result = manager._needs_update(issue, ReleaseState.SNAPSHOT_ACTIVE, {"repository": {}})
         assert result is True
 
 


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Fixes a bug where `sync_release_issue()` determined the Release Issue was "up_to_date" even when `release-plan.yaml` content had changed (e.g., API name renamed). The `_needs_update()` method only checked state label and title — it did not compare the CONFIG section content (APIs, dependencies) with the current `release-plan.yaml`.

The fix: in PLANNED state, always refresh the issue body. PLANNED is the only state where `release-plan.yaml` is actively edited, so refreshing is always appropriate. The update is idempotent. Other states (SNAPSHOT_ACTIVE, DRAFT_READY) have a frozen snapshot, so their CONFIG doesn't change from plan edits.

Discovered on [ReleaseTest run 22279374398](https://github.com/camaraproject/ReleaseTest/actions/runs/22279374398) — [Release Issue #6](https://github.com/camaraproject/ReleaseTest/issues/6) showed stale API name after [PR #9](https://github.com/camaraproject/ReleaseTest/pull/9) renamed it.

#### Which issue(s) this PR fixes:

Bug discovered during E2E testing on `camaraproject/ReleaseTest`.

#### Special notes for reviewers:

- 4 lines added to `_needs_update()` in `issue_sync.py` — the only code change
- Tests updated: 1 renamed to match new behavior, 1 moved to use SNAPSHOT_ACTIVE instead of PLANNED, 1 new test added for the always-update PLANNED check
- 472 tests pass (was 471)

#### Changelog input

```
 release-note
Fix: sync-issue now always refreshes Release Issue body in PLANNED state to reflect release-plan.yaml changes
```

#### Additional documentation

This section can be blank.

```
docs

```