### PR TITLE
chore: update caller workflow template to reference @ra-v1-rc

### DIFF
--- a/release_automation/workflows/release-automation-caller.yml
+++ b/release_automation/workflows/release-automation-caller.yml
@@ -79,5 +79,5 @@ jobs:
        github.event.pull_request.merged == true &&
        startsWith(github.event.pull_request.base.ref, 'release-snapshot/'))
 
-    uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@release-automation
+    uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@ra-v1-rc
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Updates the reusable workflow reference in the caller template from `@release-automation` to `@ra-v1-rc`, pinning the release candidate version for volunteer API repositories adopting the release automation.

#### Which issue(s) this PR fixes:

Part of release automation RC milestone preparation.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

The `ra-v1-rc` tag will be created on the `release-automation` branch HEAD after this PR merges.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation 

```
docs
N/A
```