### PR TITLE
feat(validation): version-specific Spectral rulesets and annotation dedup

### DIFF
--- a/linting/config/.spectral-r3.4.yaml
+++ b/linting/config/.spectral-r3.4.yaml
@@ -1,0 +1,283 @@
+# CAMARA Project - Spectral linting ruleset for Commonalities r3.4 (Fall25, 0.6.x)
+# Frozen — only maintenance fixes allowed.
+#
+# Based on: https://github.com/camaraproject/Commonalities/blob/r3.4/artifacts/linting_rules/.spectral.yml
+# Changelog:
+# - 31.01.2024: Initial version
+# - 19.03.2024: Corrected camara-http-methods rule
+# - 03.12.2024: Corrected camara-path-param-id and camara-discriminator-use to handle null values error in example fields
+# - 09.01.2025: Updated info-contact rule
+# - 21.07.2025: Added camara-schema-type-check rule
+
+
+extends: "spectral:oas"
+functions:
+  - camara-reserved-words
+  - camara-language-avoid-telco
+  - camara-security-no-secrets-in-path-or-query-parameters
+functionsDir: "./lint_function"
+rules:
+  #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
+  #  The severity keyword is optional in rule definition and can be error, warn, info, hint, or off. The default value is warn.
+  contact-properties: false
+  duplicated-entry-in-enum: true
+  info-contact: false
+  info-description: true
+  info-license: true
+  license-url: true
+  no-$ref-siblings: error
+  no-eval-in-markdown: true
+  no-script-tags-in-markdown: true
+  openapi-tags: false
+  openapi-tags-alphabetical: false
+  openapi-tags-uniqueness: error
+  operation-description: true
+  operation-operationId: true
+  operation-operationId-unique: error
+  operation-operationId-valid-in-url: true
+  operation-parameters: true
+  operation-singular-tag: true
+  operation-success-response: true
+  operation-tags: true
+  operation-tag-defined: true
+  path-declarations-must-exist: true
+  path-keys-no-trailing-slash: true
+  path-not-include-query: true
+  path-params: error
+  tag-description: false
+  typed-enum: true
+  oas3-api-servers: true
+  oas3-examples-value-or-externalValue: true
+  oas3-operation-security-defined: false
+  oas3-parameter-description: false
+  oas3-schema: true
+  oas3-server-not-example.com: false
+  oas3-server-trailing-slash: true
+  oas3-unused-component: true
+  oas3-valid-media-example: true
+  oas3-valid-schema-example: true
+  # oas3-server-variables: true
+
+  # Custom Rules Utilizing Spectral's Built-in Functions and JavaScript Implementations
+
+  camara-language-avoid-telco:
+    message: "{{error}}"
+    severity: hint
+    description: |
+      This rule checks for telco-specific terminology in your API definitions and suggests more inclusive terms.
+    given: "$..*.*"
+    then:
+      function: camara-language-avoid-telco
+    recommended: false  # Set to true/false to enable/disable this rule
+
+  camara-oas-version:
+    message: "OpenAPI Version Error: The OpenAPI specification must adhere to version 3.0.3."
+    severity: error
+    description: |
+      This rule validates the OpenAPI version in your specification and requires compliance with version 3.0.3.
+    given: "$"
+    then:
+      field: openapi
+      function: pattern
+      functionOptions:
+        match: 3.0.3
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-path-param-id:
+    message: "Path Parameter Naming Warning: Use 'resource_id' instead of just 'id' in path parameters."
+    severity: warn
+    description: |
+      This rule ensures consistent and descriptive naming for path parameters in your OpenAPI specification.
+      Please use 'resource_id' instead of just 'id' for your path parameters.
+    given: "$.paths[*][*].parameters[?(@.in == 'path')].name"
+    then:
+      field: name
+      function: pattern
+      functionOptions:
+        match: "^(?!.*\\b(id|Id|ID|iD)\\b).*$"
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-security-no-secrets-in-path-or-query-parameters:
+    message: "Sensitive data found in path: {{error}} Consider avoiding the use of sensitive data "
+    severity: warn
+    description: |
+      This rule checks for sensitive data ('MSISDN' and 'IMSI') in API paths and suggests avoiding their use.
+    given:
+      - "$.paths"
+    then:
+      function: camara-security-no-secrets-in-path-or-query-parameters
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-http-methods:
+    description: "Ensure that all path URLs have valid HTTP methods (GET, PUT, POST, DELETE, PATCH, OPTIONS)."
+    message: "Invalid HTTP method for '{{path}}'. Must be one of get, put, post, delete, patch, options."
+    severity: error
+    given: $.paths[*][*]~
+    then:
+      function: pattern
+      functionOptions:
+        match: "^(get|put|post|delete|patch|options|parameters)$"
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-get-no-request-body:
+    message: There must be no request body for Get and DELETE
+    severity: error
+    given:
+      - "$.paths.*.get"
+      - "$.paths.*.delete"
+    then:
+      field: requestBody
+      function: falsy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-reserved-words:
+    message: "Reserved words found {{error}} Consider avoiding the use of reserved word "
+    severity: warn
+    description: |
+      This rule checks Reserved words must not be used in the following parts of an API specification [Paths, Request Body properties, Component, Operation Id, Security Schema]
+    given:
+      - "$.paths"                              # Paths
+      - "$..parameters[*]"                     # Path or Query Parameter Names:
+      - "$..components.schemas.*.properties.*"   # Request and Response body parameter
+      - "$.paths.*."                           # Path and Operation Names:
+      - "$.components.securitySchemes"         # Security Schemes:
+      - "$.components.*.*"                     # Component Names:
+      - "$.paths.*.*.operationId"              # OperationIds:
+    then:
+      function: camara-reserved-words
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-routes-description:
+    message: "Functionality method description Warning: Each method should have description."
+    severity: warn
+    description: |
+            This rule checks if each operation (POST, GET, DELETE, PUT, PATCH, OPTIONS) in your API specification has a description.
+            Ensure that you have added a 'summary' field for each operation in your OpenAPI specification.
+    given:
+      - "$.paths.*.post"
+      - "$.paths.*.get"
+      - "$.paths.*.delete"
+      - "$.paths.*.put"
+      - "$.paths.*.patch"
+      - "$.paths.*.options"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-parameters-descriptions:
+    message: "Parameter description is missing or empty: {{error}}"
+    severity: warn
+    description: |
+      This Spectral rule ensures that each path parameter in the API specification has a descriptive and meaningful description.
+    given:
+      - "$.paths..parameters.*"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-response-descriptions:
+    message: "Parameter description is missing or empty: {{error}}"
+    severity: warn
+    description: |
+      This Spectral rule ensures that each responese object in the API specification has a descriptive and meaningful description.
+    given:
+      - "$.paths..responses.*"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-properties-descriptions:
+    message: "Property description is missing or empty: {{error}}"
+    severity: warn
+    description: |
+      This Spectral rule ensures that each propoerty within objects in the API specification has a descriptive and meaningful description.
+    given:
+      - "$.components.*.*"
+      - "$.components.*.*.properties.*"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-operation-summary:
+    message: "Operation Summary Warning: Each operation should include a short summary for better understanding."
+    severity: warn
+    description: |
+            This rule checks if each operation (POST, GET, DELETE, PUT, PATCH, OPTIONS) in your API specification has a meaningful summary.
+            Ensure that you have added a 'summary' field for each operation in your OpenAPI specification.
+    given:
+      - "$.paths.*.post"
+      - "$.paths.*.get"
+      - "$.paths.*.delete"
+      - "$.paths.*.put"
+      - "$.paths.*.patch"
+      - "$.paths.*.options"
+    then:
+      field: summary
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-discriminator-use:
+    description: |
+      Ensure that API definition YAML files with oneOf or anyOf sections include a discriminator object for serialization, deserialization, and validation.
+    severity: hint
+    given: "$.components.schemas[*]"
+    then:
+      - field: oneOf
+        function: truthy
+        message: "Schemas with 'oneOf' should include a 'discriminator' for type identification."
+      - field: anyOf
+        function: truthy
+        message: "Schemas with 'anyOf' should include a 'discriminator' for type identification."
+      - field: discriminator
+        function: truthy
+        message: "A 'discriminator' object is required when using 'oneOf' or 'anyOf'."
+    recommended: false # Muted — findings were always ignored in r3.4
+
+  camara-operationid-casing-convention:
+    message: Operation Id must be in Camel case "{{error}}"
+    severity: hint
+    description: |
+        This rule checks Operation ids should follow a specific case convention: camel case.
+    given: "$.paths.*.*.operationId"
+    then:
+      function: casing
+      functionOptions:
+        type: camel
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-schema-casing-convention:
+    description: This rule checks schema should follow a specific case convention pascal case.
+    message: "{{property}} should be pascal case (UppperCamelCase)"
+    severity: warn
+    given: $.components.schemas[*]~
+    then:
+      function: casing
+      functionOptions:
+        type: pascal
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-parameter-casing-convention:
+    description: Paths should be kebab-case.
+    severity: error
+    message: "{{property}} is not kebab-case: {{error}}"
+    given: $.paths[*]~
+    then:
+      function: pattern
+      functionOptions:
+        match: "^\/([a-z0-9]+(-[a-z0-9]+)*)?(\/[a-z0-9]+(-[a-z0-9]+)*|\/{.+})*$"  # doesn't allow /asasd{asdas}sadas pattern or not closed braces
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-schema-type-check:
+    message: "Invalid type in schema definition."
+    severity: error
+    given: "$.components.schemas.*"
+    then:
+      field: type
+      function: pattern
+      functionOptions:
+        match: "^(string|number|integer|boolean|array|object)$"
+    recommended: true

