### PR TITLE
fix(release-automation): resolve dependency versions from VERSION.yaml

### DIFF
--- a/release_automation/config/transformations.yaml
+++ b/release_automation/config/transformations.yaml
@@ -14,11 +14,12 @@
 #   - {major_version}: major version number (e.g., "3" from "3.2.0-rc.2")
 #   - {repo_name}: repository name (e.g., "QualityOnDemand")
 #   - {commonalities_release}: commonalities release tag from dependencies (e.g., "r3.4")
+#   - {commonalities_version}: commonalities semantic version from VERSION.yaml (e.g., "0.7.0-rc.1")
 #   - {icm_release}: ICM release tag from dependencies (e.g., "r3.3")
 #   - {api_name}: current API name
 #
-# Future (not yet available):
-#   - {commonalities_version}: commonalities documentation version (e.g., "0.5.0")
+# Available elsewhere in release automation, but not currently used by any
+# transformation rule in this file:
 #   - {icm_version}: ICM documentation version
 
 transformations:
@@ -64,8 +65,7 @@ transformations:
     file_pattern: "code/API_definitions/*.yaml"
     path: info.x-camara-commonalities
     # No match_value - replace any value (could be "wip", "0.6", etc.)
-    # Uses commonalities_release until commonalities_version is available
-    replacement: "{commonalities_release}"
+    replacement: "{commonalities_version}"
 
   # T4: REMOVED - x-camara-icm field does not (yet?) exist in CAMARA specs
 

--- a/release_automation/scripts/github_client.py
+++ b/release_automation/scripts/github_client.py
@@ -240,17 +240,64 @@ class GitHubClient:
             print(f"Warning: Failed to read {path} from {ref}: {e}")
             return None
 
+    def get_yaml_file(self, path: str, ref: str = "main") -> Optional[dict]:
+        """
+        Read and parse a YAML file from the repository.
+
+        Args:
+            path: File path relative to repository root
+            ref: Branch, tag, or commit SHA to read from
+
+        Returns:
+            Parsed YAML dict, or None if the file cannot be read or parsed
+        """
+        content = self.get_file_content(path, ref=ref)
+        if not content:
+            return None
+
+        try:
+            parsed = yaml.safe_load(content)
+        except yaml.YAMLError:
+            return None
+
+        return parsed if isinstance(parsed, dict) else None
+
+    def get_repository_yaml_file(
+        self, repo: str, path: str, ref: str = "main"
+    ) -> Optional[dict]:
+        """
+        Read and parse a YAML file from another repository using the same auth.
+
+        Args:
+            repo: Repository in format "owner/name"
+            path: File path relative to repository root
+            ref: Branch, tag, or commit SHA to read from
+
+        Returns:
+            Parsed YAML dict, or None if the file cannot be read or parsed
+        """
+        client = GitHubClient(repo=repo, token=self.token)
+        return client.get_yaml_file(path, ref=ref)
+
     def get_release_metadata(self, tag: str) -> Optional[dict]:
         """Read release-metadata.yaml from a release tag or legacy asset."""
         content = self.get_file_content("release-metadata.yaml", ref=tag)
-        if not content:
-            content = self.download_release_asset(tag, "release-metadata.yaml")
+        if content is not None:
+            try:
+                metadata = yaml.safe_load(content)
+            except yaml.YAMLError:
+                return None
+            return metadata if isinstance(metadata, dict) else None
+
+        content = self.download_release_asset(tag, "release-metadata.yaml")
         if not content:
             return None
+
         try:
             metadata = yaml.safe_load(content)
         except yaml.YAMLError:
             return None
+
         return metadata if isinstance(metadata, dict) else None
 
     def get_releases(self, include_drafts: bool = False) -> List[Release]:

--- a/release_automation/scripts/mechanical_transformer.py
+++ b/release_automation/scripts/mechanical_transformer.py
@@ -71,6 +71,7 @@ class TransformationContext:
     api_versions: Dict[str, str]
     commonalities_release: str  # Release tag, e.g., "r3.4"
     icm_release: str  # Release tag, e.g., "r3.3"
+    commonalities_version: str = ""  # Semantic version, e.g., "0.7.0-rc.1"
     repo_name: str = ""  # Repository name, e.g., "QualityOnDemand"
     release_plan: Dict[str, Any] = field(default_factory=dict)
 
