### PR TITLE
fix(validation): skip bundling for specs without external $ref

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -378,6 +378,12 @@ jobs:
           for spec in code/API_definitions/*.yaml; do
             [ -f "$spec" ] || continue
             name=$(basename "$spec")
+            # Skip specs with no external $ref — bundling would only
+            # normalize formatting, producing a misleading diff artifact.
+            if ! grep -qE '\$ref:\s*["'"'"'][^#]' "$spec"; then
+              echo "Skipped (no external \$ref): $name"
+              continue
+            fi
             if err=$(redocly bundle "$spec" -o "validation-output/bundled/$name" 2>&1); then
               if ! diff -q "$spec" "validation-output/bundled/$name" > /dev/null 2>&1; then
                 BUNDLED=$((BUNDLED + 1))


### PR DESCRIPTION
#### What type of PR is this?

* bug fix

#### What this PR does / why we need it:

The bundling workflow step runs `redocly bundle` on every YAML in `code/API_definitions/`, then uses `diff` to detect if bundling changed anything. However, Redocly normalizes formatting (quote styles, field ordering, character encoding) even for specs with no external `$ref`, producing a misleading diff artifact.

For example, `release-test.yaml` (all internal `#/components/...` refs) gets bundled with em-dash encoding changes and reordered fields — appearing in the artifact as if bundling changed it.

**Fix:** Check for external `$ref` (any `$ref` not starting with `#`) before invoking `redocly bundle`. Specs without external refs are skipped with a log message.

The release automation `snapshot_creator._bundle_specs()` already has this guard (regex check for `$ref` with `..` paths). This aligns the validation workflow to the same pattern.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No