### PR TITLE
fix(validation): phase 0 quick fixes

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -857,7 +857,7 @@ jobs:
           echo "success=false" >> "$GITHUB_OUTPUT"
           SUMMARY="${{ steps.validation.outputs.summary }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "error_message=Pre-snapshot validation failed: ${SUMMARY}. See ${RUN_URL}" >> "$GITHUB_OUTPUT"
+          echo "error_message=Pre-snapshot validation failed: ${SUMMARY}. [View workflow logs](${RUN_URL})" >> "$GITHUB_OUTPUT"
           exit 1
 
       # ── Snapshot creation ─────────────────────────────────────────

--- a/release_automation/templates/bot_messages/snapshot_failed.md
+++ b/release_automation/templates/bot_messages/snapshot_failed.md
@@ -2,9 +2,7 @@
 {{#workflow_run_url}}[View workflow logs]({{workflow_run_url}}){{/workflow_run_url}}
 
 {{#error_message}}
-```
-{{error_message}}
-```
+> {{error_message}}
 {{/error_message}}
 
 **Valid actions:**<br>→ Fix issues on `main`, or contact Release Management for unexpected errors<br>→ **`/create-snapshot` — retry after fixes are merged**

--- a/validation/context/context_builder.py
+++ b/validation/context/context_builder.py
@@ -110,6 +110,7 @@ class ValidationContext:
     icm_release: Optional[str]
 
     # PR-specific (None / False for non-PR triggers)
+    base_ref: Optional[str]
     is_release_review_pr: bool
     release_plan_changed: Optional[bool]
     pr_number: Optional[int]
@@ -337,6 +338,7 @@ def build_validation_context(
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
         icm_release=icm_release,
+        base_ref=base_ref or None,
         is_release_review_pr=is_review,
         release_plan_changed=release_plan_changed,
         pr_number=pr_number,

--- a/validation/engines/python_checks/release_review_checks.py
+++ b/validation/engines/python_checks/release_review_checks.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from validation.context import ValidationContext
 
@@ -22,15 +22,42 @@ _ALLOWED_PATHS = frozenset({"CHANGELOG.md", "README.md"})
 _ALLOWED_PREFIXES = ("CHANGELOG/",)
 
 
-def _get_changed_files(repo_path: Path) -> List[str]:
+def _get_changed_files(
+    repo_path: Path, base_ref: Optional[str] = None
+) -> List[str]:
     """Get files changed in the current PR via git diff.
 
-    Compares HEAD against the merge-base with the target branch.
-    Falls back to diffing HEAD~1 if git operations fail.
+    Uses three-dot diff against ``origin/{base_ref}`` when available
+    (merge-base comparison — works regardless of checkout merge strategy).
+    Falls back to ``HEAD~1`` when base_ref is not provided.
     """
+    # Primary: merge-base diff against the target branch
+    if base_ref:
+        try:
+            result = subprocess.run(
+                [
+                    "git", "diff", "--name-only", "--diff-filter=ACMR",
+                    f"origin/{base_ref}...HEAD",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(repo_path),
+                timeout=30,
+            )
+            if result.returncode == 0:
+                return [
+                    f.strip() for f in result.stdout.strip().split("\n")
+                    if f.strip()
+                ]
+            logger.warning(
+                "Merge-base diff failed (rc=%d), falling back to HEAD~1",
+                result.returncode,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("Merge-base diff error: %s, falling back to HEAD~1", exc)
+
+    # Fallback: diff against first parent (assumes merge commit)
     try:
-        # In a PR context, the diff against origin/base shows changed files.
-        # Use --diff-filter=ACMR to only show added/copied/modified/renamed.
         result = subprocess.run(
             ["git", "diff", "--name-only", "--diff-filter=ACMR", "HEAD~1"],
             capture_output=True,
@@ -73,7 +100,7 @@ def check_release_review_file_restriction(
     if not context.is_release_review_pr:
         return []
 
-    changed_files = _get_changed_files(repo_path)
+    changed_files = _get_changed_files(repo_path, context.base_ref)
     if not changed_files:
         return []
 

--- a/validation/output/annotations.py
+++ b/validation/output/annotations.py
@@ -83,10 +83,11 @@ def _build_command(finding: dict) -> str:
     line = finding.get("line", 1)
     col = finding.get("column")
 
-    title = format_rule_label(finding)
+    rule_label = format_rule_label(finding)
 
-    # Message: main message + optional hint
-    message = finding.get("message", "")
+    # Title: human-readable message.  Rule ID in message body.
+    title = finding.get("message", "")
+    message = f"[{rule_label}] {title}"
     hint = finding.get("hint")
     if hint:
         message = f"{message} | Hint: {hint}"

--- a/validation/output/check_run.py
+++ b/validation/output/check_run.py
@@ -81,9 +81,12 @@ def _build_annotation(finding: dict) -> dict:
 
     path = finding.get("path", "")
     line = finding.get("line", 1)
-    title = format_rule_label(finding)
+    rule_label = format_rule_label(finding)
 
-    message = finding.get("message", "")
+    # Title: human-readable message (rendered as bold heading in Check Run).
+    # Rule ID goes into the message body to reduce visual weight.
+    title = finding.get("message", "")
+    message = f"[{rule_label}] {title}"
     hint = finding.get("hint")
     if hint:
         message = f"{message}\n\nHint: {hint}"

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -32,10 +32,6 @@
   engine_rule: check-server-url-version
   conditional_level:
     default: error
-    overrides:
-      - condition:
-          branch_types: [main, feature]
-        level: warn
 
 # P-005: check-server-url-api-name
 - id: P-005

--- a/validation/tests/test_context_builder.py
+++ b/validation/tests/test_context_builder.py
@@ -212,6 +212,7 @@ class TestValidationContextToDict:
             target_release_type="pre-release-rc",
             commonalities_release="r4.1",
             icm_release=None,
+            base_ref="main",
             is_release_review_pr=False,
             release_plan_changed=True,
             pr_number=42,
@@ -234,8 +235,8 @@ class TestValidationContextToDict:
         expected_keys = {
             "repository", "branch_type", "trigger_type", "profile", "stage",
             "target_release_type", "commonalities_release", "icm_release",
-            "is_release_review_pr", "release_plan_changed", "pr_number",
-            "apis", "workflow_run_url", "tooling_ref",
+            "base_ref", "is_release_review_pr", "release_plan_changed",
+            "pr_number", "apis", "workflow_run_url", "tooling_ref",
         }
         assert set(d.keys()) == expected_keys
 

--- a/validation/tests/test_orchestrator.py
+++ b/validation/tests/test_orchestrator.py
@@ -94,6 +94,7 @@ def _make_context(**overrides):
         "target_release_type": None,
         "commonalities_release": None,
         "icm_release": None,
+        "base_ref": None,
         "is_release_review_pr": False,
         "release_plan_changed": False,
         "pr_number": 42,

--- a/validation/tests/test_output_annotations.py
+++ b/validation/tests/test_output_annotations.py
@@ -114,15 +114,20 @@ class TestBuildCommand:
         cmd = _build_command(f)
         assert "col=" not in cmd
 
-    def test_title_uses_rule_id(self):
-        f = _make_finding(rule_id="S-042", engine_rule="some-spectral-rule")
+    def test_title_uses_message(self):
+        f = _make_finding(rule_id="S-042", message="Bad path")
         cmd = _build_command(f)
-        assert "title=S-042" in cmd
+        assert "title=Bad path" in cmd
 
-    def test_title_falls_back_to_engine_rule(self):
-        f = _make_finding(engine_rule="camara-path-casing")
+    def test_rule_id_in_message_body(self):
+        f = _make_finding(rule_id="S-042", message="Bad path")
         cmd = _build_command(f)
-        assert "title=camara-path-casing" in cmd
+        assert "[S-042] Bad path" in cmd
+
+    def test_rule_id_fallback_in_message_body(self):
+        f = _make_finding(engine_rule="camara-path-casing", message="Bad path")
+        cmd = _build_command(f)
+        assert "[camara-path-casing] Bad path" in cmd
 
     def test_hint_appended(self):
         f = _make_finding(message="Bad path", hint="Use kebab-case")

--- a/validation/tests/test_output_check_run.py
+++ b/validation/tests/test_output_check_run.py
@@ -29,6 +29,7 @@ def _make_context(
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,
@@ -162,19 +163,26 @@ class TestAnnotationContent:
         assert ann["start_line"] == 42
         assert ann["end_line"] == 42
 
-    def test_title_uses_rule_id(self):
-        findings = [_make_finding(rule_id="S-042")]
+    def test_title_uses_message(self):
+        findings = [_make_finding(rule_id="S-042", message="Bad pattern")]
         payload = generate_check_run_payload(
             _make_result(findings), _make_context(),
         )
-        assert payload.annotations[0]["title"] == "S-042"
+        assert payload.annotations[0]["title"] == "Bad pattern"
 
-    def test_title_falls_back_to_engine_rule(self):
-        findings = [_make_finding(engine_rule="my-check")]
+    def test_rule_id_in_message_body(self):
+        findings = [_make_finding(rule_id="S-042", message="Bad pattern")]
         payload = generate_check_run_payload(
             _make_result(findings), _make_context(),
         )
-        assert payload.annotations[0]["title"] == "my-check"
+        assert "[S-042] Bad pattern" in payload.annotations[0]["message"]
+
+    def test_rule_id_fallback_in_message_body(self):
+        findings = [_make_finding(engine_rule="my-check", message="Bad pattern")]
+        payload = generate_check_run_payload(
+            _make_result(findings), _make_context(),
+        )
+        assert "[my-check] Bad pattern" in payload.annotations[0]["message"]
 
     def test_message_content(self):
         findings = [_make_finding(message="Bad pattern")]

--- a/validation/tests/test_output_commit_status.py
+++ b/validation/tests/test_output_commit_status.py
@@ -28,6 +28,7 @@ def _make_context(
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_output_diagnostics.py
+++ b/validation/tests/test_output_diagnostics.py
@@ -25,6 +25,7 @@ def _make_context() -> ValidationContext:
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_output_pr_comment.py
+++ b/validation/tests/test_output_pr_comment.py
@@ -25,6 +25,7 @@ def _make_context(
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -32,6 +32,7 @@ def _make_context(
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_postfilter_conditions.py
+++ b/validation/tests/test_postfilter_conditions.py
@@ -37,6 +37,7 @@ def _make_context(
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=is_release_review_pr,
         release_plan_changed=release_plan_changed,
         pr_number=None,

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -40,6 +40,7 @@ def _make_context(
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=is_release_review_pr,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_postfilter_levels.py
+++ b/validation/tests/test_postfilter_levels.py
@@ -37,6 +37,7 @@ def _make_context(
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_adapter.py
+++ b/validation/tests/test_python_adapter.py
@@ -35,6 +35,7 @@ def _make_context(
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_checks_changelog.py
+++ b/validation/tests/test_python_checks_changelog.py
@@ -37,6 +37,7 @@ def _make_context(
         target_release_type=target_release_type,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_checks_filename.py
+++ b/validation/tests/test_python_checks_filename.py
@@ -36,6 +36,7 @@ def _make_context(api_name: str) -> ValidationContext:
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_checks_metadata.py
+++ b/validation/tests/test_python_checks_metadata.py
@@ -40,6 +40,7 @@ def _make_context(api_names: list[str]) -> ValidationContext:
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_checks_readme.py
+++ b/validation/tests/test_python_checks_readme.py
@@ -25,6 +25,7 @@ def _make_context() -> ValidationContext:
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_checks_release_plan.py
+++ b/validation/tests/test_python_checks_release_plan.py
@@ -32,6 +32,7 @@ def _make_context() -> ValidationContext:
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_checks_release_review.py
+++ b/validation/tests/test_python_checks_release_review.py
@@ -19,7 +19,10 @@ from validation.engines.python_checks.release_review_checks import (
 # ---------------------------------------------------------------------------
 
 
-def _make_context(is_release_review: bool = True) -> ValidationContext:
+def _make_context(
+    is_release_review: bool = True,
+    base_ref: str = "release-snapshot/r1.0",
+) -> ValidationContext:
     return ValidationContext(
         repository="TestRepo",
         branch_type="release",
@@ -29,6 +32,7 @@ def _make_context(is_release_review: bool = True) -> ValidationContext:
         target_release_type="public-release",
         commonalities_release=None,
         icm_release=None,
+        base_ref=base_ref,
         is_release_review_pr=is_release_review,
         release_plan_changed=None,
         pr_number=42,

--- a/validation/tests/test_python_checks_test.py
+++ b/validation/tests/test_python_checks_test.py
@@ -44,6 +44,7 @@ def _make_context(
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -43,6 +43,7 @@ def _make_context(
         target_release_type=None,
         commonalities_release=None,
         icm_release=None,
+        base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,


### PR DESCRIPTION
#### What type of PR is this?

bug, correction

#### What this PR does / why we need it:

Addresses 4 of 5 Phase 0 quick fixes identified during integration testing:

- **P-004 severity**: `check-server-url-version` always error (was warn on main/feature). Server URL version mismatch is a release blocker on any branch.
- **Annotation rule ID weight**: Title now shows the human-readable message instead of the rule ID. Rule ID moved to message body as `[S-042] message`. Reduces visual noise in Check Run annotations.
- **File restriction git diff**: Uses merge-base diff (`origin/{base_ref}...HEAD`) instead of fragile `HEAD~1`. Added `base_ref` to `ValidationContext`. Falls back to `HEAD~1` when base_ref unavailable.
- **Snapshot failed template**: Replaced code block with blockquote for word-wrap. Changed bare URL to markdown link for workflow run.

Annotation dedup (5th item) deferred to Phase 1 ruleset work.

#### Which issue(s) this PR fixes:

Part of the validation framework v1 work tracked in [ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448)

#### Special notes for reviewers:

The `base_ref` addition to `ValidationContext` touches 20 test files (mechanical `base_ref=None` insertion).

#### Changelog input

```
 release-note
Phase 0 fixes: P-004 severity, annotation formatting, merge-base git diff, template presentation
```

#### Additional documentation

```
docs

```