--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -1,0 +1,285 @@
+# CAMARA Project - Spectral linting ruleset for Commonalities r4.x (Spring26+)
+# r4.1 baseline (Commonalities 0.7.0-rc.1), evolves with pre-releases per DEC-025.
+# Stabilizes at Commonalities 0.7.0 public release.
+#
+# Based on: https://github.com/camaraproject/Commonalities/blob/main/artifacts/linting_rules/.spectral.yml
+# Changelog:
+# - 31.01.2024: Initial version
+# - 19.03.2024: Corrected camara-http-methods rule
+# - 03.12.2024: Corrected camara-path-param-id and camara-discriminator-use to handle null values error in example fields
+# - 09.01.2025: Updated info-contact rule
+# - 21.07.2025: Added camara-schema-type-check rule
+# - 12.01.2026: camara-discriminator-use deprecated
+
+
+extends: "spectral:oas"
+functions:
+  - camara-reserved-words
+  - camara-language-avoid-telco
+  - camara-security-no-secrets-in-path-or-query-parameters
+functionsDir: "./lint_function"
+rules:
+  #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
+  #  The severity keyword is optional in rule definition and can be error, warn, info, hint, or off. The default value is warn.
+  contact-properties: false
+  duplicated-entry-in-enum: true
+  info-contact: false
+  info-description: true
+  info-license: true
+  license-url: true
+  no-$ref-siblings: error
+  no-eval-in-markdown: true
+  no-script-tags-in-markdown: true
+  openapi-tags: false
+  openapi-tags-alphabetical: false
+  openapi-tags-uniqueness: error
+  operation-description: true
+  operation-operationId: true
+  operation-operationId-unique: error
+  operation-operationId-valid-in-url: true
+  operation-parameters: true
+  operation-singular-tag: true
+  operation-success-response: true
+  operation-tags: true
+  operation-tag-defined: true
+  path-declarations-must-exist: true
+  path-keys-no-trailing-slash: true
+  path-not-include-query: true
+  path-params: error
+  tag-description: false
+  typed-enum: true
+  oas3-api-servers: true
+  oas3-examples-value-or-externalValue: true
+  oas3-operation-security-defined: false
+  oas3-parameter-description: false
+  oas3-schema: true
+  oas3-server-not-example.com: false
+  oas3-server-trailing-slash: true
+  oas3-unused-component: true
+  oas3-valid-media-example: true
+  oas3-valid-schema-example: true
+  # oas3-server-variables: true
+
+  # Custom Rules Utilizing Spectral's Built-in Functions and JavaScript Implementations
+
+  camara-language-avoid-telco:
+    message: "{{error}}"
+    severity: hint
+    description: |
+      This rule checks for telco-specific terminology in your API definitions and suggests more inclusive terms.
+    given: "$..*.*"
+    then:
+      function: camara-language-avoid-telco
+    recommended: false  # Set to true/false to enable/disable this rule
+
+  camara-oas-version:
+    message: "OpenAPI Version Error: The OpenAPI specification must adhere to version 3.0.3."
+    severity: error
+    description: |
+      This rule validates the OpenAPI version in your specification and requires compliance with version 3.0.3.
+    given: "$"
+    then:
+      field: openapi
+      function: pattern
+      functionOptions:
+        match: 3.0.3
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-path-param-id:
+    message: "Path Parameter Naming Warning: Use 'resource_id' instead of just 'id' in path parameters."
+    severity: warn
+    description: |
+      This rule ensures consistent and descriptive naming for path parameters in your OpenAPI specification.
+      Please use 'resource_id' instead of just 'id' for your path parameters.
+    given: "$.paths[*][*].parameters[?(@.in == 'path')].name"
+    then:
+      field: name
+      function: pattern
+      functionOptions:
+        match: "^(?!.*\\b(id|Id|ID|iD)\\b).*$"
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-security-no-secrets-in-path-or-query-parameters:
+    message: "Sensitive data found in path: {{error}} Consider avoiding the use of sensitive data "
+    severity: warn
+    description: |
+      This rule checks for sensitive data ('MSISDN' and 'IMSI') in API paths and suggests avoiding their use.
+    given:
+      - "$.paths"
+    then:
+      function: camara-security-no-secrets-in-path-or-query-parameters
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-http-methods:
+    description: "Ensure that all path URLs have valid HTTP methods (GET, PUT, POST, DELETE, PATCH, OPTIONS)."
+    message: "Invalid HTTP method for '{{path}}'. Must be one of get, put, post, delete, patch, options."
+    severity: error
+    given: $.paths[*][*]~
+    then:
+      function: pattern
+      functionOptions:
+        match: "^(get|put|post|delete|patch|options|parameters)$"
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-get-no-request-body:
+    message: There must be no request body for Get and DELETE
+    severity: error
+    given:
+      - "$.paths.*.get"
+      - "$.paths.*.delete"
+    then:
+      field: requestBody
+      function: falsy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-reserved-words:
+    message: "Reserved words found {{error}} Consider avoiding the use of reserved word "
+    severity: warn
+    description: |
+      This rule checks Reserved words must not be used in the following parts of an API specification [Paths, Request Body properties, Component, Operation Id, Security Schema]
+    given:
+      - "$.paths"                              # Paths
+      - "$..parameters[*]"                     # Path or Query Parameter Names:
+      - "$..components.schemas.*.properties.*"   # Request and Response body parameter
+      - "$.paths.*."                           # Path and Operation Names:
+      - "$.components.securitySchemes"         # Security Schemes:
+      - "$.components.*.*"                     # Component Names:
+      - "$.paths.*.*.operationId"              # OperationIds:
+    then:
+      function: camara-reserved-words
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-routes-description:
+    message: "Functionality method description Warning: Each method should have description."
+    severity: warn
+    description: |
+            This rule checks if each operation (POST, GET, DELETE, PUT, PATCH, OPTIONS) in your API specification has a description.
+            Ensure that you have added a 'summary' field for each operation in your OpenAPI specification.
+    given:
+      - "$.paths.*.post"
+      - "$.paths.*.get"
+      - "$.paths.*.delete"
+      - "$.paths.*.put"
+      - "$.paths.*.patch"
+      - "$.paths.*.options"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-parameters-descriptions:
+    message: "Parameter description is missing or empty: {{error}}"
+    severity: warn
+    description: |
+      This Spectral rule ensures that each path parameter in the API specification has a descriptive and meaningful description.
+    given:
+      - "$.paths..parameters.*"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-response-descriptions:
+    message: "Parameter description is missing or empty: {{error}}"
+    severity: warn
+    description: |
+      This Spectral rule ensures that each responese object in the API specification has a descriptive and meaningful description.
+    given:
+      - "$.paths..responses.*"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-properties-descriptions:
+    message: "Property description is missing or empty: {{error}}"
+    severity: warn
+    description: |
+      This Spectral rule ensures that each propoerty within objects in the API specification has a descriptive and meaningful description.
+    given:
+      - "$.components.*.*"
+      - "$.components.*.*.properties.*"
+    then:
+      field: description
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-operation-summary:
+    message: "Operation Summary Warning: Each operation should include a short summary for better understanding."
+    severity: warn
+    description: |
+            This rule checks if each operation (POST, GET, DELETE, PUT, PATCH, OPTIONS) in your API specification has a meaningful summary.
+            Ensure that you have added a 'summary' field for each operation in your OpenAPI specification.
+    given:
+      - "$.paths.*.post"
+      - "$.paths.*.get"
+      - "$.paths.*.delete"
+      - "$.paths.*.put"
+      - "$.paths.*.patch"
+      - "$.paths.*.options"
+    then:
+      field: summary
+      function: truthy
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-discriminator-use:
+    description: |
+      Ensure that API definition YAML files with oneOf or anyOf sections include a discriminator object for serialization, deserialization, and validation.
+    severity: hint
+    given: "$.components.schemas[*]"
+    then:
+      - field: oneOf
+        function: truthy
+        message: "Schemas with 'oneOf' should include a 'discriminator' for type identification."
+      - field: anyOf
+        function: truthy
+        message: "Schemas with 'anyOf' should include a 'discriminator' for type identification."
+      - field: discriminator
+        function: truthy
+        message: "A 'discriminator' object is required when using 'oneOf' or 'anyOf'."
+    recommended: false # Deprecated in r4.x (12.01.2026)
+
+  camara-operationid-casing-convention:
+    message: Operation Id must be in Camel case "{{error}}"
+    severity: hint
+    description: |
+        This rule checks Operation ids should follow a specific case convention: camel case.
+    given: "$.paths.*.*.operationId"
+    then:
+      function: casing
+      functionOptions:
+        type: camel
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-schema-casing-convention:
+    description: This rule checks schema should follow a specific case convention pascal case.
+    message: "{{property}} should be pascal case (UppperCamelCase)"
+    severity: warn
+    given: $.components.schemas[*]~
+    then:
+      function: casing
+      functionOptions:
+        type: pascal
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-parameter-casing-convention:
+    description: Paths should be kebab-case.
+    severity: error
+    message: "{{property}} is not kebab-case: {{error}}"
+    given: $.paths[*]~
+    then:
+      function: pattern
+      functionOptions:
+        match: "^\/([a-z0-9]+(-[a-z0-9]+)*)?(\/[a-z0-9]+(-[a-z0-9]+)*|\/{.+})*$"  # doesn't allow /asasd{asdas}sadas pattern or not closed braces
+    recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-schema-type-check:
+    message: "Invalid type in schema definition."
+    severity: error
+    given: "$.components.schemas.*"
+    then:
+      field: type
+      function: pattern
+      functionOptions:
+        match: "^(string|number|integer|boolean|array|object)$"
+    recommended: true