@@ -452,6 +453,7 @@ class MechanicalTransformer:
         - {major_version}
         - {repo_name}
         - {commonalities_release}
+        - {commonalities_version}
         - {icm_release}
         - {api_name}
 
@@ -496,6 +498,7 @@ class MechanicalTransformer:
             "{major_version}": major_version,
             "{repo_name}": context.repo_name,
             "{commonalities_release}": context.commonalities_release,
+            "{commonalities_version}": context.commonalities_version,
             "{icm_release}": context.icm_release,
             "{api_name}": api_name or "",
         }

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -9,6 +9,7 @@ import os
 import re
 import shutil
 import tempfile
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -95,6 +96,11 @@ class TransformationError(SnapshotCreatorError):
     pass
 
 
+class DependencyResolutionError(SnapshotCreatorError):
+    """Raised when release dependency metadata cannot be resolved."""
+    pass
+
+
 class SnapshotCreator:
     """
     Orchestrates release snapshot creation.
@@ -106,6 +112,9 @@ class SnapshotCreator:
     SNAPSHOT_BRANCH_PREFIX = "release-snapshot"
     RELEASE_REVIEW_BRANCH_PREFIX = "release-review"
     SHORT_SHA_LENGTH = 7
+    COMMONALITIES_REPO = "camaraproject/Commonalities"
+    ICM_REPO = "camaraproject/IdentityAndConsentManagement"
+    COMMONALITIES_VERSION_FILE = "VERSION.yaml"
 
     def __init__(
         self,
@@ -193,6 +202,16 @@ class SnapshotCreator:
             result.snapshot_branch = snapshot_branch
             result.release_review_branch = release_review_branch
 
+            # Step 5b: Resolve Commonalities semantic version from VERSION.yaml
+            dependencies = release_plan.get("dependencies", {})
+            commonalities_release = dependencies.get("commonalities_release", "main")
+            icm_release = dependencies.get("identity_consent_management_release", "main")
+            icm_dependency_configured = "identity_consent_management_release" in dependencies
+            commonalities_version = self._resolve_commonalities_version(
+                commonalities_release
+            )
+            icm_version = self._resolve_icm_version(icm_release) if icm_dependency_configured else ""
+
             if config.dry_run:
                 result.success = True
                 result.warnings.append("Dry run: no branches or PR created")
@@ -221,15 +240,11 @@ class SnapshotCreator:
                 return result
 
             # Step 8: Apply transformations
-            # Extract dependency release tags from release-plan.yaml
-            dependencies = release_plan.get("dependencies", {})
-            commonalities_release = dependencies.get("commonalities_release", "main")
-            icm_release = dependencies.get("identity_consent_management_release", "main")
-
             context = TransformationContext(
                 release_tag=config.release_tag,
                 api_versions=api_versions,
                 commonalities_release=commonalities_release,
+                commonalities_version=commonalities_version,
                 icm_release=icm_release,
                 repo_name=self.gh.repo.split("/")[-1],
                 release_plan=release_plan,
@@ -248,8 +263,18 @@ class SnapshotCreator:
 
             # Step 9: Generate and write release-metadata.yaml
             api_titles = self._extract_api_titles(release_plan, temp_dir)
+            metadata_release_plan = self._build_release_plan_for_metadata(
+                release_plan,
+                commonalities_release,
+                commonalities_version,
+                icm_release if icm_dependency_configured else "",
+                icm_version,
+            )
             metadata = self.metadata_gen.generate(
-                release_plan, api_versions, base_sha, api_titles,
+                metadata_release_plan,
+                api_versions,
+                base_sha,
+                api_titles,
                 repo=self.gh.repo,
             )
             metadata_path = os.path.join(temp_dir, "release-metadata.yaml")
@@ -291,7 +316,14 @@ class SnapshotCreator:
             try:
                 repo_name = self.gh.repo.split("/")[-1]
                 self._generate_changelog(
-                    temp_dir, config, release_plan, api_versions, metadata, repo_name
+                    temp_dir,
+                    config,
+                    release_plan,
+                    api_versions,
+                    metadata,
+                    repo_name,
+                    commonalities_version=commonalities_version,
+                    icm_version=icm_version,
                 )
                 git_ops.commit_all(
                     f"Add CHANGELOG draft for {config.release_tag}"
@@ -317,6 +349,8 @@ class SnapshotCreator:
 
         except InvalidStateError as e:
             result.errors.append(str(e))
+        except DependencyResolutionError as e:
+            result.errors.append(str(e))
         except TransformationError as e:
             result.errors.append(str(e))
             cleanup_errors = self._cleanup_branches(snapshot_branch, release_review_branch)
@@ -335,6 +369,90 @@ class SnapshotCreator:
                 shutil.rmtree(temp_dir, ignore_errors=True)
 
         return result
+
+    def _resolve_commonalities_version(self, release_tag: str) -> str:
+        """
+        Resolve the Commonalities semantic version from VERSION.yaml.
+
+        Args:
+            release_tag: Commonalities release tag from release-plan.yaml
+
+        Returns:
+            Semantic version string from VERSION.yaml
+
+        Raises:
+            DependencyResolutionError: If VERSION.yaml cannot be resolved or parsed
+        """
+        return self._resolve_dependency_version(
+            repo=self.COMMONALITIES_REPO,
+            release_tag=release_tag,
+            display_name="Commonalities",
+        )
+
+    def _resolve_icm_version(self, release_tag: str) -> str:
+        """Resolve the Identity and Consent Management semantic version."""
+        return self._resolve_dependency_version(
+            repo=self.ICM_REPO,
+            release_tag=release_tag,
+            display_name="IdentityAndConsentManagement",
+        )
+
+    def _resolve_dependency_version(
+        self,
+        repo: str,
+        release_tag: str,
+        display_name: str,
+    ) -> str:
+        """Resolve a dependency semantic version from VERSION.yaml."""
+        version_data = self.gh.get_repository_yaml_file(
+            repo,
+            self.COMMONALITIES_VERSION_FILE,
+            ref=release_tag,
+        )
+        if version_data is None:
+            raise DependencyResolutionError(
+                f"{display_name} VERSION.yaml could not be resolved for "
+                f"release '{release_tag}'"
+            )
+
+        if not isinstance(version_data, dict):
+            raise DependencyResolutionError(
+                f"{display_name} VERSION.yaml could not be resolved for "
+                f"release '{release_tag}': expected a YAML mapping"
+            )
+
+        version = version_data.get("version")
+        if not isinstance(version, str) or not version.strip():
+            raise DependencyResolutionError(
+                f"{display_name} VERSION.yaml could not be resolved for "
+                f"release '{release_tag}': missing 'version'"
+            )
+
+        return version.strip()
+
+    def _build_release_plan_for_metadata(
+        self,
+        release_plan: Dict[str, Any],
+        commonalities_release: str,
+        commonalities_version: str,
+        icm_release: str,
+        icm_version: str,
+    ) -> Dict[str, Any]:
+        """
+        Enrich release-plan dependencies for release-metadata generation only.
+        """
+        enriched_plan = deepcopy(release_plan)
+        dependencies = enriched_plan.setdefault("dependencies", {})
+        dependencies["commonalities_release"] = {
+            "release_tag": commonalities_release,
+            "version": commonalities_version,
+        }
+        if icm_release and icm_version:
+            dependencies["identity_consent_management_release"] = {
+                "release_tag": icm_release,
+                "version": icm_version,
+            }
+        return enriched_plan
 
     def validate_preconditions(self, release_tag: str) -> List[str]:
         """
