### PR TITLE
fix: use api_name instead of api_title in CHANGELOG release summary

### DIFF
--- a/release_automation/scripts/changelog_generator.py
+++ b/release_automation/scripts/changelog_generator.py
@@ -109,7 +109,7 @@ class ChangelogGenerator:
         # Extract API info for template
         apis = metadata.get("apis", [])
         api_list = [
-            {"api_title": api.get("api_title", api.get("api_name", "")),
+            {"api_name": api.get("api_name", ""),
              "api_version": api.get("api_version", "")}
             for api in apis
         ]

--- a/release_automation/templates/changelog/release_section.mustache
+++ b/release_automation/templates/changelog/release_section.mustache
@@ -4,7 +4,7 @@
 
 This {{release_type_description}} contains the definition and documentation of
 {{#apis}}
-* {{api_title}} {{api_version}}
+* {{api_name}} {{api_version}}
 {{/apis}}
 
 The API definition(s) are based on

--- a/release_automation/tests/test_changelog_generator.py
+++ b/release_automation/tests/test_changelog_generator.py
@@ -267,6 +267,29 @@ class TestDraftGeneration:
         assert "qos-profiles v1.1.0" in result
         assert "public release" in result
 
+    def test_generate_draft_uses_api_name_not_title_in_summary(self, generator):
+        """Release notes summary list must use api_name, not api_title."""
+        metadata = {
+            "repository": {"release_type": "pre-release-alpha"},
+            "apis": [
+                {
+                    "api_name": "quality-on-demand",
+                    "api_version": "v1.0.0-alpha.1",
+                    "api_title": "CAMARA Quality On Demand",
+                    "api_file_name": "quality-on-demand",
+                }
+            ],
+            "dependencies": {
+                "commonalities_release": "v0.6.0 (r3.3)",
+                "identity_consent_management_release": "v0.4.0 (r3.3)",
+            },
+        }
+        result = generator.generate_draft(
+            release_tag="r1.1", metadata=metadata, repo_name="TestRepo"
+        )
+        assert "* quality-on-demand v1.0.0-alpha.1" in result
+        assert "CAMARA Quality On Demand" not in result
+
 
 # --- File Writing ---
 


### PR DESCRIPTION

#### What type of PR is this?

* correction

#### What this PR does / why we need it:

The CHANGELOG release section template used `{{api_title}}` (OpenAPI `info.title`) for the API list in the release notes summary. All other release automation outputs (release-metadata.yaml, Release Issue body, release description, readiness checklist) consistently use the canonical `api_name` (filename-derived identifier). This PR aligns the CHANGELOG to match.

**Changes:**
- `release_section.mustache`: `{{api_title}}` → `{{api_name}}`
- `changelog_generator.py`: build template context with `api_name` key instead of `api_title`
- `test_changelog_generator.py`: add regression test verifying `api_name` is used when `api_title` differs

**Tests:** 513 passed, 0 failures.

#### Which issue(s) this PR fixes:

N/A (internal consistency fix)

#### Special notes for reviewers:


#### Additional documentation

N/A