### PR TITLE
fix(workflow): resolve tooling checkout ref from called workflow sha

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -30,17 +30,17 @@ on:
         type: string
         required: false
         default: ""
+      tooling_ref_override:
+        description: "Optional tooling checkout ref override (40-char SHA)"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: write
   issues: write
   pull-requests: write
-
-env:
-  # Tooling repository and ref for all checkout steps.
-  # Change these when testing on a fork or switching between branches.
-  TOOLING_REPO: camaraproject/tooling
-  TOOLING_REF: release-automation
+  id-token: write
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
@@ -58,6 +58,11 @@ jobs:
       confirm_tag: ${{ steps.detect.outputs.confirm_tag }}
       trigger_pr_number: ${{ steps.detect.outputs.trigger_pr_number }}
       trigger_pr_url: ${{ steps.detect.outputs.trigger_pr_url }}
+      tooling_checkout_repo: ${{ steps.resolve-tooling-ref.outputs.tooling_checkout_repo }}
+      tooling_checkout_ref: ${{ steps.resolve-tooling-ref.outputs.tooling_checkout_ref }}
+      tooling_checkout_ref_source: ${{ steps.resolve-tooling-ref.outputs.tooling_checkout_ref_source }}
+      tooling_workflow_ref: ${{ steps.resolve-tooling-ref.outputs.tooling_workflow_ref }}
+      tooling_workflow_sha: ${{ steps.resolve-tooling-ref.outputs.tooling_workflow_sha }}
       comment_id: ${{ steps.ack.outputs.comment_id }}
       # Note: release_tag is NOT output here - it comes from derive-state job
       # which reads from authoritative sources (release-plan.yaml or release-metadata.yaml)
@@ -250,6 +255,73 @@ jobs:
             core.setOutput('should_continue', shouldContinue);
             core.setOutput('confirm_tag', confirmTag);
 
+      - name: Resolve Tooling Checkout Ref
+        id: resolve-tooling-ref
+        if: steps.detect.outputs.should_continue == 'true'
+        uses: actions/github-script@v8
+        env:
+          TOOLING_REF_OVERRIDE: ${{ inputs.tooling_ref_override }}
+        with:
+          script: |
+            const overrideRef = (process.env.TOOLING_REF_OVERRIDE || '').trim();
+            const shaPattern = /^[0-9a-f]{40}$/i;
+            const workflowRefPattern =
+              /^([^/]+\/[^/]+)\/\.github\/workflows\/release-automation-reusable\.yml@.+$/;
+
+            function decodeJwtPayload(jwt) {
+              const parts = jwt.split('.');
+              if (parts.length !== 3) {
+                throw new Error('OIDC token is not a valid JWT');
+              }
+
+              const payload = parts[1]
+                .replace(/-/g, '+')
+                .replace(/_/g, '/');
+              const padLength = (4 - (payload.length % 4)) % 4;
+              const padded = payload + '='.repeat(padLength);
+              return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
+            }
+
+            const oidcToken = await core.getIDToken('release-automation-tooling-ref');
+            const claims = decodeJwtPayload(oidcToken);
+            const workflowRef = claims.job_workflow_ref || '';
+            const workflowSha = claims.job_workflow_sha || '';
+            const workflowRefMatch = workflowRef.match(workflowRefPattern);
+
+            if (!workflowRefMatch) {
+              core.setFailed(`Unexpected job_workflow_ref claim: ${workflowRef}`);
+              return;
+            }
+
+            if (!shaPattern.test(workflowSha)) {
+              core.setFailed(`Invalid job_workflow_sha claim: ${workflowSha}`);
+              return;
+            }
+
+            const checkoutRepo = workflowRefMatch[1];
+            let checkoutRef = workflowSha.toLowerCase();
+            let checkoutRefSource = 'oidc_job_workflow_sha';
+
+            if (overrideRef !== '') {
+              if (!shaPattern.test(overrideRef)) {
+                core.setFailed('tooling_ref_override must be a full 40-character SHA');
+                return;
+              }
+              checkoutRef = overrideRef.toLowerCase();
+              checkoutRefSource = 'override';
+            }
+
+            core.info(`tooling_checkout_repo=${checkoutRepo}`);
+            core.info(`tooling_checkout_ref=${checkoutRef} source=${checkoutRefSource}`);
+            core.info(`job_workflow_ref=${workflowRef}`);
+            core.info(`job_workflow_sha=${workflowSha}`);
+
+            core.setOutput('tooling_checkout_repo', checkoutRepo);
+            core.setOutput('tooling_checkout_ref', checkoutRef);
+            core.setOutput('tooling_checkout_ref_source', checkoutRefSource);
+            core.setOutput('tooling_workflow_ref', workflowRef);
+            core.setOutput('tooling_workflow_sha', workflowSha);
+
       # Post early acknowledgment for slash commands (within check-trigger to avoid runner cold-start)
       # This comment is later updated by post-interim (valid) or post-rejection (rejected).
       # Uses GITHUB_TOKEN (not App token) to avoid triggering extra workflow runs.