@@ -671,6 +789,8 @@ class SnapshotCreator:
         api_versions: Dict[str, str],
         metadata: Dict[str, Any],
         repo_name: str,
+        commonalities_version: str = "",
+        icm_version: str = "",
     ) -> str:
         """Generate CHANGELOG draft on release-review branch.
 
@@ -684,11 +804,20 @@ class SnapshotCreator:
         candidate_changes = self._get_candidate_changes(
             config.release_tag, previous_release
         )
+        changelog_metadata = deepcopy(metadata)
+        if commonalities_version:
+            changelog_metadata.setdefault("dependencies", {})[
+                "commonalities_release"
+            ] = commonalities_version
+        if icm_version:
+            changelog_metadata.setdefault("dependencies", {})[
+                "identity_consent_management_release"
+            ] = icm_version
 
         generator = ChangelogGenerator()
         content = generator.generate_draft(
             release_tag=config.release_tag,
-            metadata=metadata,
+            metadata=changelog_metadata,
             repo_name=repo_name,
             candidate_changes=candidate_changes,
         )

--- a/release_automation/tests/test_changelog_generator.py
+++ b/release_automation/tests/test_changelog_generator.py
@@ -204,6 +204,23 @@ class TestDraftGeneration:
         assert "quality-on-demand v1.1.0-rc.1" in result
         assert "Commonalities v0.6.0 (r3.3)" in result
 
+    def test_generate_draft_allows_commonalities_version_only(
+        self, generator, single_api_metadata
+    ):
+        single_api_metadata["dependencies"]["commonalities_release"] = "0.7.0-rc.1"
+        single_api_metadata["dependencies"][
+            "identity_consent_management_release"
+        ] = "0.5.0-rc.1"
+
+        result = generator.generate_draft(
+            release_tag="r4.1",
+            metadata=single_api_metadata,
+            repo_name="QualityOnDemand",
+        )
+
+        assert "Commonalities 0.7.0-rc.1" in result
+        assert "Identity and Consent Management 0.5.0-rc.1" in result
+
     def test_generate_draft_with_candidate_changes(
         self, generator, single_api_metadata, sample_changes_body
     ):

--- a/release_automation/tests/test_github_client.py
+++ b/release_automation/tests/test_github_client.py
@@ -79,6 +79,23 @@ class TestGitHubClient(unittest.TestCase):
         content = self.client.get_file_content("missing")
         self.assertIsNone(content)
 
+    @patch("release_automation.scripts.github_client.GitHubClient.get_file_content")
+    def test_get_yaml_file(self, mock_get_file_content):
+        mock_get_file_content.return_value = "version: 0.7.0-rc.1\n"
+
+        content = self.client.get_yaml_file("VERSION.yaml", ref="r4.1")
+
+        self.assertEqual(content, {"version": "0.7.0-rc.1"})
+        mock_get_file_content.assert_called_once_with("VERSION.yaml", ref="r4.1")
+
+    @patch("release_automation.scripts.github_client.GitHubClient.get_file_content")
+    def test_get_yaml_file_invalid(self, mock_get_file_content):
+        mock_get_file_content.return_value = "not: [valid"
+
+        content = self.client.get_yaml_file("VERSION.yaml", ref="r4.1")
+
+        self.assertIsNone(content)
+
     @patch("release_automation.scripts.github_client.GitHubClient.download_release_asset")
     @patch("release_automation.scripts.github_client.GitHubClient.get_file_content")
     def test_get_release_metadata_from_repo_tree(

--- a/release_automation/tests/test_mechanical_transformer.py
+++ b/release_automation/tests/test_mechanical_transformer.py
@@ -35,6 +35,7 @@ def context():
         },
         commonalities_release="r3.4",
         icm_release="r3.3",
+        commonalities_version="0.7.0-rc.1",
         repo_name="QualityOnDemand",
     )
 
@@ -141,6 +142,13 @@ class TestResolveTemplate:
         )
         assert result == "r3.4"
 
+    def test_resolve_commonalities_version(self, transformer, context):
+        """Resolve {commonalities_version} variable."""
+        result = transformer._resolve_template(
+            "{commonalities_version}", context, None
+        )
+        assert result == "0.7.0-rc.1"
+
     def test_resolve_icm_release(self, transformer, context):
         """Resolve {icm_release} variable."""
         result = transformer._resolve_template(
@@ -209,6 +217,7 @@ class TestResolveTemplate:
             },
             commonalities_release="r3.4",
             icm_release="r3.3",
+            commonalities_version="0.7.0-rc.1",
         )
         # sim-swap-subscriptions-createSubscription → sim-swap-subscriptions
         result = transformer._resolve_template(
@@ -377,6 +386,7 @@ class TestYamlPathTransformation:
                 api_versions={"test": "3.2.0-rc.2"},
                 commonalities_release="r3.4",
                 icm_release="r3.3",
+                commonalities_version="0.7.0-rc.1",
                 repo_name="TestRepo",
             )
 

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -38,6 +38,10 @@ def mock_github_client():
     client.list_branches.return_value = [
         Mock(name="main", sha="abc1234567890abcdef1234567890abcdef12345678")
     ]
+    client.get_repository_yaml_file.side_effect = lambda repo, path, ref="main": {
+        "camaraproject/Commonalities": {"version": "0.7.0-rc.1"},
+        "camaraproject/IdentityAndConsentManagement": {"version": "0.5.0-rc.1"},
+    }.get(repo)
     return client
 
 
@@ -683,6 +687,41 @@ class TestMetadataIntegration:
             "qos-profiles": "1.0.0",
         }
 
+    @patch("release_automation.scripts.snapshot_creator.tempfile.mkdtemp")
+    @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
+    @patch("release_automation.scripts.snapshot_creator.GitOperations")
+    @patch("builtins.open", create=True)
+    def test_passes_enriched_commonalities_dependency_to_metadata_generator(
+        self,
+        mock_open,
+        mock_git_ops_class,
+        mock_rmtree,
+        mock_mkdtemp,
+        snapshot_creator,
+        mock_metadata_generator,
+        sample_release_plan,
+    ):
+        """Metadata generation receives Commonalities release tag and version."""
+        mock_mkdtemp.return_value = "/tmp/test-snapshot"
+        mock_git_ops = MagicMock()
+        mock_git_ops_class.return_value = mock_git_ops
+        mock_git_ops.create_pr.return_value = PullRequestInfo(number=1, url="url")
+
+        snapshot_creator.create_snapshot(
+            sample_release_plan,
+            SnapshotConfig(release_tag="r4.1"),
+        )
+
+        metadata_plan = mock_metadata_generator.generate.call_args[0][0]
+        assert metadata_plan["dependencies"]["commonalities_release"] == {
+            "release_tag": "r3.4",
+            "version": "0.7.0-rc.1",
+        }
+        assert metadata_plan["dependencies"]["identity_consent_management_release"] == {
+            "release_tag": "r3.3",
+            "version": "0.5.0-rc.1",
+        }
+
 
 # --- Tests for version calculator integration ---
 
@@ -734,6 +773,7 @@ class TestVersionCalculatorIntegration:
             "qos-profiles": "1.0.0",
         }
         assert context.release_tag == "r4.1"
+        assert context.commonalities_version == "0.7.0-rc.1"
 
 
 # --- Tests for transformation integration ---
@@ -773,6 +813,73 @@ class TestTransformationIntegration:
         # These are derived from release_plan['dependencies']
         assert context.commonalities_release == "r3.4"
         assert context.icm_release == "r3.3"
+        assert context.commonalities_version == "0.7.0-rc.1"
+
+    @patch("release_automation.scripts.snapshot_creator.tempfile.mkdtemp")
+    @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
+    @patch("release_automation.scripts.snapshot_creator.GitOperations")
+    def test_fails_when_icm_version_cannot_be_resolved(
+        self,
+        mock_git_ops_class,
+        mock_rmtree,
+        mock_mkdtemp,
+        snapshot_creator,
+        mock_github_client,
+        sample_release_plan,
+    ):
+        """Missing ICM VERSION.yaml fails snapshot creation early."""
+        mock_mkdtemp.return_value = "/tmp/test-snapshot"
+
+        def version_lookup(repo, path, ref="main"):
+            if repo == "camaraproject/Commonalities":
+                return {"version": "0.7.0-rc.1"}
+            return None
+
+        mock_github_client.get_repository_yaml_file.side_effect = version_lookup
+
+        result = snapshot_creator.create_snapshot(
+            sample_release_plan,
+            SnapshotConfig(release_tag="r4.1"),
+        )
+
+        assert result.success is False
+        assert result.errors == [
+            "IdentityAndConsentManagement VERSION.yaml could not be resolved for release 'r3.3'"
+        ]
+        mock_git_ops_class.assert_not_called()
+
+    @patch("release_automation.scripts.snapshot_creator.tempfile.mkdtemp")
+    @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
+    @patch("release_automation.scripts.snapshot_creator.GitOperations")
+    def test_fails_when_commonalities_version_cannot_be_resolved(
+        self,
+        mock_git_ops_class,
+        mock_rmtree,
+        mock_mkdtemp,
+        snapshot_creator,
+        mock_github_client,
+        sample_release_plan,
+    ):
+        """Missing Commonalities VERSION.yaml fails snapshot creation early."""
+        mock_mkdtemp.return_value = "/tmp/test-snapshot"
+
+        def version_lookup(repo, path, ref="main"):
+            if repo == "camaraproject/Commonalities":
+                return None
+            return {"version": "0.5.0-rc.1"}
+
+        mock_github_client.get_repository_yaml_file.side_effect = version_lookup
+
+        result = snapshot_creator.create_snapshot(
+            sample_release_plan,
+            SnapshotConfig(release_tag="r4.1"),
+        )
+
+        assert result.success is False
+        assert result.errors == [
+            "Commonalities VERSION.yaml could not be resolved for release 'r3.4'"
+        ]
+        mock_git_ops_class.assert_not_called()
 
     @patch("release_automation.scripts.snapshot_creator.tempfile.mkdtemp")
     @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
@@ -1010,6 +1117,46 @@ class TestReleaseDocumentation:
         assert result == "CHANGELOG/CHANGELOG-r4.md"
         mock_instance.generate_draft.assert_called_once()
         mock_instance.write_changelog.assert_called_once()
+
+    @patch("release_automation.scripts.snapshot_creator.ChangelogGenerator")
+    def test_generate_changelog_uses_commonalities_version_only(
+        self, mock_gen_cls, snapshot_creator, mock_github_client, tmp_path
+    ):
+        """CHANGELOG generation uses semantic version instead of metadata display string."""
+        mock_github_client.get_releases.return_value = []
+        mock_github_client.generate_release_notes.return_value = None
+
+        mock_instance = Mock()
+        mock_instance.generate_draft.return_value = "# r4.1\n\nContent\n"
+        mock_instance.write_changelog.return_value = "CHANGELOG/CHANGELOG-r4.md"
+        mock_gen_cls.return_value = mock_instance
+
+        metadata = {
+            "repository": {"release_type": "pre-release-alpha"},
+            "apis": [],
+            "dependencies": {
+                "commonalities_release": "r4.1 (0.7.0-rc.1)",
+                "identity_consent_management_release": "r4.1 (0.5.0-rc.1)",
+            },
+        }
+
+        snapshot_creator._generate_changelog(
+            str(tmp_path),
+            SnapshotConfig(release_tag="r4.1"),
+            {},
+            {},
+            metadata,
+            "TestRepo-QoD",
+            commonalities_version="0.7.0-rc.1",
+            icm_version="0.5.0-rc.1",
+        )
+
+        draft_metadata = mock_instance.generate_draft.call_args.kwargs["metadata"]
+        assert draft_metadata["dependencies"]["commonalities_release"] == "0.7.0-rc.1"
+        assert (
+            draft_metadata["dependencies"]["identity_consent_management_release"]
+            == "0.5.0-rc.1"
+        )
 
     def test_readme_update_uses_shared_release_metadata_loader(
         self, snapshot_creator, mock_github_client


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

- resolve Commonalities and IdentityAndConsentManagement semantic versions from `VERSION.yaml` during snapshot creation
- use the Commonalities semantic version for `info.x-camara-commonalities`
- use dependency semantic versions in `CHANGELOG-rX.md`
- write schema-compliant dependency values to `release-metadata.yaml` as `release-tag (semantic-version)`
- fail snapshot creation early when a dependency `VERSION.yaml` cannot be read or does not contain a valid `version`
- clarify in `transformations.yaml` that `icm_version` is available at runtime but not consumed by transformation rules

#### Which issue(s) this PR fixes:

Fixes camaraproject/ReleaseManagement#433

#### Special notes for reviewers:

- `release-plan.yaml` stays tag-only; dependency semantic versions are resolved at runtime from the configured release tags
- Commonalities keeps separate values for link rewriting (`commonalities_release`) and semantic-version substitution (`commonalities_version`)
- IdentityAndConsentManagement semantic version is currently used in changelog and metadata generation only
- live validation was run in `hdamker/TestRepo-QoD` with one positive snapshot and one negative run using a nonexistent Commonalities release tag

#### Changelog input

```
release-note
Fix snapshot creation so dependency semantic versions are resolved from VERSION.yaml and written consistently into API, changelog, and release metadata output.
```

#### Additional documentation

```
docs
Tested with TestRepo-QoD issue #96:
- positive run 22904541274 produced `x-camara-commonalities: 0.7.0-rc.1`, changelog dependency versions, and schema-compliant metadata values
- negative run 22904868083 failed early with `Commonalities VERSION.yaml could not be resolved for release 'r999.999'`
```