--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -47,7 +47,13 @@ _VERSION_RULESET_MAP: dict[str, str] = {
     "r4": ".spectral-r4.yaml",
 }
 
-# Latest version line used when commonalities_release is absent.
+# When commonalities_release is absent (no release-plan.yaml), default to the
+# oldest supported version line — conservative choice for repos that haven't
+# declared a Commonalities dependency yet.
+_DEFAULT_VERSION_LINE = "r3"
+
+# When commonalities_release is present but unrecognised (likely a newer version
+# than what we support), default to the latest available version line.
 _LATEST_VERSION_LINE = "r4"
 
 # Sentinel rule name for adapter-level errors.
@@ -103,9 +109,13 @@ def select_ruleset_path(
     Resolution order:
     1. Map *commonalities_release* prefix to a version-specific filename
        (e.g. ``r4.1`` -> ``.spectral-r4.yaml``).
-    2. If *commonalities_release* is absent or unrecognised, default to the
-       latest version line (currently r4).
-    3. If the version-specific file does not exist on disk, fall back to
+    2. If *commonalities_release* is ``None`` (no release-plan.yaml),
+       default to the oldest supported version line (currently r3 —
+       conservative choice for repos without a Commonalities dependency).
+    3. If *commonalities_release* is present but unrecognised (likely
+       newer than supported), default to the latest version line
+       (currently r4).
+    4. If the version-specific file does not exist on disk, fall back to
        ``.spectral.yaml``.
 
     Args:
@@ -117,8 +127,12 @@ def select_ruleset_path(
         Absolute path to the selected ruleset file.
     """
     # Determine target version line.
-    version_line = _LATEST_VERSION_LINE
-    if commonalities_release:
+    if commonalities_release is None:
+        # No release-plan.yaml or no commonalities dependency declared.
+        version_line = _DEFAULT_VERSION_LINE
+    else:
+        # Start with latest; override if a known prefix matches.
+        version_line = _LATEST_VERSION_LINE
         for prefix in _VERSION_RULESET_MAP:
             if commonalities_release.startswith(prefix):
                 version_line = prefix

--- a/validation/output/annotations.py
+++ b/validation/output/annotations.py
@@ -15,7 +15,7 @@ from typing import List
 
 from validation.postfilter.engine import PostFilterResult
 
-from .formatting import format_rule_label, sort_findings_by_priority
+from .formatting import deduplicate_findings, format_rule_label, sort_findings_by_priority
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +120,8 @@ def generate_annotations(
     Returns:
         :class:`AnnotationResult` with workflow command strings.
     """
-    sorted_findings = sort_findings_by_priority(post_filter_result.findings)
+    deduped = deduplicate_findings(post_filter_result.findings)
+    sorted_findings = sort_findings_by_priority(deduped)
     total = len(sorted_findings)
 
     selected = sorted_findings[:ANNOTATION_LIMIT]

--- a/validation/output/check_run.py
+++ b/validation/output/check_run.py
@@ -21,7 +21,12 @@ from typing import List
 from validation.context import ValidationContext
 from validation.postfilter.engine import PostFilterResult
 
-from .formatting import count_findings, format_rule_label, sort_findings_by_priority
+from .formatting import (
+    count_findings,
+    deduplicate_findings,
+    format_rule_label,
+    sort_findings_by_priority,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +165,8 @@ def generate_check_run_payload(
         f"Trigger: {context.trigger_type}"
     )
 
-    sorted_findings = sort_findings_by_priority(findings)
+    deduped = deduplicate_findings(findings)
+    sorted_findings = sort_findings_by_priority(deduped)
     annotations = [_build_annotation(f) for f in sorted_findings]
 
     logger.info(

--- a/validation/output/formatting.py
+++ b/validation/output/formatting.py
@@ -103,6 +103,76 @@ def count_findings_by_engine(
 
 
 # ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+# Cap on the number of messages to concatenate when merging duplicates.
+_MAX_MERGED_MESSAGES = 3
+
+
+def deduplicate_findings(findings: List[dict]) -> List[dict]:
+    """Merge findings that share the same ``(path, line, engine_rule)`` key.
+
+    Spectral's ``oas3-schema`` (and similar meta-rules) can fire multiple
+    times on the same source line with different messages.  Merging them
+    reduces annotation noise without losing information.
+
+    For each group of duplicates:
+    - The highest severity (error > warn > hint) is kept.
+    - Distinct messages are concatenated with ``" | "``, capped at
+      :data:`_MAX_MERGED_MESSAGES` (extras noted as ``"... and N more"``).
+    - All other fields come from the first finding in the group.
+
+    Order of first occurrence is preserved.
+    """
+    groups: dict[tuple, List[dict]] = {}
+    order: list[tuple] = []
+
+    for f in findings:
+        key = (f.get("path", ""), f.get("line", 0), f.get("engine_rule", ""))
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(f)
+
+    result: List[dict] = []
+    for key in order:
+        group = groups[key]
+        if len(group) == 1:
+            result.append(group[0])
+            continue
+
+        merged = dict(group[0])
+
+        # Highest severity wins.
+        best_priority = min(
+            _LEVEL_PRIORITY.get(f.get("level", ""), 99) for f in group
+        )
+        for level_name, priority in _LEVEL_PRIORITY.items():
+            if priority == best_priority:
+                merged["level"] = level_name
+                break
+
+        # Concatenate distinct messages.
+        seen_messages: list[str] = []
+        for f in group:
+            msg = f.get("message", "")
+            if msg and msg not in seen_messages:
+                seen_messages.append(msg)
+
+        if len(seen_messages) <= _MAX_MERGED_MESSAGES:
+            merged["message"] = " | ".join(seen_messages)
+        else:
+            shown = " | ".join(seen_messages[:_MAX_MERGED_MESSAGES])
+            extra = len(seen_messages) - _MAX_MERGED_MESSAGES
+            merged["message"] = f"{shown} | ... and {extra} more"
+
+        result.append(merged)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Sorting
 # ---------------------------------------------------------------------------
 

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -94,12 +94,12 @@
   conditional_level:
     default: warn
 
-# P-011: check-license-commonalities-consistency
+# P-011: check-license-commonalities-consistency (muted — likely to be retired)
 - id: P-011
   engine: python
   engine_rule: check-license-commonalities-consistency
   conditional_level:
-    default: warn
+    default: muted
 
 # P-012: check-release-review-file-restriction
 - id: P-012

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,6 +18,7 @@ summary:
   total_gap: 21
   total_manual: 25
   total_pending: 17
+  total_tested: 0
   by_engine:
     spectral: 46
     gherkin: 25
@@ -184,6 +185,18 @@ pending_rules:
 # Manual rules — require human judgment
 # ---------------------------------------------------------------------------
 # Source: private-dev-docs/validation-framework/reviews/testing-guidelines-audit.md
+
+# ---------------------------------------------------------------------------
+# Tested rules — verified via regression branches (Phase 1b)
+# ---------------------------------------------------------------------------
+# Updated as regression branches verify rules.
+# Format: rule_id: regression_branch (or list of branches)
+
+tested_rules: {}
+
+# ---------------------------------------------------------------------------
+# Manual rules — require human judgment
+# ---------------------------------------------------------------------------
 
 manual_rules:
   count: 25

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -15,7 +15,7 @@ generated: 2026-03-26
 
 summary:
   total_implemented: 96
-  total_gap: 21
+  total_gap: 22
   total_manual: 25
   total_pending: 17
   total_tested: 0
@@ -151,6 +151,12 @@ gap_rules:
     description: README.md placeholder must be removed from API_definitions/ when spec files are present
     target_engine: python
     priority: medium
+
+  - audit_id: NEW-002
+    description: "apiRoot variable: default and description MUST match Design Guide values"
+    target_engine: spectral
+    priority: low
+    notes: "Hint level. Standard values: default 'http://localhost:9091', description 'API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`'"
 
 # ---------------------------------------------------------------------------
 # Fixes needed — implemented rules with incorrect behavior

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -15,7 +15,7 @@ generated: 2026-03-26
 
 summary:
   total_implemented: 96
-  total_gap: 22
+  total_gap: 25
   total_manual: 25
   total_pending: 17
   total_tested: 0
@@ -64,6 +64,28 @@ gap_rules:
     target_engine: spectral
     priority: medium
     notes: commonalities_release >=r4.0
+
+  - audit_id: DG-026
+    description: "info.license.name MUST be 'Apache 2.0'"
+    target_engine: spectral
+    priority: medium
+    notes: Static value check, previously v0_6 only (V6-005)
+
+  - audit_id: DG-027
+    description: info.license.url MUST be Apache License URL
+    target_engine: spectral
+    priority: medium
+    notes: Value check (not just presence). Spectral license-url only checks existence. Previously v0_6 (V6-006)
+
+  - audit_id: DG-028
+    description: x-camara-commonalities MUST specify valid version
+    target_engine: python
+    priority: medium
+    notes: >
+      Rewrite P-011. Presence check + value validation. On main: wip, tbd,
+      X.Y (e.g. 0.7), or X.Y.Z (e.g. 0.7.0) allowed — if X.Y/X.Y.Z then
+      must match declared commonalities_release. On release: real version
+      required, must match commonalities_release. Previously v0_6 (V6-007)
 
   - audit_id: DG-015
     description: "API-specific error: API_NAME.SPECIFIC_CODE format"

--- a/validation/tests/test_output_annotations.py
+++ b/validation/tests/test_output_annotations.py
@@ -162,9 +162,9 @@ class TestGenerateAnnotations:
 
     def test_priority_ordering(self):
         findings = [
-            _make_finding(level="hint", path="a.yaml", line=1),
-            _make_finding(level="error", path="a.yaml", line=1),
-            _make_finding(level="warn", path="a.yaml", line=1),
+            _make_finding(level="hint", path="a.yaml", line=1, engine_rule="rule-a"),
+            _make_finding(level="error", path="a.yaml", line=1, engine_rule="rule-b"),
+            _make_finding(level="warn", path="a.yaml", line=1, engine_rule="rule-c"),
         ]
         result = generate_annotations(_make_result(findings))
         assert result.commands[0].startswith("::error ")
@@ -181,8 +181,8 @@ class TestGenerateAnnotations:
         assert result.truncated
 
     def test_limit_prioritises_errors(self):
-        errors = [_make_finding(level="error", line=i) for i in range(30)]
-        warnings = [_make_finding(level="warn", line=i) for i in range(30)]
+        errors = [_make_finding(level="error", line=i, engine_rule="err-rule") for i in range(30)]
+        warnings = [_make_finding(level="warn", line=i, engine_rule="warn-rule") for i in range(30)]
         findings = warnings + errors  # Interleave — warnings first in input
         result = generate_annotations(_make_result(findings))
         # All 30 errors should be in the first 30 commands

--- a/validation/tests/test_output_formatting.py
+++ b/validation/tests/test_output_formatting.py
@@ -7,6 +7,7 @@ from validation.output.formatting import (
     FindingCounts,
     count_findings,
     count_findings_by_api,
+    deduplicate_findings,
     format_finding_location,
     format_rule_label,
     sort_findings_by_priority,
@@ -43,6 +44,115 @@ def _make_finding(
     if column is not None:
         f["column"] = column
     return f
+
+
+# ---------------------------------------------------------------------------
+# deduplicate_findings
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplicateFindings:
+    def test_no_duplicates_passthrough(self):
+        """Non-duplicate findings pass through unchanged."""
+        findings = [
+            _make_finding(path="a.yaml", line=10, engine_rule="rule-a"),
+            _make_finding(path="a.yaml", line=20, engine_rule="rule-a"),
+            _make_finding(path="a.yaml", line=10, engine_rule="rule-b"),
+        ]
+        result = deduplicate_findings(findings)
+        assert len(result) == 3
+
+    def test_same_rule_same_line_merged(self):
+        """Findings with same (path, line, engine_rule) are merged."""
+        f1 = _make_finding(path="a.yaml", line=10, engine_rule="oas3-schema")
+        f1["message"] = "type is not valid"
+        f2 = _make_finding(path="a.yaml", line=10, engine_rule="oas3-schema")
+        f2["message"] = "format is not valid"
+
+        result = deduplicate_findings([f1, f2])
+        assert len(result) == 1
+        assert "type is not valid" in result[0]["message"]
+        assert "format is not valid" in result[0]["message"]
+        assert " | " in result[0]["message"]
+
+    def test_different_lines_not_merged(self):
+        """Same rule on different lines stays separate."""
+        f1 = _make_finding(path="a.yaml", line=10, engine_rule="oas3-schema")
+        f1["message"] = "msg1"
+        f2 = _make_finding(path="a.yaml", line=20, engine_rule="oas3-schema")
+        f2["message"] = "msg2"
+
+        result = deduplicate_findings([f1, f2])
+        assert len(result) == 2
+
+    def test_different_rules_not_merged(self):
+        """Different rules on same line stay separate."""
+        f1 = _make_finding(path="a.yaml", line=10, engine_rule="rule-a")
+        f2 = _make_finding(path="a.yaml", line=10, engine_rule="rule-b")
+
+        result = deduplicate_findings([f1, f2])
+        assert len(result) == 2
+
+    def test_severity_promotion(self):
+        """Merged group gets the highest severity."""
+        f1 = _make_finding(
+            path="a.yaml", line=10, engine_rule="oas3-schema", level="hint",
+        )
+        f1["message"] = "msg1"
+        f2 = _make_finding(
+            path="a.yaml", line=10, engine_rule="oas3-schema", level="error",
+        )
+        f2["message"] = "msg2"
+
+        result = deduplicate_findings([f1, f2])
+        assert len(result) == 1
+        assert result[0]["level"] == "error"
+
+    def test_duplicate_messages_not_repeated(self):
+        """Identical messages within a group appear only once."""
+        f1 = _make_finding(path="a.yaml", line=10, engine_rule="oas3-schema")
+        f1["message"] = "same message"
+        f2 = _make_finding(path="a.yaml", line=10, engine_rule="oas3-schema")
+        f2["message"] = "same message"
+
+        result = deduplicate_findings([f1, f2])
+        assert len(result) == 1
+        assert result[0]["message"] == "same message"
+
+    def test_message_cap_at_three(self):
+        """More than 3 distinct messages are truncated."""
+        findings = []
+        for i in range(5):
+            f = _make_finding(path="a.yaml", line=10, engine_rule="oas3-schema")
+            f["message"] = f"msg{i}"
+            findings.append(f)
+
+        result = deduplicate_findings(findings)
+        assert len(result) == 1
+        assert "... and 2 more" in result[0]["message"]
+        assert "msg0" in result[0]["message"]
+        assert "msg1" in result[0]["message"]
+        assert "msg2" in result[0]["message"]
+
+    def test_empty_list(self):
+        assert deduplicate_findings([]) == []
+
+    def test_single_finding(self):
+        f = _make_finding()
+        result = deduplicate_findings([f])
+        assert result == [f]
+
+    def test_order_preserved(self):
+        """First occurrence order is preserved."""
+        f1 = _make_finding(path="b.yaml", line=5, engine_rule="rule-x")
+        f2 = _make_finding(path="a.yaml", line=1, engine_rule="rule-y")
+        f3 = _make_finding(path="b.yaml", line=5, engine_rule="rule-x")
+        f3["message"] = "extra msg"
+
+        result = deduplicate_findings([f1, f2, f3])
+        assert len(result) == 2
+        assert result[0]["path"] == "b.yaml"  # first occurrence
+        assert result[1]["path"] == "a.yaml"
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -29,6 +29,8 @@ _RULES_DIR = _REPO_ROOT / "validation" / "rules"
 _LINTING_DIR = _REPO_ROOT / "linting" / "config"
 
 _SPECTRAL_CONFIG = _LINTING_DIR / ".spectral.yaml"
+_SPECTRAL_R34_CONFIG = _LINTING_DIR / ".spectral-r3.4.yaml"
+_SPECTRAL_R4_CONFIG = _LINTING_DIR / ".spectral-r4.yaml"
 _GHERKIN_CONFIG = _LINTING_DIR / ".gherkin-lintrc"
 _YAMLLINT_CONFIG = _LINTING_DIR / ".yamllint.yaml"
 
@@ -153,11 +155,12 @@ class TestStructuralIntegrity:
 class TestEngineCoverage:
     """Verify rule metadata covers all enabled engine rules."""
 
-    def _get_spectral_enabled_rules(self) -> set[str]:
-        """Extract enabled rules from .spectral.yaml."""
-        if not _SPECTRAL_CONFIG.is_file():
-            pytest.skip("Spectral config not found")
-        data = yaml.safe_load(_SPECTRAL_CONFIG.read_text(encoding="utf-8"))
+    @staticmethod
+    def _get_spectral_enabled_rules_from(config_path: Path) -> set[str]:
+        """Extract enabled rules from a Spectral config file."""
+        if not config_path.is_file():
+            pytest.skip(f"Spectral config not found: {config_path.name}")
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         rules = data.get("rules", {})
         enabled = set()
         for name, value in rules.items():
@@ -170,6 +173,10 @@ class TestEngineCoverage:
                 pass
             enabled.add(name)
         return enabled
+
+    def _get_spectral_enabled_rules(self) -> set[str]:
+        """Extract enabled rules from the fallback .spectral.yaml."""
+        return self._get_spectral_enabled_rules_from(_SPECTRAL_CONFIG)
 
     def _get_gherkin_enabled_rules(self) -> set[str]:
         """Extract enabled rules from .gherkin-lintrc."""
@@ -219,12 +226,30 @@ class TestEngineCoverage:
         return {c.name for c in CHECKS}
 
     def test_spectral_coverage(self, rule_index):
-        """Every enabled Spectral rule has a metadata entry."""
+        """Every enabled Spectral rule in the fallback ruleset has metadata."""
         enabled = self._get_spectral_enabled_rules()
         indexed = {er for (eng, er) in rule_index if eng == "spectral"}
         missing = enabled - indexed
         assert not missing, (
             f"Spectral rules without metadata: {sorted(missing)}"
+        )
+
+    def test_spectral_r34_coverage(self, rule_index):
+        """Every enabled Spectral rule in .spectral-r3.4.yaml has metadata."""
+        enabled = self._get_spectral_enabled_rules_from(_SPECTRAL_R34_CONFIG)
+        indexed = {er for (eng, er) in rule_index if eng == "spectral"}
+        missing = enabled - indexed
+        assert not missing, (
+            f"Spectral r3.4 rules without metadata: {sorted(missing)}"
+        )
+
+    def test_spectral_r4_coverage(self, rule_index):
+        """Every enabled Spectral rule in .spectral-r4.yaml has metadata."""
+        enabled = self._get_spectral_enabled_rules_from(_SPECTRAL_R4_CONFIG)
+        indexed = {er for (eng, er) in rule_index if eng == "spectral"}
+        missing = enabled - indexed
+        assert not missing, (
+            f"Spectral r4.x rules without metadata: {sorted(missing)}"
         )
 
     def test_gherkin_coverage(self, rule_index):

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -178,12 +178,14 @@ class TestSelectRulesetPath:
         result = select_ruleset_path("r3.4", tmp_path)
         assert result.name == ".spectral-r3.4.yaml"
 
-    def test_none_defaults_to_latest(self, tmp_path):
-        (tmp_path / ".spectral-r4.yaml").touch()
+    def test_none_defaults_to_oldest(self, tmp_path):
+        """No release-plan.yaml → conservative default (r3.4)."""
+        (tmp_path / ".spectral-r3.4.yaml").touch()
         result = select_ruleset_path(None, tmp_path)
-        assert result.name == ".spectral-r4.yaml"
+        assert result.name == ".spectral-r3.4.yaml"
 
     def test_unrecognised_version_defaults_to_latest(self, tmp_path):
+        """Unknown version (likely newer) → latest available (r4)."""
         (tmp_path / ".spectral-r4.yaml").touch()
         result = select_ruleset_path("r99.0", tmp_path)
         assert result.name == ".spectral-r4.yaml"


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

- Create `.spectral-r3.4.yaml` (frozen Fall25 ruleset) and `.spectral-r4.yaml` (r4.1 baseline)
- Fix ruleset fallback logic: repos without `release-plan.yaml` default to r3.4 (conservative); unrecognised versions default to latest (r4)
- Add finding deduplication: findings with same `(path, line, engine_rule)` are merged (highest severity, concatenated messages), reducing annotation noise from `oas3-schema`
- Add `tested_rules` tracking to `rule-inventory.yaml` for regression coverage
- Add metadata coverage tests for both version-specific rulesets

663 tests passed, 0 failed.

#### Which issue(s) this PR fixes:

Part of [ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448)

#### Special notes for reviewers:

Both rulesets start identical (discriminator muted in both). They diverge as gap rules and OWASP rules are added to the r4.x ruleset.

#### Changelog input

```
feat(validation): add version-specific Spectral rulesets (.spectral-r3.4.yaml, .spectral-r4.yaml) and annotation deduplication
```

#### Additional documentation

```
docs
```