### PR TITLE
fix: guard empty PR link in issue_created bot message

### DIFF
--- a/release_automation/templates/bot_messages/issue_created.md
+++ b/release_automation/templates/bot_messages/issue_created.md
@@ -6,7 +6,7 @@ Created via workflow dispatch from [`release-plan.yaml`]({{release_plan_url}}).
 Created to replace closed [#{{closed_issue_number}}]({{closed_issue_url}}).
 {{/trigger_issue_close}}
 {{#trigger_release_plan_change}}
-Created after [`release-plan.yaml`]({{release_plan_url}}) update (PR [#{{trigger_pr_number}}]({{trigger_pr_url}})).
+Created after [`release-plan.yaml`]({{release_plan_url}}) update{{#trigger_pr_number}} (PR [#{{trigger_pr_number}}]({{trigger_pr_url}})){{/trigger_pr_number}}.
 {{/trigger_release_plan_change}}
 
 <details><summary><b>Configuration:</b> Release {{release_tag}}{{#short_type}} ({{short_type}}{{#has_meta_release}}, {{meta_release}}{{/has_meta_release}}){{/short_type}}</summary>

--- a/release_automation/tests/test_bot_responder.py
+++ b/release_automation/tests/test_bot_responder.py
@@ -290,6 +290,38 @@ class TestRealTemplates:
         assert "Unexpected error" in result
         assert "'str' object has no attribute 'get'" in result
 
+    def test_issue_created_template_with_pr(self, bot_responder):
+        """issue_created template shows PR link when trigger_pr_number is set."""
+        from release_automation.scripts.context_builder import build_context
+        context = build_context(
+            release_tag="r4.1",
+            state="planned",
+            trigger_type="release_plan_change",
+            trigger_pr_number="42",
+            trigger_pr_url="https://github.com/org/repo/pull/42",
+            apis=[{"api_name": "quality-on-demand", "api_version": "1.0.0"}],
+        )
+        result = bot_responder.render("issue_created", context)
+        assert "Release issue created" in result
+        assert "PR [#42]" in result
+        assert "pull/42" in result
+        assert "release-plan.yaml" in result
+
+    def test_issue_created_template_without_pr(self, bot_responder):
+        """issue_created template omits PR link when trigger_pr_number is empty."""
+        from release_automation.scripts.context_builder import build_context
+        context = build_context(
+            release_tag="r4.1",
+            state="planned",
+            trigger_type="release_plan_change",
+            apis=[{"api_name": "quality-on-demand", "api_version": "1.0.0"}],
+        )
+        result = bot_responder.render("issue_created", context)
+        assert "Release issue created" in result
+        assert "release-plan.yaml" in result
+        assert "[#]" not in result  # No broken link
+        assert "update." in result  # Sentence ends cleanly
+
 
 class TestContextIntegration:
     """Tests simulating the post-bot-comment action's context flow.


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

When the release automation creates a Release Issue via a push event that has no associated PR (direct push or API timing issue), the `issue_created` bot message renders an empty PR link `[#]()`. This adds a Mustache conditional guard around the PR reference, matching the pattern already used in `config_drift_warning.md`.

#### Which issue(s) this PR fixes:

N/A (internal bug found during demo walkthrough)

#### Special notes for reviewers:

- Template change is a one-line conditional guard
- 2 new tests added (with-PR and without-PR paths)
- Full test suite: 512 passed

#### Changelog input

```
fix: guard empty PR link in issue_created bot message when push event has no associated PR
```

#### Additional documentation

```
N/A
```