### PR TITLE
Surface non-critical post-publish warnings in Release Issue

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -2144,6 +2144,31 @@ jobs:
               --arg sync_pr_number "${{ needs.create-sync-pr.outputs.sync_pr_number }}" \
               --arg src_commit_sha_short "$SRC_SHA_SHORT" \
               '. + {release_url: $release_url, reference_tag: $reference_tag, reference_tag_url: $reference_tag_url, sync_pr_url: $sync_pr_url, sync_pr_number: $sync_pr_number, src_commit_sha_short: $src_commit_sha_short}')
+
+            # Collect post-publish warnings (ref tag, pointer branch, cleanup, sync PR)
+            PUBLISH_WARNINGS=""
+
+            # Warnings from publish job (non-critical steps 2-4)
+            PUBLISH_ERR="${{ needs.publish-release.outputs.error_message }}"
+            if [ -n "$PUBLISH_ERR" ]; then
+              PUBLISH_WARNINGS="$PUBLISH_ERR"
+            fi
+
+            # Warning for sync PR failure
+            if [ "${{ needs.create-sync-pr.outputs.success }}" != "true" ]; then
+              SYNC_WARNING="Post-release sync PR failed — create manually"
+              if [ -n "$PUBLISH_WARNINGS" ]; then
+                PUBLISH_WARNINGS="$PUBLISH_WARNINGS; $SYNC_WARNING"
+              else
+                PUBLISH_WARNINGS="$SYNC_WARNING"
+              fi
+            fi
+
+            if [ -n "$PUBLISH_WARNINGS" ]; then
+              CONTEXT=$(echo "$CONTEXT" | jq \
+                --arg pw "$PUBLISH_WARNINGS" \
+                '. + {publish_warnings: $pw}')
+            fi
           fi
 
           # Add error message for command failure cases
@@ -2195,6 +2220,8 @@ jobs:
           RELEASE_URL: ${{ needs.publish-release.outputs.release_url }}
           REFERENCE_TAG: ${{ needs.publish-release.outputs.reference_tag }}
           SYNC_PR_URL: ${{ needs.create-sync-pr.outputs.sync_pr_url }}
