### PR TITLE
fix(release-automation): reuse legacy release metadata fallback for version calculation

### DIFF
--- a/release_automation/scripts/github_client.py
+++ b/release_automation/scripts/github_client.py
@@ -6,12 +6,14 @@ needed by the release automation workflow. It uses the `gh` CLI
 for authentication and API access.
 """
 
+from fnmatch import fnmatch
 import json
 import subprocess
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-from fnmatch import fnmatch
+
+import yaml
 
 
 @dataclass
@@ -237,6 +239,19 @@ class GitHubClient:
             # Other errors (auth, server, rate limit) should be surfaced
             print(f"Warning: Failed to read {path} from {ref}: {e}")
             return None
+
+    def get_release_metadata(self, tag: str) -> Optional[dict]:
+        """Read release-metadata.yaml from a release tag or legacy asset."""
+        content = self.get_file_content("release-metadata.yaml", ref=tag)
+        if not content:
+            content = self.download_release_asset(tag, "release-metadata.yaml")
+        if not content:
+            return None
+        try:
+            metadata = yaml.safe_load(content)
+        except yaml.YAMLError:
+            return None
+        return metadata if isinstance(metadata, dict) else None
 
     def get_releases(self, include_drafts: bool = False) -> List[Release]:
         """

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -557,28 +557,6 @@ class SnapshotCreator:
             return releases[0].tag_name
         return None
 
-    def _read_release_metadata(self, tag: str) -> Optional[Dict[str, Any]]:
-        """Read release-metadata.yaml from a release tag.
-
-        Tries two sources in order:
-        1. Repository tree at tag (newer releases with committed file)
-        2. Release asset (legacy releases where metadata was uploaded)
-
-        Returns:
-            Parsed metadata dict, or None if not found/parseable.
-        """
-        # Try 1: repository tree (newer releases)
-        content = self.gh.get_file_content("release-metadata.yaml", ref=tag)
-        # Try 2: release asset (legacy releases)
-        if not content:
-            content = self.gh.download_release_asset(tag, "release-metadata.yaml")
-        if not content:
-            return None
-        try:
-            return yaml.safe_load(content)
-        except yaml.YAMLError:
-            return None
-
     def _get_candidate_changes(
         self, release_tag: str, previous_release: Optional[str]
     ) -> Optional[str]:
@@ -643,7 +621,7 @@ class SnapshotCreator:
             if is_prerelease:
                 # Pre-release: public section shows existing public release info
                 public_tag = existing_public
-                public_metadata = self._read_release_metadata(public_tag)
+                public_metadata = self.gh.get_release_metadata(public_tag)
                 public_apis = []
                 public_meta_release = ""
                 if public_metadata:

--- a/release_automation/scripts/version_calculator.py
+++ b/release_automation/scripts/version_calculator.py
@@ -9,8 +9,6 @@ import re
 from dataclasses import dataclass
 from typing import List, Optional
 
-import yaml
-
 from .github_client import GitHubClient
 
 
@@ -177,7 +175,7 @@ class VersionCalculator:
 
         for release in releases:
             # Read release-metadata.yaml from the tag
-            metadata = self._read_release_metadata(release.tag_name)
+            metadata = self.gh.get_release_metadata(release.tag_name)
             if not metadata:
                 continue
 
@@ -223,26 +221,6 @@ class VersionCalculator:
                 )
 
         return versions
