### PR TITLE
fix: use api_name for CHANGELOG section headings

### DIFF
--- a/release_automation/scripts/changelog_generator.py
+++ b/release_automation/scripts/changelog_generator.py
@@ -412,7 +412,7 @@ class ChangelogGenerator:
         description, documentation links, and change category stubs.
 
         Args:
-            api: Dict with api_name, api_version, api_title, api_file_name
+            api: Dict with api_name, api_version, api_file_name
             release_tag: For URL construction
             repo_name: For URL construction
             org: GitHub organization
@@ -420,7 +420,7 @@ class ChangelogGenerator:
         Returns:
             Formatted markdown section for this API
         """
-        title = api.get("api_title", api.get("api_name", ""))
+        title = api.get("api_name", "")
         version = api.get("api_version", "")
         file_name = api.get("api_file_name", api.get("api_name", ""))
         yaml_path = f"code/API_definitions/{file_name}.yaml"

--- a/release_automation/tests/test_changelog_generator.py
+++ b/release_automation/tests/test_changelog_generator.py
@@ -165,7 +165,20 @@ class TestApiSectionFormatting:
         assert "redocly.github.io/redoc" in result
         assert "camaraproject.github.io/swagger-ui" in result
 
-    def test_format_api_section_uses_api_name_as_fallback(self):
+    def test_format_api_section_uses_api_name_not_title(self):
+        """Heading must use kebab-case api_name, not the OpenAPI info.title."""
+        api = {
+            "api_name": "quality-on-demand",
+            "api_version": "v1.0.0",
+            "api_title": "CAMARA Quality On Demand",
+            "api_file_name": "quality-on-demand",
+        }
+        result = ChangelogGenerator.format_api_section(api, "r1.1", "TestRepo")
+        assert "## quality-on-demand v1.0.0" in result
+        assert "**quality-on-demand v1.0.0 is ...**" in result
+        assert "CAMARA" not in result
+
+    def test_format_api_section_without_title(self):
         api = {
             "api_name": "fallback-api",
             "api_version": "v1.0.0",


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The CHANGELOG per-API section heading used `api_title` (from OpenAPI `info.title`), producing names like "CAMARA Release Test 1.0.0-alpha.1" instead of the expected kebab-case identifier like "release-test 1.0.0-alpha.1". This aligns with the existing CAMARA convention where headings use `api_name` (e.g. `## quality-on-demand v1.1.0`).

#### Which issue(s) this PR fixes:

Found during E2E validation on camaraproject/ReleaseTest.

#### Special notes for reviewers:

Single line change in `changelog_generator.py:format_api_section()` — uses `api_name` instead of `api_title` for section headings. 510 tests pass.

#### Changelog input

```
fix: use api_name (kebab-case) for CHANGELOG section headings instead of api_title
```

#### Additional documentation

```
docs

```