### PR TITLE
feat(validation): integrate OWASP API Security Top 10 2023 rules

### DIFF
--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -12,7 +12,12 @@
 # - 12.01.2026: camara-discriminator-use deprecated
 
 
-extends: "spectral:oas"
+# Note: @stoplight/spectral-owasp-ruleset is installed via validation/package.json.
+# Spectral resolves this package via NODE_PATH (set in shared-actions/run-validation/action.yml)
+# because the ruleset file lives in linting/config/ while node_modules is in validation/.
+extends:
+  - "spectral:oas"
+  - "@stoplight/spectral-owasp-ruleset"
 functions:
   - camara-reserved-words
   - camara-language-avoid-telco
@@ -283,3 +288,56 @@ rules:
       functionOptions:
         match: "^(string|number|integer|boolean|array|object)$"
     recommended: true
+
+  # ===== OWASP API Security Top 10 2023 =====
+  # Source: Commonalities Linting-rules.md section 5
+  # Severity overrides per CAMARA agreement (Commonalities #539, #548, #551, #552)
+  # Target severity escalation for API4 resource consumption rules: warn → error in 2027
+
+  # --- API1: Broken Object Level Authorization ---
+  owasp:api1:2023-no-numeric-ids: error
+
+  # --- API2: Broken Authentication ---
+  owasp:api2:2023-auth-insecure-schemes: off      # OpenID used exclusively
+  owasp:api2:2023-jwt-best-practices: off          # OpenID handles JWT
+  owasp:api2:2023-no-api-keys-in-url: off          # No API keys — OpenID used
+  owasp:api2:2023-no-credentials-in-url: error
+  owasp:api2:2023-no-http-basic: off               # No HTTP basic — OpenID used
+  owasp:api2:2023-short-lived-access-tokens: error
+  owasp:api2:2023-write-restricted: error
+  owasp:api2:2023-read-restricted: warn
+
+  # --- API3: Broken Object Property Level Authorization ---
+  owasp:api3:2023-constrained-additionalProperties: warn   # OAS 3.0 only
+  owasp:api3:2023-constrained-unevaluatedProperties: warn  # OAS 3.1 only (no-op for 3.0.3)
+  owasp:api3:2023-no-additionalProperties: warn            # OAS 3.0 only
+  owasp:api3:2023-no-unevaluatedProperties: warn           # OAS 3.1 only (no-op for 3.0.3)
+
+  # --- API4: Unrestricted Resource Consumption ---
+  owasp:api4:2023-array-limit: warn                 # → error in 2027
+  owasp:api4:2023-integer-format: warn              # → error in 2027
+  owasp:api4:2023-integer-limit: off                # OAS 3.1 only; legacy covers 3.0
+  owasp:api4:2023-integer-limit-legacy: warn        # → error in 2027
+  owasp:api4:2023-rate-limit: off                   # Gateway-level
+  owasp:api4:2023-rate-limit-retry-after: off       # Gateway-level
+  owasp:api4:2023-rate-limit-responses-429: off     # Gateway-level
+  owasp:api4:2023-string-limit: warn                # → error in 2027
+  owasp:api4:2023-string-restricted: warn
+
+  # --- API5: Broken Function Level Authorization ---
+  owasp:api5:2023-admin-security-unique: error
+
+  # --- API7: Server Side Request Forgery ---
+  owasp:api7:2023-concerning-url-parameter: info
+
+  # --- API8: Security Misconfiguration ---
+  owasp:api8:2023-define-cors-origin: off           # Gateway/implementation-level
+  owasp:api8:2023-define-error-responses-401: error  # Elevated from upstream warn
+  owasp:api8:2023-define-error-responses-500: off    # Not recommended in CAMARA
+  owasp:api8:2023-define-error-validation: warn
+  owasp:api8:2023-no-scheme-http: error              # OAS 2 only (no-op for 3.0.3)
+  owasp:api8:2023-no-server-http: error
+
+  # --- API9: Improper Inventory Management ---
+  owasp:api9:2023-inventory-access: off             # x-internal not used
+  owasp:api9:2023-inventory-environment: off        # Environment terms not used

--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -65,6 +65,11 @@ runs:
       env:
         PYTHONPATH: ${{ inputs.tooling_path }}
         PATH_NODE_MODULES: ${{ inputs.tooling_path }}/validation/node_modules/.bin