-
-    def _read_release_metadata(self, tag: str) -> Optional[dict]:
-        """
-        Read release-metadata.yaml from a release tag.
-
-        Args:
-            tag: Release tag name (e.g., "r4.1")
-
-        Returns:
-            Parsed YAML content or None if not found
-        """
-        content = self.gh.get_file_content("release-metadata.yaml", tag)
-        if not content:
-            return None
-
-        try:
-            return yaml.safe_load(content)
-        except yaml.YAMLError as e:
-            print(f"Warning: Failed to parse release-metadata.yaml from {tag}: {e}")
-            return None
 
     def _parse_extension(
         self,

--- a/release_automation/tests/test_github_client.py
+++ b/release_automation/tests/test_github_client.py
@@ -79,6 +79,51 @@ class TestGitHubClient(unittest.TestCase):
         content = self.client.get_file_content("missing")
         self.assertIsNone(content)
 
+    @patch("release_automation.scripts.github_client.GitHubClient.download_release_asset")
+    @patch("release_automation.scripts.github_client.GitHubClient.get_file_content")
+    def test_get_release_metadata_from_repo_tree(
+        self, mock_get_file_content, mock_download_release_asset
+    ):
+        mock_get_file_content.return_value = (
+            "repository:\n  release_tag: r4.1\napis:\n  - api_name: test-api\n"
+            "    api_version: 1.0.0-rc.1\n"
+        )
+
+        metadata = self.client.get_release_metadata("r4.1")
+
+        self.assertEqual(metadata["repository"]["release_tag"], "r4.1")
+        self.assertEqual(metadata["apis"][0]["api_version"], "1.0.0-rc.1")
+        mock_get_file_content.assert_called_once_with("release-metadata.yaml", ref="r4.1")
+        mock_download_release_asset.assert_not_called()
+
+    @patch("release_automation.scripts.github_client.GitHubClient.download_release_asset")
+    @patch("release_automation.scripts.github_client.GitHubClient.get_file_content")
+    def test_get_release_metadata_falls_back_to_release_asset(
+        self, mock_get_file_content, mock_download_release_asset
+    ):
+        mock_get_file_content.return_value = None
+        mock_download_release_asset.return_value = (
+            "repository:\n  release_tag: r4.1\napis:\n  - api_name: test-api\n"
+            "    api_version: 1.0.0-rc.1\n"
+        )
+
+        metadata = self.client.get_release_metadata("r4.1")
+
+        self.assertEqual(metadata["apis"][0]["api_version"], "1.0.0-rc.1")
+        mock_download_release_asset.assert_called_once_with("r4.1", "release-metadata.yaml")
+
+    @patch("release_automation.scripts.github_client.GitHubClient.download_release_asset")
+    @patch("release_automation.scripts.github_client.GitHubClient.get_file_content")
+    def test_get_release_metadata_returns_none_for_invalid_yaml(
+        self, mock_get_file_content, mock_download_release_asset
+    ):
+        mock_get_file_content.return_value = "just-a-string"
+
+        metadata = self.client.get_release_metadata("r4.1")
+
+        self.assertIsNone(metadata)
+        mock_download_release_asset.assert_not_called()
+
     @patch("release_automation.scripts.github_client.GitHubClient._run_gh")
     def test_create_issue(self, mock_run_gh):
         # create_issue returns a local dict from the URL output (no fetch-back)

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -1011,42 +1011,37 @@ class TestReleaseDocumentation:
         mock_instance.generate_draft.assert_called_once()
         mock_instance.write_changelog.assert_called_once()
 
-    def test_read_release_metadata_from_repo_tree(
+    def test_readme_update_uses_shared_release_metadata_loader(
         self, snapshot_creator, mock_github_client
     ):
-        """Returns metadata when file exists in repository tree at tag."""
-        yaml_content = "repository:\n  release_type: public-release\napis:\n- api_name: qod\n  api_version: v1.0.0\n"
-        mock_github_client.get_file_content.return_value = yaml_content
-        result = snapshot_creator._read_release_metadata("r3.2")
-        assert result is not None
-        assert result["repository"]["release_type"] == "public-release"
-        assert result["apis"][0]["api_version"] == "v1.0.0"
-        mock_github_client.get_file_content.assert_called_once_with(
-            "release-metadata.yaml", ref="r3.2"
-        )
+        """README update goes through GitHubClient shared metadata loading."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r3.2", draft=False, prerelease=False, html_url="")
+        ]
+        mock_github_client.get_release_metadata.return_value = {
+            "repository": {
+                "release_type": "public-release",
+                "meta_release": "Fall25",
+            },
+            "apis": [{
+                "api_name": "qod",
+                "api_version": "v1.0.0",
+            }],
+        }
 
-    def test_read_release_metadata_falls_back_to_release_asset(
-        self, snapshot_creator, mock_github_client
-    ):
-        """Falls back to release asset when file not in repo tree."""
-        mock_github_client.get_file_content.return_value = None
-        yaml_content = "repository:\n  release_type: public-release\napis:\n- api_name: qod\n  api_version: v1.0.0\n"
-        mock_github_client.download_release_asset.return_value = yaml_content
-        result = snapshot_creator._read_release_metadata("r3.2")
-        assert result is not None
-        assert result["apis"][0]["api_version"] == "v1.0.0"
-        mock_github_client.download_release_asset.assert_called_once_with(
-            "r3.2", "release-metadata.yaml"
-        )
+        with patch("release_automation.scripts.snapshot_creator.os.path.exists", return_value=True), \
+             patch("release_automation.scripts.snapshot_creator.ReadmeUpdater.update_release_info", return_value=True), \
+             patch("release_automation.scripts.snapshot_creator.ReadmeUpdater.format_api_links", return_value="formatted-links"):
+            result = snapshot_creator._update_readme(
+                temp_dir="/tmp/test-dir",
+                config=SnapshotConfig(release_tag="r4.1"),
+                release_plan={},
+                api_versions={"qod": "v1.1.0-rc.1"},
+                metadata={"repository": {"release_type": "pre-release-rc"}},
+            )
 
-    def test_read_release_metadata_returns_none_when_not_found(
-        self, snapshot_creator, mock_github_client
-    ):
-        """Returns None when metadata not found in tree or assets."""
-        mock_github_client.get_file_content.return_value = None
-        mock_github_client.download_release_asset.return_value = None
-        result = snapshot_creator._read_release_metadata("r3.2")
-        assert result is None
+        assert result is True
+        mock_github_client.get_release_metadata.assert_called_once_with("r3.2")
 
 
 class TestWipCheckIntegration:

--- a/release_automation/tests/test_version_calculator.py
+++ b/release_automation/tests/test_version_calculator.py
@@ -22,6 +22,7 @@ def mock_github_client():
     client = Mock()
     client.get_releases.return_value = []
     client.get_file_content.return_value = None
+    client.get_release_metadata.return_value = None
     return client
 
 
@@ -65,13 +66,13 @@ class TestCalculateVersion:
             Release(tag_name="r4.1", name="Release r4.1", draft=False,
                     prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-repository:
-  release_tag: r4.1
-apis:
-  - api_name: location-verification
-    api_version: 3.2.0-rc.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "repository": {"release_tag": "r4.1"},
+            "apis": [{
+                "api_name": "location-verification",
+                "api_version": "3.2.0-rc.1",
+            }],
+        }
 
         result = calculator.calculate_version(
             api_name="location-verification",
@@ -80,6 +81,30 @@ apis:
         )
 
         assert result == "3.2.0-rc.2"
+
+    def test_second_rc_release_uses_release_asset_fallback(
+        self, calculator, mock_github_client
+    ):
+        """Legacy asset-only metadata still increments the RC extension."""
+        mock_github_client.get_releases.return_value = [
+            Release(tag_name="r2.1", name="Release r2.1", draft=False,
+                    prerelease=True, html_url="")
+        ]
+        mock_github_client.get_release_metadata.return_value = {
+            "repository": {"release_tag": "r2.1"},
+            "apis": [{
+                "api_name": "consent-info",
+                "api_version": "0.2.0-rc.1",
+            }],
+        }
+
+        result = calculator.calculate_version(
+            api_name="consent-info",
+            target_version="0.2.0",
+            target_status="rc"
+        )
+
+        assert result == "0.2.0-rc.2"
 
     def test_first_alpha_release_gets_extension_1(
         self, calculator, mock_github_client
@@ -103,22 +128,24 @@ apis:
             Release(tag_name="r3.2", name="", draft=False, prerelease=True, html_url="")
         ]
 
-        def get_content(path, ref):
+        def get_release_metadata(ref):
             if ref == "r3.0":
-                return """
-apis:
-  - api_name: test-api
-    api_version: 2.0.0-rc.1
-"""
+                return {
+                    "apis": [{
+                        "api_name": "test-api",
+                        "api_version": "2.0.0-rc.1",
+                    }]
+                }
             elif ref == "r3.2":
-                return """
-apis:
-  - api_name: test-api
-    api_version: 2.0.0-rc.3
-"""
+                return {
+                    "apis": [{
+                        "api_name": "test-api",
+                        "api_version": "2.0.0-rc.3",
+                    }]
+                }
             return None
 
-        mock_github_client.get_file_content.side_effect = get_content
+        mock_github_client.get_release_metadata.side_effect = get_release_metadata
 
         result = calculator.calculate_version(
             api_name="test-api",
@@ -134,11 +161,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r4.1", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: other-api
-    api_version: 3.2.0-rc.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "other-api",
+                "api_version": "3.2.0-rc.1",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="location-verification",
@@ -154,11 +182,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r4.0", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: location-verification
-    api_version: 3.2.0-alpha.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "location-verification",
+                "api_version": "3.2.0-alpha.1",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="location-verification",
@@ -177,11 +206,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r3.0", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: location-verification
-    api_version: 3.1.0-rc.5
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "location-verification",
+                "api_version": "3.1.0-rc.5",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="location-verification",
@@ -199,11 +229,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r4.1", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: qos-profiles
-    api_version: 1.2.0-alpha.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "qos-profiles",
+                "api_version": "1.2.0-alpha.1",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="qos-profiles",
@@ -221,11 +252,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r4.2", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: qos-profiles
-    api_version: 1.2.0-rc.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "qos-profiles",
+                "api_version": "1.2.0-rc.1",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="qos-profiles",
@@ -245,22 +277,24 @@ apis:
             Release(tag_name="r6.1", name="", draft=False, prerelease=True, html_url="")
         ]
 
-        def get_content(path, ref):
+        def get_release_metadata(ref):
             if ref == "r4.1":
-                return """
-apis:
-  - api_name: qos-profiles
-    api_version: 1.2.0-alpha.1
-"""
+                return {
+                    "apis": [{
+                        "api_name": "qos-profiles",
+                        "api_version": "1.2.0-alpha.1",
+                    }]
+                }
             elif ref == "r6.1":
-                return """
-apis:
-  - api_name: qos-profiles
-    api_version: 1.3.0-alpha.2
-"""
+                return {
+                    "apis": [{
+                        "api_name": "qos-profiles",
+                        "api_version": "1.3.0-alpha.2",
+                    }]
+                }
             return None
 
-        mock_github_client.get_file_content.side_effect = get_content
+        mock_github_client.get_release_metadata.side_effect = get_release_metadata
 
         result = calculator.calculate_version(
             api_name="qos-profiles",
@@ -278,11 +312,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r4.1", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: qos-provisioning
-    api_version: 0.4.0-alpha.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "qos-provisioning",
+                "api_version": "0.4.0-alpha.1",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="qos-provisioning",
@@ -300,11 +335,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r4.1", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: qos-provisioning
-    api_version: 0.4.0-alpha.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "qos-provisioning",
+                "api_version": "0.4.0-alpha.1",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="qos-provisioning",
@@ -322,11 +358,12 @@ apis:
         mock_github_client.get_releases.return_value = [
             Release(tag_name="r4.1", name="", draft=False, prerelease=True, html_url="")
         ]
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - api_name: quality-on-demand
-    api_version: 1.2.0-alpha.1
-"""
+        mock_github_client.get_release_metadata.return_value = {
+            "apis": [{
+                "api_name": "quality-on-demand",
+                "api_version": "1.2.0-alpha.1",
+            }]
+        }
 
         result = calculator.calculate_version(
             api_name="quality-on-demand",
@@ -364,22 +401,24 @@ class TestFindExistingExtensions:
             Release(tag_name="r3.1", name="", draft=False, prerelease=True, html_url="")
         ]
 
-        def get_content(path, ref):
+        def get_release_metadata(ref):
             if ref == "r3.0":
-                return """
-apis:
-  - api_name: test-api
-    api_version: 1.0.0-rc.1
-"""
+                return {
+                    "apis": [{
+                        "api_name": "test-api",
+                        "api_version": "1.0.0-rc.1",
+                    }]
+                }
             elif ref == "r3.1":
-                return """
-apis:
-  - api_name: test-api
-    api_version: 1.0.0-rc.2
-"""
+                return {
+                    "apis": [{
+                        "api_name": "test-api",
+                        "api_version": "1.0.0-rc.2",
+                    }]
+                }
             return None
 
-        mock_github_client.get_file_content.side_effect = get_content
+        mock_github_client.get_release_metadata.side_effect = get_release_metadata
 
         result = calculator.find_existing_extensions(
             api_name="test-api",
@@ -398,18 +437,19 @@ apis:
             Release(tag_name="r3.0", name="", draft=False, prerelease=True, html_url="")
         ]
 
-        def get_content(path, ref):
+        def get_release_metadata(ref):
             if ref == "r2.0":
                 return None  # No metadata
             elif ref == "r3.0":
-                return """
-apis:
-  - api_name: test-api
-    api_version: 1.0.0-rc.1
-"""
+                return {
+                    "apis": [{
+                        "api_name": "test-api",
+                        "api_version": "1.0.0-rc.1",
+                    }]
+                }
             return None
 
-        mock_github_client.get_file_content.side_effect = get_content
+        mock_github_client.get_release_metadata.side_effect = get_release_metadata
 
         result = calculator.find_existing_extensions(
             api_name="test-api",


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

This fixes a release automation regression where RC version calculation only reads
`release-metadata.yaml` from the tagged repository tree. Older releases can store
that metadata only as a release asset, which caused the calculator to miss the
previous RC and reuse the same extension.

The change introduces a shared `GitHubClient` metadata loader that:
- reads `release-metadata.yaml` from the tag tree when present
- falls back to the legacy release asset when the file is not in the tag tree

`VersionCalculator` and `SnapshotCreator` now both use that shared loader.

This fixes the `ConsentInfo` scenario where:
- `r2.1` has `release-metadata.yaml` only as a release asset
- `r2.2` snapshot creation incorrectly calculated `0.2.0-rc.1`
- expected result is `0.2.0-rc.2`

#### Which issue(s) this PR fixes:

Fixes #116

#### Special notes for reviewers:

Focused internal release-automation fix only.
No RC numbering policy changed; this only restores legacy metadata lookup parity.

Verified with:
- `release_automation/tests/test_github_client.py`
- `release_automation/tests/test_version_calculator.py`
- `release_automation/tests/test_snapshot_creator.py`

#### Changelog input

```
release-note
Fix release automation RC version calculation for legacy releases where release-metadata.yaml exists only as a release asset.
```

#### Additional documentation 

```
docs
```
