### PR TITLE
fix(workflow): sync release issue from post-action state

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -2016,6 +2016,45 @@ jobs:
             shared-actions/sync-release-issue
             shared-actions/post-bot-comment
 
+      - name: Resolve Sync Context
+        id: sync-context
+        shell: bash
+        run: |
+          state_override=""
+          snapshot_branch_override=""
+          release_pr_number_override=""
+          draft_release_url_override=""
+          force_update="false"
+
+          if [ "${{ needs.create-snapshot.result }}" = "success" ] && [ "${{ needs.create-snapshot.outputs.success }}" = "true" ]; then
+            state_override="snapshot-active"
+            snapshot_branch_override="${{ needs.create-snapshot.outputs.snapshot_branch }}"
+            release_pr_number_override="${{ needs.create-snapshot.outputs.release_pr_number }}"
+            force_update="true"
+          elif [ "${{ needs.handle-pr-merge.result }}" = "success" ] && [ "${{ needs.handle-pr-merge.outputs.success }}" = "true" ]; then
+            state_override="draft-ready"
+            snapshot_branch_override="${{ needs.derive-state.outputs.snapshot_branch }}"
+            release_pr_number_override="${{ github.event.pull_request.number }}"
+            draft_release_url_override="${{ needs.handle-pr-merge.outputs.draft_release_url }}"
+            force_update="true"
+          elif [ "${{ needs.discard-snapshot.result }}" = "success" ] && [ "${{ needs.discard-snapshot.outputs.success }}" = "true" ]; then
+            state_override="planned"
+            force_update="true"
+          elif [ "${{ needs.delete-draft.result }}" = "success" ] && [ "${{ needs.delete-draft.outputs.success }}" = "true" ]; then
+            state_override="planned"
+            force_update="true"
+          elif [ "${{ needs.check-trigger.outputs.command }}" = "sync-issue" ]; then
+            force_update="true"
+          fi
+
+          {
+            echo "state_override=$state_override"
+            echo "snapshot_branch_override=$snapshot_branch_override"
+            echo "release_pr_number_override=$release_pr_number_override"
+            echo "draft_release_url_override=$draft_release_url_override"
+            echo "force_update=$force_update"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Sync Release Issue
         id: sync
         uses: ./_tooling/shared-actions/sync-release-issue
@@ -2024,6 +2063,11 @@ jobs:
           state: ${{ needs.derive-state.outputs.state }}
           snapshot_branch: ${{ needs.derive-state.outputs.snapshot_branch }}
           release_pr_number: ${{ needs.derive-state.outputs.release_pr_number }}
+          state_override: ${{ steps.sync-context.outputs.state_override }}
+          snapshot_branch_override: ${{ steps.sync-context.outputs.snapshot_branch_override }}
+          release_pr_number_override: ${{ steps.sync-context.outputs.release_pr_number_override }}
+          draft_release_url_override: ${{ steps.sync-context.outputs.draft_release_url_override }}
+          force_update: ${{ steps.sync-context.outputs.force_update }}
           trigger_type: ${{ needs.check-trigger.outputs.trigger_type }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
 

--- a/release_automation/scripts/issue_sync.py
+++ b/release_automation/scripts/issue_sync.py
@@ -111,7 +111,12 @@ class IssueSyncManager:
     def sync_release_issue(
         self,
         release_plan: Dict[str, Any],
-        trigger_pr: Optional[int] = None
+        trigger_pr: Optional[int] = None,
+        state_override: Optional[ReleaseState] = None,
+        snapshot_branch_override: Optional[str] = None,
+        release_pr_number_override: Optional[str] = None,
+        draft_release_url_override: Optional[str] = None,
+        force_update: bool = False,
     ) -> SyncResult:
         """
         Ensure Release Issue exists and reflects current state.
@@ -125,6 +130,11 @@ class IssueSyncManager:
         Args:
             release_plan: Parsed release-plan.yaml content
             trigger_pr: Optional PR number that triggered the sync
+            state_override: Authoritative state for same-run workflow transitions
+            snapshot_branch_override: Authoritative snapshot branch for same-run updates
+            release_pr_number_override: Authoritative release PR number for same-run updates
+            draft_release_url_override: Authoritative draft release URL for same-run updates
+            force_update: Force a refresh even if state appears unchanged
 
         Returns:
             SyncResult with action taken and issue details
@@ -137,7 +147,19 @@ class IssueSyncManager:
         self.ensure_labels_exist()
 
         # Derive current state
-        state = self.state_manager.derive_state(release_tag)
+        state = state_override or self.state_manager.derive_state(
+            release_tag,
+            retry_draft_release=True,
+        )
+        context_source = "override" if state_override else "re-derived"
+        print(
+            f"Issue sync effective context: source={context_source}, "
+            f"state={state.value}, "
+            f"snapshot_branch={snapshot_branch_override or '(auto)'}, "
+            f"release_pr_number={release_pr_number_override or '(auto)'}, "
+            f"draft_release_url={'yes' if draft_release_url_override else 'auto'}, "
+            f"force_update={force_update}"
+        )
 
         # Find existing workflow-owned issue
         issue = self.find_workflow_owned_issue(release_tag)
@@ -151,7 +173,14 @@ class IssueSyncManager:
                 # Wrapped in retry_on_not_found because GitHub API may
                 # return 404 for a freshly created issue (eventual consistency).
                 def _post_create():
-                    self._update_release_issue(new_issue, state, release_plan)
+                    self._update_release_issue(
+                        new_issue,
+                        state,
+                        release_plan,
+                        snapshot_branch_override=snapshot_branch_override,
+                        release_pr_number_override=release_pr_number_override,
+                        draft_release_url_override=draft_release_url_override,
+                    )
                     return self.gh.get_issue(new_issue["number"])
                 updated_issue = self.gh.retry_on_not_found(_post_create)
                 return SyncResult(action="created", issue=updated_issue)
@@ -159,8 +188,15 @@ class IssueSyncManager:
                 return SyncResult(action="none", reason="no_planned_release")
 
         # Issue exists - check if update needed
-        if self._needs_update(issue, state, release_plan):
-            self._update_release_issue(issue, state, release_plan)
+        if force_update or self._needs_update(issue, state, release_plan):
+            self._update_release_issue(
+                issue,
+                state,
+                release_plan,
+                snapshot_branch_override=snapshot_branch_override,
+                release_pr_number_override=release_pr_number_override,
+                draft_release_url_override=draft_release_url_override,
+            )
             # Refetch issue after update
             updated_issue = self.gh.get_issue(issue["number"])
             return SyncResult(action="updated", issue=updated_issue)
@@ -287,7 +323,6 @@ class IssueSyncManager:
         expected_state_label = self.get_state_label(state)
 
         # Check if the expected state label is present
-        state_labels = [l for l in current_labels if l.startswith(self.STATE_LABEL_PREFIX)]
         if expected_state_label not in current_labels:
             return True
 
@@ -308,7 +343,10 @@ class IssueSyncManager:
         self,
         issue: Dict[str, Any],
         state: ReleaseState,
-        release_plan: Dict[str, Any]
+        release_plan: Dict[str, Any],
+        snapshot_branch_override: Optional[str] = None,
+        release_pr_number_override: Optional[str] = None,
+        draft_release_url_override: Optional[str] = None,
     ) -> None:
         """
         Update an existing Release Issue to match current state.
@@ -324,6 +362,9 @@ class IssueSyncManager:
             issue: Issue dict to update
             state: Current derived state
             release_plan: Current release plan
+            snapshot_branch_override: Authoritative snapshot branch for same-run updates
+            release_pr_number_override: Authoritative release PR number for same-run updates
+            draft_release_url_override: Authoritative draft release URL for same-run updates
         """
         issue_number = issue["number"]
         release_tag = release_plan.get("repository", {}).get("target_release_tag", "")
@@ -349,14 +390,20 @@ class IssueSyncManager:
         # Get snapshot info and artifact URLs
         snapshot = self.state_manager.get_current_snapshot(release_tag)
         snapshot_id = snapshot.snapshot_id if snapshot else ""
-        snapshot_branch = snapshot.snapshot_branch if snapshot else ""
+        snapshot_branch = snapshot_branch_override or (snapshot.snapshot_branch if snapshot else "")
         release_pr_url = ""
         draft_release_url = ""
         snapshot_branch_url = ""
+        release_pr_number = release_pr_number_override or (
+            str(snapshot.release_pr_number) if snapshot and snapshot.release_pr_number else ""
+        )
 
-        if snapshot and snapshot.release_pr_number:
+        if snapshot_branch and not snapshot_id:
+            snapshot_id = snapshot_branch.replace("release-snapshot/", "")
+
+        if release_pr_number:
             # Construct PR URL
-            release_pr_url = f"https://github.com/{self.gh.repo}/pull/{snapshot.release_pr_number}"
+            release_pr_url = f"https://github.com/{self.gh.repo}/pull/{release_pr_number}"
 
         if snapshot_branch:
             # Construct snapshot branch tree URL
@@ -364,7 +411,7 @@ class IssueSyncManager:
 
         # Get draft release URL if in draft-ready state
         if state == ReleaseState.DRAFT_READY:
-            draft_release_url = self._get_draft_release_url(release_tag)
+            draft_release_url = draft_release_url_override or self._get_draft_release_url(release_tag)
 
         # Update STATE section with artifact links
         new_state_content = self.issue_manager.generate_state_section(

--- a/release_automation/scripts/state_manager.py
+++ b/release_automation/scripts/state_manager.py
@@ -8,6 +8,7 @@ the current release state by examining repository artifacts.
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+import time
 from typing import Any, Dict, List, Optional
 
 import yaml
@@ -159,7 +160,11 @@ class ReleaseStateManager:
         """
         self.gh = github_client
 
-    def derive_state(self, release_tag: str) -> ReleaseState:
+    def derive_state(
+        self,
+        release_tag: str,
+        retry_draft_release: bool = False
+    ) -> ReleaseState:
         """
         Derive the current release state from repository artifacts.
 
@@ -175,6 +180,7 @@ class ReleaseStateManager:
 
         Args:
             release_tag: Release tag to check (e.g., "r4.1")
+            retry_draft_release: Retry draft-release detection for eventual consistency
 
         Returns:
             Current ReleaseState for the given release tag
@@ -188,7 +194,7 @@ class ReleaseStateManager:
 
         if snapshot_branches:
             # Step 3: Check for draft release
-            if self.gh.draft_release_exists(release_tag):
+            if self._draft_release_exists(release_tag, retry=retry_draft_release):
                 return ReleaseState.DRAFT_READY
             return ReleaseState.SNAPSHOT_ACTIVE
 
@@ -205,6 +211,28 @@ class ReleaseStateManager:
                     return ReleaseState.NOT_PLANNED
 
         return ReleaseState.NOT_PLANNED
+
+    def _draft_release_exists(self, release_tag: str, retry: bool = False) -> bool:
+        """
+        Check if a draft release exists, optionally retrying for eventual consistency.
+
+        Args:
+            release_tag: Release tag to check (e.g., "r4.1")
+            retry: Whether to retry draft-release detection
+
+        Returns:
+            True if a draft release exists, False otherwise
+        """
+        attempts = 3 if retry else 1
+
+        for attempt in range(attempts):
+            if self.gh.draft_release_exists(release_tag):
+                return True
+
+            if attempt < attempts - 1:
+                time.sleep(5)
+
+        return False
 
     def get_current_snapshot(self, release_tag: str) -> Optional[SnapshotInfo]:
         """

--- a/release_automation/tests/test_issue_sync.py
+++ b/release_automation/tests/test_issue_sync.py
@@ -161,6 +161,7 @@ class TestSyncReleaseIssue:
         state_manager = MagicMock()
         issue_manager = MagicMock()
         bot_responder = MagicMock()
+        state_manager.get_current_snapshot.return_value = None
 
         # Make retry_on_not_found call the function directly (no actual retry in tests)
         gh.retry_on_not_found.side_effect = lambda fn, **kwargs: fn()
@@ -283,6 +284,80 @@ class TestSyncReleaseIssue:
 
         assert result.action == "none"
         assert result.reason == "missing_release_tag"
+
+    def test_force_update_refreshes_issue_when_state_matches(self):
+        """Test force_update refreshes issue even when label and title already match."""
+        manager, gh, state_manager, issue_manager, _ = self._create_manager()
+
+        release_plan = {
+            "repository": {
+                "target_release_tag": "r4.1",
+                "target_release_type": "pre-release-rc"
+            }
+        }
+
+        gh.search_issues.return_value = [
+            {
+                "number": 1,
+                "title": "Release r4.1 (RC)",
+                "body": f"{WORKFLOW_MARKER}\n<!-- release-automation:release-tag:r4.1 -->",
+                "labels": [{"name": "release-state:snapshot-active"}]
+            }
+        ]
+        gh.get_issue.return_value = {"number": 1, "title": "Release r4.1 (RC)"}
+        issue_manager.should_update_title.return_value = False
+        issue_manager.generate_state_section.return_value = "**State**: snapshot-active"
+        issue_manager.update_section.return_value = "updated body"
+
+        result = manager.sync_release_issue(
+            release_plan,
+            state_override=ReleaseState.SNAPSHOT_ACTIVE,
+            force_update=True,
+        )
+
+        assert result.action == "updated"
+        state_manager.derive_state.assert_not_called()
+
+    def test_uses_draft_release_url_override_for_draft_ready(self):
+        """Test draft release URL override is passed to the issue body generator."""
+        manager, gh, _, issue_manager, _ = self._create_manager()
+
+        release_plan = {
+            "repository": {
+                "target_release_tag": "r4.1",
+                "target_release_type": "pre-release-rc"
+            }
+        }
+
+        gh.search_issues.return_value = [
+            {
+                "number": 1,
+                "title": "Release r4.1 (RC)",
+                "body": f"{WORKFLOW_MARKER}\n<!-- release-automation:release-tag:r4.1 -->",
+                "labels": [{"name": "release-state:snapshot-active"}]
+            }
+        ]
+        gh.get_issue.return_value = {"number": 1, "title": "Release r4.1 (RC)"}
+        issue_manager.should_update_title.return_value = False
+        issue_manager.generate_state_section.return_value = "**State**: draft-ready"
+        issue_manager.update_section.return_value = "updated body"
+
+        draft_release_url = "https://github.com/org/repo/releases/tag/untagged-123"
+        result = manager.sync_release_issue(
+            release_plan,
+            state_override=ReleaseState.DRAFT_READY,
+            draft_release_url_override=draft_release_url,
+            force_update=True,
+        )
+
+        assert result.action == "updated"
+        issue_manager.generate_state_section.assert_called_once_with(
+            state=ReleaseState.DRAFT_READY.value,
+            snapshot_id="",
+            release_pr_url="",
+            draft_release_url=draft_release_url,
+            snapshot_branch_url=""
+        )
 
 
 class TestCreateReleaseIssue:

--- a/release_automation/tests/test_state_manager.py
+++ b/release_automation/tests/test_state_manager.py
@@ -83,6 +83,38 @@ class TestDeriveState:
 
         assert state == ReleaseState.SNAPSHOT_ACTIVE
 
+    @patch("release_automation.scripts.state_manager.time.sleep")
+    def test_draft_ready_retries_when_enabled(
+        self, mock_sleep, state_manager, mock_github_client
+    ):
+        """Draft release detection retries before concluding DRAFT_READY."""
+        mock_github_client.list_branches.return_value = [
+            Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
+        ]
+        mock_github_client.draft_release_exists.side_effect = [False, False, True]
+
+        state = state_manager.derive_state("r4.1", retry_draft_release=True)
+
+        assert state == ReleaseState.DRAFT_READY
+        assert mock_github_client.draft_release_exists.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch("release_automation.scripts.state_manager.time.sleep")
+    def test_snapshot_active_when_retry_exhausted(
+        self, mock_sleep, state_manager, mock_github_client
+    ):
+        """Retry exhaustion falls back to SNAPSHOT_ACTIVE."""
+        mock_github_client.list_branches.return_value = [
+            Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
+        ]
+        mock_github_client.draft_release_exists.side_effect = [False, False, False]
+
+        state = state_manager.derive_state("r4.1", retry_draft_release=True)
+
+        assert state == ReleaseState.SNAPSHOT_ACTIVE
+        assert mock_github_client.draft_release_exists.call_count == 3
+        assert mock_sleep.call_count == 2
+
     def test_planned_when_release_plan_defines_release(
         self, state_manager, mock_github_client
     ):

--- a/shared-actions/sync-release-issue/action.yml
+++ b/shared-actions/sync-release-issue/action.yml
@@ -22,6 +22,26 @@ inputs:
     description: 'Release PR number if exists'
     required: false
     default: ''
+  state_override:
+    description: 'Authoritative state override for same-run transitions'
+    required: false
+    default: ''
+  snapshot_branch_override:
+    description: 'Authoritative snapshot branch override for same-run transitions'
+    required: false
+    default: ''
+  release_pr_number_override:
+    description: 'Authoritative release PR number override for same-run transitions'
+    required: false
+    default: ''
+  draft_release_url_override:
+    description: 'Authoritative draft release URL override for same-run transitions'
+    required: false
+    default: ''
+  force_update:
+    description: 'Force a Release Issue refresh even if state appears unchanged'
+    required: false
+    default: 'false'
   trigger_type:
     description: 'What triggered the workflow (slash_command, pr_merge, issue_event, workflow_dispatch)'
     required: false
@@ -62,14 +82,17 @@ runs:
         CURRENT_STATE: ${{ inputs.state }}
         SNAPSHOT_BRANCH: ${{ inputs.snapshot_branch }}
         RELEASE_PR_NUMBER: ${{ inputs.release_pr_number }}
+        STATE_OVERRIDE: ${{ inputs.state_override }}
+        SNAPSHOT_BRANCH_OVERRIDE: ${{ inputs.snapshot_branch_override }}
+        RELEASE_PR_NUMBER_OVERRIDE: ${{ inputs.release_pr_number_override }}
+        DRAFT_RELEASE_URL_OVERRIDE: ${{ inputs.draft_release_url_override }}
+        FORCE_UPDATE: ${{ inputs.force_update }}
         TRIGGER_TYPE: ${{ inputs.trigger_type }}
         REPO: ${{ github.repository }}
         SCRIPTS_PATH: ${{ github.action_path }}/../../release_automation/scripts
       run: |
         import os
         import sys
-        import json
-
         # Add scripts path to module search path
         scripts_path = os.environ['SCRIPTS_PATH']
         # Go up two levels: scripts -> release_automation -> tooling root
@@ -88,9 +111,26 @@ runs:
         token = os.environ['GITHUB_TOKEN']
         release_tag = os.environ.get('RELEASE_TAG', '').strip()
         current_state = os.environ.get('CURRENT_STATE', '').strip()
+        state_override_raw = os.environ.get('STATE_OVERRIDE', '').strip()
+        snapshot_branch_override = os.environ.get('SNAPSHOT_BRANCH_OVERRIDE', '').strip()
+        release_pr_number_override = os.environ.get('RELEASE_PR_NUMBER_OVERRIDE', '').strip()
+        draft_release_url_override = os.environ.get('DRAFT_RELEASE_URL_OVERRIDE', '').strip()
+        force_update = os.environ.get('FORCE_UPDATE', 'false').strip().lower() == 'true'
         trigger_type = os.environ.get('TRIGGER_TYPE', 'workflow_dispatch')
 
         output_file = os.environ['GITHUB_OUTPUT']
+
+        def parse_state(value):
+            normalized = value.strip().lower().replace('-', '_')
+            if not normalized:
+                return None
+
+            for state in ReleaseState:
+                state_value = state.value.lower().replace('-', '_')
+                if normalized in {state_value, state.name.lower()}:
+                    return state
+
+            raise ValueError(f"Unknown release state override: {value}")
 
         def write_outputs(issue_number='', issue_action='skipped', issue_url=''):
             """Write outputs to GITHUB_OUTPUT file."""
@@ -98,6 +138,24 @@ runs:
                 f.write(f"issue_number={issue_number}\n")
                 f.write(f"issue_action={issue_action}\n")
                 f.write(f"issue_url={issue_url}\n")
+
+        try:
+            state_override = parse_state(state_override_raw)
+        except ValueError as e:
+            print(f"::error::{e}")
+            write_outputs(issue_action='error')
+            sys.exit(1)
+
+        requested_state = state_override_raw or current_state
+        context_source = 'override' if state_override else 're-derived'
+
+        print("Effective sync context:")
+        print(f"  Source: {context_source}")
+        print(f"  Requested state: {requested_state or '(none)'}")
+        print(f"  Snapshot branch override: {snapshot_branch_override or '(none)'}")
+        print(f"  Release PR override: {release_pr_number_override or '(none)'}")
+        print(f"  Draft release URL override present: {'yes' if draft_release_url_override else 'no'}")
+        print(f"  Force update: {force_update}")
 
         # Skip if no release tag or state indicates no action needed
         if not release_tag:
@@ -107,13 +165,13 @@ runs:
 
         # Skip for states where no issue management is needed
         skip_states = ['published', '']
-        if current_state.lower() in skip_states:
-            print(f"State '{current_state}' does not require issue sync - skipping")
+        if requested_state.lower() in skip_states:
+            print(f"State '{requested_state}' does not require issue sync - skipping")
             # Write workflow summary for visibility
             summary_file = os.environ.get('GITHUB_STEP_SUMMARY', '')
             if summary_file:
                 with open(summary_file, 'a') as f:
-                    if current_state.lower() == 'published':
+                    if requested_state.lower() == 'published':
                         f.write(f"## Release Status: Published\n\n")
                         f.write(f"Release `{release_tag}` has already been published. No further actions needed.\n")
                     else:
@@ -167,9 +225,16 @@ runs:
             # Continue anyway - use the input release_tag as authoritative
 
         # Call sync_release_issue
-        print(f"Syncing Release Issue for {release_tag} (state: {current_state})")
+        print(f"Syncing Release Issue for {release_tag} (state: {requested_state or current_state})")
         try:
-            result = sync_manager.sync_release_issue(release_plan_data)
+            result = sync_manager.sync_release_issue(
+                release_plan_data,
+                state_override=state_override,
+                snapshot_branch_override=snapshot_branch_override or None,
+                release_pr_number_override=release_pr_number_override or None,
+                draft_release_url_override=draft_release_url_override or None,
+                force_update=force_update,
+            )
 
             # Extract results
             action = result.action  # 'created', 'updated', 'none'


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

- resolve authoritative release-issue sync context after release mutations in the reusable workflow
- pass state, release PR, draft URL, and force-update overrides into the sync action for same-run transitions
- avoid stale issue state after draft creation by using override context instead of re-deriving from artifacts in the same run
- retry fallback draft-release detection to tolerate short GitHub API visibility delays
- add regression tests for forced refresh, draft URL override, and retry-based draft detection
- validate the fix against `hdamker/TestRepo-QoD`, where merging the release review PR now updates the Release Issue to `draft-ready` in the same workflow run

#### Which issue(s) this PR fixes:

Fixes #114

#### Special notes for reviewers:

- the main workflow change is in `.github/workflows/release-automation-reusable.yml`, where `update-issue` now resolves effective sync context from mutation job outcomes before calling `sync-release-issue`
- `shared-actions/sync-release-issue` remains backward compatible when no overrides are provided
- same-run `create-snapshot`, `handle-pr-merge`, `discard-snapshot`, `delete-draft`, and manual `/sync-issue` paths now force a single issue refresh

#### Changelog input

```
 release-note
fix the release issue sync after same-run draft creation so labels and issue body update deterministically
```

#### Additional documentation 

This section can be blank.

```
docs
none
```