+        # NODE_PATH: Spectral rulesets live in linting/config/ but npm packages
+        # (including @stoplight/spectral-owasp-ruleset) are installed in
+        # validation/node_modules/. NODE_PATH bridges this gap for Node's
+        # module resolution.
+        NODE_PATH: ${{ inputs.tooling_path }}/validation/node_modules
         VALIDATION_REPO_PATH: ${{ inputs.repo_path }}
         VALIDATION_TOOLING_PATH: ${{ inputs.tooling_path }}
         VALIDATION_OUTPUT_DIR: ${{ inputs.repo_path }}/validation-output

--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@redocly/cli": "^1.31.0",
         "@stoplight/spectral-cli": "^6.14.0",
+        "@stoplight/spectral-owasp-ruleset": "^2.0.0",
         "gherkin-lint": "^4.2.4"
       }
     },
@@ -994,6 +995,16 @@
       },
       "engines": {
         "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-owasp-ruleset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-owasp-ruleset/-/spectral-owasp-ruleset-2.0.1.tgz",
+      "integrity": "sha512-9S6Z3lMwIh5oe5X5xS867iQm8xYMgCwY08FiR4At6Ivu78lQ7okFS7+I9RUs01Zawd0PtageQeZ83Ety/vlJQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stoplight/spectral-formats": "^1.6.0",
+        "@stoplight/spectral-functions": "^1.7.2"
       }
     },
     "node_modules/@stoplight/spectral-parsers": {

--- a/validation/package.json
+++ b/validation/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@redocly/cli": "^1.31.0",
     "@stoplight/spectral-cli": "^6.14.0",
+    "@stoplight/spectral-owasp-ruleset": "^2.0.0",
     "gherkin-lint": "^4.2.4"
   }
 }

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -180,6 +180,12 @@ gap_rules:
     priority: low
     notes: "Hint level. Standard values: default 'http://localhost:9091', description 'API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`'"
 
+  - audit_id: NEW-003
+    description: "Orphan API definitions: YAML files in code/API_definitions/ not listed in release-plan.yaml"
+    target_engine: python
+    priority: low
+    notes: "Compare filenames against release-plan.yaml APIs. Also detect missing files (declared but absent)."
+
 # ---------------------------------------------------------------------------
 # Fixes needed — implemented rules with incorrect behavior
 # ---------------------------------------------------------------------------

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -14,13 +14,13 @@ version: 1
 generated: 2026-03-26
 
 summary:
-  total_implemented: 96
+  total_implemented: 116
   total_gap: 25
   total_manual: 25
-  total_pending: 17
+  total_pending: 0
   total_tested: 0
   by_engine:
-    spectral: 46
+    spectral: 66
     gherkin: 25
     python: 12
     yamllint: 13
@@ -209,11 +209,7 @@ fixes:
 # Source: tooling#95 (OWASP Spectral rules)
 
 pending_rules:
-  - source: tooling#95
-    description: OWASP API security rules (17 rules)
-    target_engine: spectral
-    notes: Parked. Introduce with v1 + bundling.
-    estimated_count: 17
+  # OWASP rules (tooling#95) implemented in WS07 Phase 1b — see spectral-rules.yaml S-300..S-319
 
 # ---------------------------------------------------------------------------
 # Manual rules — require human judgment

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -191,3 +191,92 @@
 - id: S-228
   engine: spectral
   engine_rule: typed-enum