@@ -315,8 +387,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -365,8 +437,8 @@ jobs:
         if: steps.decide.outputs.action == 'post_comment'
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -435,8 +507,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -486,8 +558,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -687,8 +759,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -740,8 +812,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -1051,8 +1123,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation
@@ -1104,8 +1176,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation
@@ -1260,8 +1332,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation
@@ -1775,8 +1847,8 @@ jobs:
         if: steps.create-draft.outputs.success == 'true' && needs.derive-state.outputs.release_issue_number != ''
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -1826,8 +1898,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -1935,8 +2007,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
@@ -2062,8 +2134,8 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.TOOLING_REPO }}
-          ref: ${{ env.TOOLING_REF }}
+          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
+          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           path: _tooling
           sparse-checkout: |
             release_automation/scripts

--- a/release_automation/docs/branching-model.md
+++ b/release_automation/docs/branching-model.md
@@ -112,6 +112,17 @@ uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@<r
 
 The campaign infrastructure in `project-administration` distributes caller workflow updates when transitioning between phases.
 
+### Reusable workflow checkout consistency
+
+The reusable workflow derives tooling checkout repository and ref from OIDC claims:
+`job_workflow_ref` (repository identity) and `job_workflow_sha` (commit identity).
+This guarantees that Python scripts and shared actions are checked out from the same repository
+and commit as the reusable workflow itself, even when callers reference floating tags such as
+`ra-v1-rc` or `v1`.
+
+An optional `tooling_ref_override` input can be set in the caller workflow for break-glass
+or testing scenarios. The override must be a full 40-character SHA.
+
 ## Coexistence with pr_validation v0
 
 The release automation is designed to work alongside pr_validation v0 without changes to the existing validation workflow. The `release-automation` branch includes the current pr_validation v0 code (branched from `main`) plus the release automation additions. No modifications to pr_validation are required for the release automation to function.

--- a/release_automation/docs/repository-setup.md
+++ b/release_automation/docs/repository-setup.md
@@ -330,9 +330,16 @@ When transitioning between phases, a campaign updates the `uses:` line across al
 
 | Aspect | Value | Purpose |
 |--------|-------|---------|
-| **Permissions** | `contents: write`, `issues: write`, `pull-requests: write` | Branch/release ops, issue management, PR creation |
+| **Permissions** | `contents: write`, `issues: write`, `pull-requests: write`, `id-token: write` | Branch/release ops, issue management, PR creation, OIDC claim access for called-workflow repo/SHA resolution |
 | **Concurrency** | `release-automation-${{ github.repository }}`, `cancel-in-progress: false` | Serialize runs, prevent race conditions |
 | **Triggers** | `issue_comment`, `issues`, `pull_request`, `push`, `workflow_dispatch` | Slash commands, lifecycle events, auto-sync, manual |
