### PR TITLE
fix(release-automation): CHANGELOG compare base depends on release type

### DIFF
--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -675,6 +675,79 @@ class SnapshotCreator:
             return releases[0].tag_name
         return None
 
+    def _get_compare_base(
+        self, release_type: str, release_tag: str
+    ) -> Optional[str]:
+        """Determine the compare base for CHANGELOG candidate changes.
+
+        The CHANGELOG convention defines different comparison bases:
+        - Alpha: delta to the previous release (any type)
+        - First RC: all changes since the last public release
+        - Subsequent RC: delta to the previous release-candidate
+        - Public/maintenance: all changes since the previous public release
+
+        For RC releases, checks same-cycle prereleases via release-metadata.yaml
+        to distinguish first RC from subsequent RC.
+
+        Args:
+            release_type: From release-metadata.yaml (e.g., "pre-release-alpha",
+                "pre-release-rc", "public-release", "maintenance-release")
+            release_tag: Current release tag (e.g., "r4.2") for cycle detection.
+
+        Returns:
+            Tag name of the compare base, or None if no prior release exists.
+        """
+        if release_type == "pre-release-alpha":
+            return self._get_previous_release()
+
+        if release_type == "pre-release-rc":
+            return self._get_rc_compare_base(release_tag)
+
+        # Public and maintenance: compare against last public release
+        return self._get_latest_public_release()
+
+    def _get_rc_compare_base(self, release_tag: str) -> Optional[str]:
+        """Find compare base for an RC release.
+
+        Checks same-cycle prereleases for a previous RC. If found,
+        this is a subsequent RC (compare against it). Otherwise,
+        this is the first RC (compare against last public release).
+
+        Args:
+            release_tag: Current release tag (e.g., "r4.2") for cycle detection.
+
+        Returns:
+            Tag name of the compare base, or None if no prior release exists.
+        """
+        releases = self.gh.get_releases(include_drafts=False)
+        if not releases:
+            return None
+
+        # Extract cycle prefix (e.g., "r4." from "r4.2")
+        match = re.match(r"(r\d+\.)", release_tag)
+        cycle_prefix = match.group(1) if match else None
+
+        if cycle_prefix:
+            for r in releases:
+                if not r.tag_name.startswith(cycle_prefix):
+                    continue  # Different cycle
+                if not r.prerelease:
+                    break  # Public release in same cycle — no prior RC possible
+                # Same-cycle prerelease — check if it's an RC
+                metadata = self.gh.get_release_metadata(r.tag_name)
+                if metadata:
+                    prev_type = metadata.get("repository", {}).get(
+                        "release_type", ""
+                    )
+                    if prev_type == "pre-release-rc":
+                        return r.tag_name  # Subsequent RC
+
+        # No previous RC in same cycle → first RC → last public (any cycle)
+        for r in releases:
+            if not r.prerelease:
+                return r.tag_name
+        return None
+
     def _get_candidate_changes(
         self, release_tag: str, previous_release: Optional[str]
     ) -> Optional[str]:
@@ -794,15 +867,17 @@ class SnapshotCreator:
     ) -> str:
         """Generate CHANGELOG draft on release-review branch.
 
-        Determines previous release, fetches candidate changes from GitHub's
-        generate-notes API, generates draft, writes to CHANGELOG directory.
+        Determines compare base (dependent on release type), fetches candidate
+        changes from GitHub's generate-notes API, generates draft, writes to
+        CHANGELOG directory.
 
         Returns:
             Relative path to the written CHANGELOG file.
         """
-        previous_release = self._get_previous_release()
+        release_type = metadata.get("repository", {}).get("release_type", "")
+        compare_base = self._get_compare_base(release_type, config.release_tag)
         candidate_changes = self._get_candidate_changes(
-            config.release_tag, previous_release
+            config.release_tag, compare_base
         )
         changelog_metadata = deepcopy(metadata)
         if commonalities_version:

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -1030,6 +1030,136 @@ class TestReleaseDocumentation:
         result = snapshot_creator._get_previous_release()
         assert result is None
 