+
+# ===== OWASP API Security Top 10 2023 (S-300+) =====
+
+- id: S-300
+  engine: spectral
+  engine_rule: "owasp:api1:2023-no-numeric-ids"
+  hint: "Use non-numeric (e.g. string) resource identifiers to prevent enumeration attacks."
+
+- id: S-301
+  engine: spectral
+  engine_rule: "owasp:api2:2023-no-credentials-in-url"
+
+- id: S-302
+  engine: spectral
+  engine_rule: "owasp:api2:2023-short-lived-access-tokens"
+
+- id: S-303
+  engine: spectral
+  engine_rule: "owasp:api2:2023-write-restricted"
+
+- id: S-304
+  engine: spectral
+  engine_rule: "owasp:api5:2023-admin-security-unique"
+
+- id: S-305
+  engine: spectral
+  engine_rule: "owasp:api8:2023-no-scheme-http"
+
+- id: S-306
+  engine: spectral
+  engine_rule: "owasp:api8:2023-no-server-http"
+
+- id: S-307
+  engine: spectral
+  engine_rule: "owasp:api8:2023-define-error-responses-401"
+  hint: "All secured operations must document a 401 Unauthorized response (CAMARA Design Guide section 3.2)."
+
+- id: S-308
+  engine: spectral
+  engine_rule: "owasp:api2:2023-read-restricted"
+
+- id: S-309
+  engine: spectral
+  engine_rule: "owasp:api4:2023-array-limit"
+  hint: "Add maxItems to constrain array size (CAMARA Design Guide section 2.2)."
+
+- id: S-310
+  engine: spectral
+  engine_rule: "owasp:api4:2023-integer-format"
+  hint: "Add format: int32 or int64 to integer properties (CAMARA Design Guide section 2.2)."
+
+- id: S-311
+  engine: spectral
+  engine_rule: "owasp:api4:2023-integer-limit-legacy"
+  hint: "Add minimum and maximum to integer properties (CAMARA Design Guide section 2.2)."
+
+- id: S-312
+  engine: spectral
+  engine_rule: "owasp:api4:2023-string-limit"
+  hint: "Add maxLength, enum, or const to string properties (CAMARA Design Guide section 2.2)."
+
+- id: S-313
+  engine: spectral
+  engine_rule: "owasp:api4:2023-string-restricted"
+
+- id: S-314
+  engine: spectral
+  engine_rule: "owasp:api3:2023-constrained-additionalProperties"
+
+- id: S-315
+  engine: spectral
+  engine_rule: "owasp:api3:2023-constrained-unevaluatedProperties"
+
+- id: S-316
+  engine: spectral
+  engine_rule: "owasp:api3:2023-no-additionalProperties"
+
+- id: S-317
+  engine: spectral
+  engine_rule: "owasp:api3:2023-no-unevaluatedProperties"
+
+- id: S-318
+  engine: spectral
+  engine_rule: "owasp:api8:2023-define-error-validation"
+  hint: "Document 400 or 422 error responses for input validation (CAMARA Design Guide section 3.2)."
+
+- id: S-319
+  engine: spectral
+  engine_rule: "owasp:api7:2023-concerning-url-parameter"

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -78,7 +78,7 @@ class TestStructuralIntegrity:
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
         assert counts["python"] == 13
-        assert counts["spectral"] == 46
+        assert counts["spectral"] == 66
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
 
@@ -306,8 +306,8 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 0, (
-            f"Expected 0 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 7, (
+            f"Expected 7 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Integrates the agreed OWASP API Security Top 10 2023 Spectral rules into the v1 validation framework, scoped to the r4.x ruleset (`.spectral-r4.yaml`) only.

- Adds `@stoplight/spectral-owasp-ruleset` npm dependency
- Enables 20 OWASP rules with CAMARA-agreed severity levels
- Disables 12 rules not applicable to CAMARA (OpenID-only auth, gateway-level, OAS 3.1-only)
- Creates rule metadata entries S-300..S-319 with hints for high-volume rules
- Adds `NODE_PATH` bridge for npm module resolution (documented inline)

**Rule configuration follows Commonalities [Linting-rules.md section 5](https://github.com/camaraproject/Commonalities/blob/main/documentation/Linting-rules.md#5-owasp-api-security-top-10-2023-rules) exactly:**
- 8 rules at error (authentication, HTTPS, 401 response, numeric IDs)
- 11 rules at warn (resource consumption, mass assignment)
- 1 rule at info (SSRF parameter review)
- Resource consumption rules (string-limit, array-limit, integer-format, integer-limit-legacy) at warn for 2026, with planned escalation to error in 2027 per Commonalities #551

#### Which issue(s) this PR fixes:

Supersedes #95 (OWASP rules — parked, v0 approach)
Related: [ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448) (validation framework umbrella)

#### Special notes for reviewers:

- OWASP rules go into `.spectral-r4.yaml` only — `.spectral-r3.4.yaml` is unchanged (frozen Fall25 ruleset)
- 5 enabled rules are no-ops for CAMARA OAS 3.0.3 but included for completeness and forward-compatibility (OAS 3.1 rules, oauth2-only rules, admin-path rules)
- Smoke tested on QualityOnDemand and ReleaseTest specs — only warn-level resource consumption findings, no false positives from security rules

#### Changelog input

```
feat: integrate OWASP API Security Top 10 2023 rules into v1 validation (20 rules enabled, 12 disabled)
```

#### Additional documentation

Commonalities discussions: #539, #548, #551, #552, #596
Design Guide alignment: sections 2.2 (data definitions), 3.2 (error responses), 6.1-6.3 (security)

```
docs

```