+          PUBLISH_WARNINGS: ${{ needs.publish-release.outputs.error_message }}
+          SYNC_PR_SUCCESS: ${{ needs.create-sync-pr.outputs.success }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
@@ -2204,6 +2231,8 @@ jobs:
             const releaseUrl = process.env.RELEASE_URL;
             const referenceTag = process.env.REFERENCE_TAG;
             const syncPrUrl = process.env.SYNC_PR_URL;
+            const publishWarnings = process.env.PUBLISH_WARNINGS;
+            const syncPrSuccess = process.env.SYNC_PR_SUCCESS;
             const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
 
             console.log(`Closing release issue #${issueNumber} after success message`);
@@ -2226,6 +2255,18 @@ jobs:
               stateLines.push(`📌 **Reference tag:** [\`${referenceTag}\`](${repoUrl}/tree/${referenceTag})`);
               if (syncPrUrl) {
                 stateLines.push(`🔄 **Sync PR:** [View PR](${syncPrUrl})`);
+              }
+
+              // Collect warnings from non-critical post-publish steps
+              let warnings = [];
+              if (publishWarnings) {
+                warnings.push(publishWarnings);
+              }
+              if (syncPrSuccess !== 'true') {
+                warnings.push('Post-release sync PR failed — create manually');
+              }
+              if (warnings.length > 0) {
+                stateLines.push(`⚠️ **Warnings:** ${warnings.join('; ')}`);
               }
               const stateContent = stateLines.join('\n');
 

--- a/release_automation/scripts/bot_context.py
+++ b/release_automation/scripts/bot_context.py
@@ -89,6 +89,11 @@ class BotContext:
     sync_pr_url: str = ""
     src_commit_sha_short: str = ""  # First 7 chars of src_commit_sha
     confirm_tag: str = ""  # Tag from --confirm argument
+    publish_warnings: str = ""  # Semicolon-separated warnings from non-critical post-publish steps
+
+    # Derived publication flags (set by derive_flags())
+    has_sync_pr: bool = False
+    has_publish_warnings: bool = False
 
     def derive_flags(self) -> None:
         """Compute boolean flags and derived fields from string fields."""
@@ -103,6 +108,8 @@ class BotContext:
         self.trigger_release_plan_change = self.trigger_type == "release_plan_change"
         self.has_meta_release = bool(self.meta_release)
         self.has_reason = bool(self.reason)
+        self.has_sync_pr = bool(self.sync_pr_url)
+        self.has_publish_warnings = bool(self.publish_warnings)
         if not self.short_type:
             self.short_type = config.SHORT_TYPE_MAP.get(
                 self.release_type, self.release_type
@@ -177,4 +184,7 @@ class BotContext:
             "sync_pr_url": self.sync_pr_url,
             "src_commit_sha_short": self.src_commit_sha_short,
             "confirm_tag": self.confirm_tag,
+            "publish_warnings": self.publish_warnings,
+            "has_sync_pr": self.has_sync_pr,
+            "has_publish_warnings": self.has_publish_warnings,
         }

--- a/release_automation/templates/bot_messages/release_published.md
+++ b/release_automation/templates/bot_messages/release_published.md
@@ -1,6 +1,9 @@
 **🚀 Release published — State: `published`**
 Release published. This issue will be closed automatically.
-**Release:** [`{{release_tag}}`]({{release_url}}) · Post-release sync PR: [#{{sync_pr_number}}]({{sync_pr_url}}) (requires codeowner merge)
+**Release:** [`{{release_tag}}`]({{release_url}}){{#has_sync_pr}} · Post-release sync PR: [#{{sync_pr_number}}]({{sync_pr_url}}) (requires codeowner merge){{/has_sync_pr}}
+{{#has_publish_warnings}}
+⚠️ **Post-release warnings:** {{publish_warnings}} ([view log]({{workflow_run_url}}))
+{{/has_publish_warnings}}
 
 <details><summary><b>Configuration:</b> Release {{release_tag}}{{#short_type}} ({{short_type}}{{#has_meta_release}}, {{meta_release}}{{/has_meta_release}}){{/short_type}}</summary>
 

--- a/release_automation/tests/test_bot_context.py
+++ b/release_automation/tests/test_bot_context.py
@@ -50,6 +50,7 @@ class TestBotContext:
         assert ctx.sync_pr_url == ""
         assert ctx.src_commit_sha_short == ""
         assert ctx.confirm_tag == ""
+        assert ctx.publish_warnings == ""
 
         # List field defaults to empty list
         assert ctx.apis == []
@@ -66,6 +67,8 @@ class TestBotContext:
         assert ctx.trigger_release_plan_change is False
         assert ctx.has_meta_release is False
         assert ctx.has_reason is False
+        assert ctx.has_sync_pr is False
+        assert ctx.has_publish_warnings is False
 
     def test_derive_flags_missing_file(self):
         """error_type 'missing_file' sets is_missing_file flag."""
@@ -174,6 +177,7 @@ class TestBotContext:
             "release_url", "reference_tag", "reference_tag_url",
             "sync_pr_number", "sync_pr_url",
             "src_commit_sha_short", "confirm_tag",
+            "publish_warnings", "has_sync_pr", "has_publish_warnings",
         }
         assert set(d.keys()) == expected_keys
 
@@ -252,6 +256,7 @@ class TestBuildContext:
             "release_url", "reference_tag", "reference_tag_url",
             "sync_pr_number", "sync_pr_url",
             "src_commit_sha_short", "confirm_tag",
+            "publish_warnings", "has_sync_pr", "has_publish_warnings",
         }
         assert set(result.keys()) == expected_keys
 
@@ -389,6 +394,30 @@ class TestWP49Fields:
         ctx = BotContext(reason="")
         ctx.derive_flags()
         assert ctx.has_reason is False
+
+    def test_has_sync_pr_true(self):
+        """has_sync_pr is True when sync_pr_url is non-empty."""
+        ctx = BotContext(sync_pr_url="https://github.com/org/repo/pull/99")
+        ctx.derive_flags()
+        assert ctx.has_sync_pr is True
+
+    def test_has_sync_pr_false(self):
+        """has_sync_pr is False when sync_pr_url is empty."""
+        ctx = BotContext(sync_pr_url="")
+        ctx.derive_flags()
+        assert ctx.has_sync_pr is False
+
+    def test_has_publish_warnings_true(self):
+        """has_publish_warnings is True when publish_warnings is non-empty."""
+        ctx = BotContext(publish_warnings="Failed to create reference tag")
+        ctx.derive_flags()
+        assert ctx.has_publish_warnings is True
+
+    def test_has_publish_warnings_false(self):
+        """has_publish_warnings is False when publish_warnings is empty."""
+        ctx = BotContext(publish_warnings="")
+        ctx.derive_flags()
+        assert ctx.has_publish_warnings is False
 
     def test_short_type_alpha(self):
         """short_type derived from pre-release-alpha."""

--- a/release_automation/tests/test_bot_responder.py
+++ b/release_automation/tests/test_bot_responder.py
@@ -478,7 +478,7 @@ class TestPublicationTemplates:
         assert "closed automatically" in result
 
     def test_release_published_template_without_sync_pr(self, bot_responder):
-        """release_published template renders without sync PR."""
+        """release_published template renders without sync PR — no broken link."""
         from release_automation.scripts.context_builder import build_context
 
         context = build_context(
@@ -490,8 +490,72 @@ class TestPublicationTemplates:
         )
         result = bot_responder.render("release_published", context)
         assert "Release published" in result
-        # sync_pr_number is empty but always rendered in new template
+        # Sync PR section should NOT render when no sync PR
+        assert "codeowner merge" not in result
+        assert "[#]" not in result  # No broken link
+
+    def test_release_published_template_with_warnings(self, bot_responder):
+        """release_published template shows warning section when warnings exist."""
+        from release_automation.scripts.context_builder import build_context
+
+        context = build_context(
+            release_tag="r4.1",
+            state="published",
+            release_type="public-release",
+            release_url="https://github.com/org/repo/releases/tag/r4.1",
+            sync_pr_number="99",
+            sync_pr_url="https://github.com/org/repo/pull/99",
+            publish_warnings="Failed to create reference tag; Failed to create pointer branch",
+            workflow_run_url="https://github.com/org/repo/actions/runs/12345",
+            apis=[],
+        )
+        result = bot_responder.render("release_published", context)
+        assert "Release published" in result
+        assert "Post-release warnings" in result
+        assert "Failed to create reference tag" in result
+        assert "Failed to create pointer branch" in result
+        assert "view log" in result
+        # Sync PR should still render
+        assert "pull/99" in result
         assert "codeowner merge" in result
+
+    def test_release_published_template_sync_pr_failure_warning(self, bot_responder):
+        """release_published shows warning when sync PR failed (no sync PR link)."""
+        from release_automation.scripts.context_builder import build_context
+
+        context = build_context(
+            release_tag="r4.1",
+            state="published",
+            release_type="public-release",
+            release_url="https://github.com/org/repo/releases/tag/r4.1",
+            publish_warnings="Post-release sync PR failed — create manually",
+            workflow_run_url="https://github.com/org/repo/actions/runs/12345",
+            apis=[],
+        )
+        result = bot_responder.render("release_published", context)
+        assert "Release published" in result
+        # No sync PR link
+        assert "codeowner merge" not in result
+        # Warning visible
+        assert "Post-release warnings" in result
+        assert "sync PR failed" in result
+
+    def test_release_published_template_no_warnings(self, bot_responder):
+        """release_published template hides warning section when no warnings."""
+        from release_automation.scripts.context_builder import build_context
+
+        context = build_context(
+            release_tag="r4.1",
+            state="published",
+            release_type="public-release",
+            release_url="https://github.com/org/repo/releases/tag/r4.1",
+            sync_pr_number="99",
+            sync_pr_url="https://github.com/org/repo/pull/99",
+            apis=[],
+        )
+        result = bot_responder.render("release_published", context)
+        assert "Release published" in result
+        assert "Post-release warnings" not in result
 
     def test_publish_failed_template(self, bot_responder):
         """publish_failed template renders with error message."""


### PR DESCRIPTION
## Summary

When `/publish-release` succeeds but non-critical follow-up steps fail (reference tag creation, pointer branch creation, branch cleanup, sync PR creation), those failures were invisible in the Release Issue. Maintainers had to check workflow logs to discover the problem.

This PR surfaces all non-critical post-publish warnings:

- **Bot comment**: Sync PR link is now conditional (no broken `[#]()` link when sync PR fails). A warning section with details and workflow log link appears when any post-publish step fails.
- **Issue body**: The STATE section on issue close includes a warning line listing any failures.
- **Unified collection**: Warnings from the publish job (Steps 2-4: reference tag, pointer branch, cleanup) and the separate sync PR job are collected into a single `publish_warnings` field.

### Changes

| File | Change |
|------|--------|
| `release_automation/scripts/bot_context.py` | Add `publish_warnings` field, `has_sync_pr` + `has_publish_warnings` derived flags |
| `release_automation/templates/bot_messages/release_published.md` | Conditional sync PR link, warning section |
| `.github/workflows/release-automation-reusable.yml` | Post-result context: collect warnings; Close issue: show warnings |
| `release_automation/tests/test_bot_context.py` | 6 new tests for new fields/flags |
| `release_automation/tests/test_bot_responder.py` | 3 new + 1 updated template rendering tests |

## Test plan

- [x] All 508 tests pass (`python3 -m pytest release_automation/tests/ -v`)
- [x] Template renders correctly with sync PR (existing test updated)
- [x] Template renders without broken link when sync PR missing
- [x] Warning section appears when `publish_warnings` set
- [x] Warning section hidden when no warnings
- [ ] E2E validation deferred