+
+For break-glass or testing, the caller can set `with.tooling_ref_override` in the workflow file.
+This requires committing a workflow file change in the target repository.
+The value must be a full 40-character SHA.
+
+No caller-side repository override is needed for fork testing: the reusable workflow derives the
+tooling repository from OIDC claim `job_workflow_ref`.
 
 ---
 

--- a/release_automation/docs/technical-architecture.md
+++ b/release_automation/docs/technical-architecture.md
@@ -564,6 +564,8 @@ Each API repository has a minimal caller workflow that forwards events to the re
 
 **Concurrency:** Global concurrency group per repository (`release-automation-{repo}`) with `cancel-in-progress: false`. This prevents overlapping workflow runs from producing inconsistent state.
 
+**Permissions:** Caller workflows grant `id-token: write` so the reusable workflow can resolve the called-workflow commit via OIDC claims.
+
 **Commands:**
 
 | Command | Description | Required State | Who may execute |
@@ -579,6 +581,8 @@ Each API repository has a minimal caller workflow that forwards events to the re
 ### 3.3 Reusable Workflow (Tooling Repository)
 
 The reusable workflow (`release-automation-reusable.yml`) orchestrates all release operations. Jobs execute in phases with conditional branching based on trigger type and command validation.
+
+**Workflow/script ref consistency:** Tooling scripts and shared actions are checked out using OIDC claims from the called reusable workflow: `job_workflow_ref` (repository) and `job_workflow_sha` (commit). This binds checkout content to the exact repository and commit of the called reusable workflow. An optional break-glass override (`tooling_ref_override`) is available as a caller-side `with:` value and must be a full 40-character SHA.
 
 **Job execution order:**
 

--- a/release_automation/workflows/release-automation-caller.yml
+++ b/release_automation/workflows/release-automation-caller.yml
@@ -54,6 +54,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-automation:
@@ -80,4 +81,6 @@ jobs:
        startsWith(github.event.pull_request.base.ref, 'release-snapshot/'))
 
     uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@ra-v1-rc
+    # with:
+    #   tooling_ref_override: "0123456789abcdef0123456789abcdef01234567"  # Optional break-glass SHA override (requires workflow file change)
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

correction


#### What this PR does / why we need it:

This PR removes a ref-drift risk in reusable workflows by making tooling checkout derive from called workflow identity.

Before this change, the reusable workflow could be resolved from one ref while scripts/shared actions were checked out from an independently configured repository/ref. That could desynchronize workflow logic and executed implementation.

This PR changes the release automation reusable workflow to:
- derive `tooling_checkout_repo` from OIDC claim `job_workflow_ref`
- derive `tooling_checkout_ref` from OIDC claim `job_workflow_sha`
- use these resolved values for all `_tooling` checkouts

An optional SHA-only `tooling_ref_override` remains available for explicit break-glass/testing via caller workflow code.


#### Which issue(s) this PR fixes:

Relates to #110

#### Special notes for reviewers:

- Caller workflow template now requires `permissions.id-token: write`
- Reusable workflow also requires `permissions.id-token: write`
- Verified in TestRepo-QoD that runtime values align:
  - `tooling_checkout_repo=hdamker/tooling`
  - `tooling_checkout_ref=<job_workflow_sha>`
  - `job_workflow_ref=hdamker/tooling/.github/workflows/release-automation-reusable.yml@refs/heads/release-automation-oidc-ref`
- Pattern is reusable for other tooling workflows (for example `pr_validation`) that combine reusable workflows with secondary script checkouts


#### Changelog input

```
 release-note
 Resolve tooling script checkout repository/ref from reusable workflow OIDC identity (job_workflow_ref/job_workflow_sha) to prevent drift.
```

#### Additional documentation 

Updated:
- `release_automation/docs/branching-model.md`
- `release_automation/docs/repository-setup.md`
- `release_automation/docs/technical-architecture.md`

```
docs
release_automation/docs/branching-model.md
release_automation/docs/repository-setup.md
release_automation/docs/technical-architecture.md
```