+    # --- Tests for _get_compare_base ---
+
+    def test_compare_base_alpha_uses_previous_release(
+        self, snapshot_creator, mock_github_client
+    ):
+        """Alpha compares against previous release (any type)."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.1", prerelease=True),
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        result = snapshot_creator._get_compare_base("pre-release-alpha", "r4.2")
+        assert result == "r4.1"
+
+    def test_compare_base_first_rc_uses_last_public(
+        self, snapshot_creator, mock_github_client
+    ):
+        """First RC (no prior RC in same cycle) compares against last public."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.1", prerelease=True),
+            Mock(tag_name="r4.0", prerelease=True),
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        # Same-cycle prereleases are alphas
+        mock_github_client.get_release_metadata.side_effect = [
+            {"repository": {"release_type": "pre-release-alpha"}},
+            {"repository": {"release_type": "pre-release-alpha"}},
+        ]
+        result = snapshot_creator._get_compare_base("pre-release-rc", "r4.2")
+        assert result == "r3.2"
+
+    def test_compare_base_subsequent_rc_uses_previous_rc(
+        self, snapshot_creator, mock_github_client
+    ):
+        """Subsequent RC compares against previous RC in same cycle."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.2", prerelease=True),
+            Mock(tag_name="r4.1", prerelease=True),
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        # First same-cycle prerelease is an RC
+        mock_github_client.get_release_metadata.return_value = {
+            "repository": {"release_type": "pre-release-rc"},
+        }
+        result = snapshot_creator._get_compare_base("pre-release-rc", "r4.3")
+        assert result == "r4.2"
+        # Should only check the first same-cycle prerelease
+        mock_github_client.get_release_metadata.assert_called_once_with("r4.2")
+
+    def test_compare_base_public_uses_last_public(
+        self, snapshot_creator, mock_github_client
+    ):
+        """Public release compares against previous public release."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.1", prerelease=True),
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        result = snapshot_creator._get_compare_base("public-release", "r4.2")
+        assert result == "r3.2"
+
+    def test_compare_base_maintenance_uses_last_public(
+        self, snapshot_creator, mock_github_client
+    ):
+        """Maintenance release compares against last public release."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r3.2", prerelease=False),
+            Mock(tag_name="r2.1", prerelease=False),
+        ]
+        result = snapshot_creator._get_compare_base("maintenance-release", "r3.3")
+        assert result == "r3.2"
+
+    def test_compare_base_alpha_no_releases_returns_none(
+        self, snapshot_creator, mock_github_client
+    ):
+        """Alpha returns None when no releases exist."""
+        mock_github_client.get_releases.return_value = []
+        result = snapshot_creator._get_compare_base("pre-release-alpha", "r4.0")
+        assert result is None
+
+    def test_compare_base_rc_no_public_returns_none(
+        self, snapshot_creator, mock_github_client
+    ):
+        """RC returns None when no public releases exist and no prior RC."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.1", prerelease=True),
+        ]
+        mock_github_client.get_release_metadata.return_value = {
+            "repository": {"release_type": "pre-release-alpha"},
+        }
+        result = snapshot_creator._get_compare_base("pre-release-rc", "r4.2")
+        assert result is None
+
+    def test_compare_base_rc_legacy_prerelease_skipped(
+        self, snapshot_creator, mock_github_client
+    ):
+        """RC skips same-cycle prereleases with no release-metadata.yaml."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.1", prerelease=True),
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        # Legacy release — no metadata
+        mock_github_client.get_release_metadata.return_value = None
+        result = snapshot_creator._get_compare_base("pre-release-rc", "r4.2")
+        assert result == "r3.2"
+
+    def test_compare_base_rc_skips_different_cycle(
+        self, snapshot_creator, mock_github_client
+    ):
+        """RC ignores prereleases from different cycles."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r3.1", prerelease=True),  # Different cycle
+            Mock(tag_name="r2.0", prerelease=False),
+        ]
+        # r3.1 is different cycle — get_release_metadata should not be called
+        result = snapshot_creator._get_compare_base("pre-release-rc", "r4.0")
+        assert result == "r2.0"
+        mock_github_client.get_release_metadata.assert_not_called()
+
+    def test_compare_base_rc_same_cycle_public_stops_search(
+        self, snapshot_creator, mock_github_client
+    ):
+        """RC stops searching same-cycle when public release found."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.0", prerelease=False),  # Public in same cycle
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        result = snapshot_creator._get_compare_base("pre-release-rc", "r4.1")
+        # Should return r4.0 (last public, found after breaking from same-cycle search)
+        assert result == "r4.0"
+        mock_github_client.get_release_metadata.assert_not_called()
+
     def test_get_candidate_changes_works_without_previous(
         self, snapshot_creator, mock_github_client
     ):
@@ -1157,6 +1287,59 @@ class TestReleaseDocumentation:
             draft_metadata["dependencies"]["identity_consent_management_release"]
             == "0.5.0-rc.1"
         )
+
+    @patch("release_automation.scripts.snapshot_creator.ChangelogGenerator")
+    def test_generate_changelog_rc_uses_public_release_as_base(
+        self, mock_gen_cls, snapshot_creator, mock_github_client, tmp_path
+    ):
+        """RC changelog compares against last public release, not previous alpha."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.1", prerelease=True),
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        mock_github_client.get_release_metadata.return_value = {
+            "repository": {"release_type": "pre-release-alpha"},
+        }
+        mock_github_client.generate_release_notes.return_value = "## What's Changed\n"
+
+        mock_instance = Mock()
+        mock_instance.generate_draft.return_value = "# r4.2\n\nContent\n"
+        mock_instance.write_changelog.return_value = "CHANGELOG/CHANGELOG-r4.md"
+        mock_gen_cls.return_value = mock_instance
+
+        config = SnapshotConfig(release_tag="r4.2")
+        metadata = {"repository": {"release_type": "pre-release-rc"}, "apis": [], "dependencies": {}}
+        snapshot_creator._generate_changelog(
+            str(tmp_path), config, {}, {}, metadata, "TestRepo-QoD"
+        )
+
+        # Should compare against r3.2 (last public), not r4.1 (previous alpha)
+        mock_github_client.generate_release_notes.assert_called_once_with("r4.2", "r3.2")
+
+    @patch("release_automation.scripts.snapshot_creator.ChangelogGenerator")
+    def test_generate_changelog_alpha_uses_previous_release_as_base(
+        self, mock_gen_cls, snapshot_creator, mock_github_client, tmp_path
+    ):
+        """Alpha changelog compares against previous release (any type)."""
+        mock_github_client.get_releases.return_value = [
+            Mock(tag_name="r4.1", prerelease=True),
+            Mock(tag_name="r3.2", prerelease=False),
+        ]
+        mock_github_client.generate_release_notes.return_value = "## What's Changed\n"
+
+        mock_instance = Mock()
+        mock_instance.generate_draft.return_value = "# r4.2\n\nContent\n"
+        mock_instance.write_changelog.return_value = "CHANGELOG/CHANGELOG-r4.md"
+        mock_gen_cls.return_value = mock_instance
+
+        config = SnapshotConfig(release_tag="r4.2")
+        metadata = {"repository": {"release_type": "pre-release-alpha"}, "apis": [], "dependencies": {}}
+        snapshot_creator._generate_changelog(
+            str(tmp_path), config, {}, {}, metadata, "TestRepo-QoD"
+        )
+
+        # Should compare against r4.1 (previous release), not r3.2 (last public)
+        mock_github_client.generate_release_notes.assert_called_once_with("r4.2", "r4.1")
 
     def test_readme_update_uses_shared_release_metadata_loader(
         self, snapshot_creator, mock_github_client


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The CHANGELOG draft's candidate changes section always compared against the immediately previous release tag. This is only correct for alpha releases. Now selects the compare base according to the CHANGELOG convention:

- **Alpha**: delta to previous release (any type)
- **First RC**: all changes since last public release
- **Subsequent RC**: delta to previous RC (same cycle)
- **Public/maintenance**: all changes since previous public release

For RC releases, checks same-cycle prereleases via `release-metadata.yaml` to distinguish first RC from subsequent RC. Legacy releases without metadata are treated as non-RC (skipped).

#### Which issue(s) this PR fixes:

Fixes #125

#### Special notes for reviewers:

E2E validated on `hdamker/TestRepo-New` with a full 5-release lifecycle:

| Step | Tag | Type | Compare Base | Full Changelog URL | Version |
|------|-----|------|-------------|-------------------|---------|
| 1 | r1.1 | alpha | None (no prior) | `commits/r1.1` | 1.0.0-alpha.1 |
| 2 | r1.2 | first RC | None (no public) | `commits/r1.2` | 1.0.0-rc.1 |
| 3 | r1.3 | subsequent RC | r1.2 (prev RC) | `compare/r1.2...r1.3` | 1.0.0-rc.2 |
| 4 | r1.4 | public | None (no prior public) | `commits/r1.4` | 1.0.0 |
| 5 | r2.1 | first RC (new cycle) | r1.4 (last public) | `compare/r1.4...r2.1` | 1.1.0-rc.3 |

563 unit tests pass (12 new tests for compare base selection).

#### Changelog input

```
release-note
fix: CHANGELOG candidate changes compare base now depends on release type (alpha/RC/public)
```

#### Additional documentation

```
docs
n/a
```