### PR TITLE
fix(validation): spectral r4.x ruleset stabilization fixes

### DIFF
--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -24,6 +24,7 @@ functions:
   - camara-language-avoid-telco
   - camara-security-no-secrets-in-path-or-query-parameters
   - camara-schema-casing-convention
+  - camara-schema-type-check
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -282,14 +283,15 @@ rules:
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-schema-type-check:
-    message: "Invalid type in schema definition."
+    description: >
+      Every schema node must declare a valid type (string, number, integer,
+      boolean, array, object) or use a combiner (allOf, anyOf, oneOf).
+      Recursively checks properties, items, and additionalProperties.
+    message: "{{error}}"
     severity: error
     given: "$.components.schemas.*"
     then:
-      field: type
-      function: pattern
-      functionOptions:
-        match: "^(string|number|integer|boolean|array|object)$"
+      function: camara-schema-type-check
     recommended: true
 
   # ===== OWASP API Security Top 10 2023 =====

--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -10,6 +10,7 @@
 # - 09.01.2025: Updated info-contact rule
 # - 21.07.2025: Added camara-schema-type-check rule
 # - 12.01.2026: camara-discriminator-use deprecated
+# - 03.04.2026: Added OWASP API Security Top 10 2023 rules (Linting-rules.md section 5)
 
 
 # Note: @stoplight/spectral-owasp-ruleset is installed via validation/package.json.

--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -23,6 +23,7 @@ functions:
   - camara-reserved-words
   - camara-language-avoid-telco
   - camara-security-no-secrets-in-path-or-query-parameters
+  - camara-schema-casing-convention
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -258,14 +259,15 @@ rules:
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-schema-casing-convention:
-    description: This rule checks schema should follow a specific case convention pascal case.
-    message: "{{property}} should be pascal case (UppperCamelCase)"
+    description: >
+      Schema names must be PascalCase (UpperCamelCase). CloudEvents schema names
+      (HTTPSettings, HTTPSubscriptionRequest, HTTPSubscriptionResponse,
+      PrivateKeyJWTCredential) are allowed as explicit exceptions.
+    message: "{{error}}"
     severity: warn
     given: $.components.schemas[*]~
     then:
-      function: casing
-      functionOptions:
-        type: pascal
+      function: camara-schema-casing-convention
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-parameter-casing-convention:

--- a/linting/config/lint_function/camara-schema-casing-convention.js
+++ b/linting/config/lint_function/camara-schema-casing-convention.js
@@ -1,0 +1,23 @@
+// CAMARA Project - support function for Spectral linter
+// PascalCase check for schema names with exact CloudEvents exceptions.
+// 03.04.2026 - initial version
+
+// Schema names allowed to deviate from PascalCase (CloudEvents convention).
+const ALLOWED = new Set([
+  "HTTPSettings",
+  "HTTPSubscriptionRequest",
+  "HTTPSubscriptionResponse",
+  "PrivateKeyJWTCredential",
+]);
+
+// PascalCase: first char uppercase, each uppercase followed by lowercase/digit
+// or end-of-string. Matches Spectral's built-in casing: pascal behavior.
+const PASCAL = /^[A-Z](?:[a-z0-9]|[A-Z](?=[a-z0-9]|$))*$/;
+
+export default (input) => {
+  if (typeof input !== "string" || ALLOWED.has(input)) return;
+
+  if (!PASCAL.test(input)) {
+    return [{ message: `${input} should be PascalCase (UpperCamelCase)` }];
+  }
+};

--- a/linting/config/lint_function/camara-schema-type-check.js
+++ b/linting/config/lint_function/camara-schema-type-check.js
@@ -1,0 +1,55 @@
+// CAMARA Project - support function for Spectral linter
+// Recursive type check for schema definitions with combiner support.
+// 03.04.2026 - initial version
+
+const VALID_TYPES = new Set(["string", "number", "integer", "boolean", "array", "object"]);
+
+export default (schema, _options, context) => {
+  const errors = [];
+
+  function check(node, path, isPartial = false) {
+    if (!node || typeof node !== "object" || node.$ref) return;
+
+    const hasCombiner = node.allOf || node.anyOf || node.oneOf;
+
+    // Only require 'type' if:
+    // - not a partial schema (inside a combiner)
+    // - and no combiner is used as a substitute
+    if (!isPartial && !hasCombiner) {
+      if (!node.type) {
+        errors.push({ message: `Missing 'type' at ${path.join(".")}`, path });
+      } else if (!VALID_TYPES.has(node.type)) {
+        errors.push({ message: `Invalid type '${node.type}' at ${path.join(".")}`, path });
+      }
+    }
+
+    // Recurse into properties
+    if (node.properties) {
+      for (const [key, value] of Object.entries(node.properties)) {
+        check(value, [...path, "properties", key], isPartial);
+      }
+    }
+
+    // Recurse into array items
+    if (node.items) {
+      check(node.items, [...path, "items"], isPartial);
+    }
+
+    // Recurse into additionalProperties when it is a schema
+    if (typeof node.additionalProperties === "object" && node.additionalProperties !== null) {
+      check(node.additionalProperties, [...path, "additionalProperties"], isPartial);
+    }
+
+    // Recurse into combiners — mark children as partial
+    for (const combiner of ["allOf", "anyOf", "oneOf"]) {
+      if (node[combiner]) {
+        node[combiner].forEach((subSchema, i) => {
+          check(subSchema, [...path, combiner, i], true);
+        });
+      }
+    }
+  }
+
+  check(schema, context.path);
+  return errors;
+};

--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -251,6 +251,20 @@ def parse_spectral_output(
     findings = []
     for item in data:
         try:
+            # The OWASP string-restricted rule uses a deep recursive JSONPath
+            # that can traverse Spectral's internally-resolved $ref copies,
+            # producing phantom findings with no source file and range 0:0.
+            # Drop these — they duplicate real findings on the actual source.
+            if (
+                item.get("code") == "owasp:api4:2023-string-restricted"
+                and not item.get("source")
+            ):
+                start = item.get("range", {}).get("start", {})
+                if start.get("line", 0) == 0 and start.get("character", 0) == 0:
+                    logger.debug(
+                        "Dropping phantom string-restricted finding (resolved $ref)"
+                    )
+                    continue
             findings.append(normalize_finding(item, repo_root=repo_root))
         except (KeyError, TypeError) as exc:
             logger.warning("Skipping malformed Spectral finding: %s", exc)

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -193,16 +193,14 @@ gap_rules:
 fixes:
   - rule_id: S-016
     engine_rule: camara-schema-type-check
-    status: partial
+    status: done
     issue: >
-      Only checks top-level schemas ($.components.schemas.*). Does not recurse
-      into properties, items, or nested schemas. Does not handle combiners
-      (allOf/anyOf/oneOf) as valid alternatives to type.
+      Original inline rule only checked top-level schemas. Did not recurse
+      into properties, items, or nested schemas. Did not handle combiners.
     fix: >
-      Rewrite as custom JS function with recursive traversal. Check type
-      presence on all schema nodes, accept combiners as substitute for type,
-      mark combiner children as partial (no type required). Skip $ref nodes.
-      Also recurse into additionalProperties when it is a schema.
+      Replaced with custom JS function in .spectral-r4.yaml. Recursive
+      traversal, combiner-aware, validates type values. Original inline
+      rule preserved in r3.4 and fallback rulesets.
 
   - rule_id: P-007
     engine_rule: check-test-file-version

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -204,9 +204,49 @@ fixes:
           level: warn
 
 # ---------------------------------------------------------------------------
+# Proposed changes — need upstream discussion before implementation
+# ---------------------------------------------------------------------------
+
+proposed_changes:
+  - rule_id: S-211
+    engine_rule: oas3-unused-component
+    current_level: warn
+    proposed_level: hint
+    reason: >
+      Spectral does not follow discriminator mappings — schemas referenced
+      only via discriminator appear as unused. False positives on subscription
+      event schemas (e.g. EventApiSpecific1, EventSubscriptionStarted).
+      Unused schemas are cosmetic, not harmful.
+    discuss_in: Commonalities
+
+  - rule_id: S-313
+    engine_rule: "owasp:api4:2023-string-restricted"
+    current_level: warn
+    proposed_level: hint
+    reason: >
+      Free-text string properties (ErrorInfo.message, CloudEvent.id,
+      SubscriptionId, *Description fields) cannot meaningfully have format
+      or pattern without risking backward-incompatibility (e.g. localized
+      messages). The resource consumption concern is already covered by
+      string-limit (maxLength). string-restricted adds noise on fields
+      where no actionable fix exists.
+    discuss_in: Commonalities
+
+  - engine_rule: camara-schema-casing-convention
+    rule_id: S-015
+    change: Add overrides for CloudEvents abbreviation prefixes (HTTP, JWT)
+    reason: >
+      CloudEvents convention uses uppercase protocol prefixes in schema names
+      (HTTPSettings, HTTPSubscriptionRequest, HTTPSubscriptionResponse).
+      PrivateKeyJWTCredential follows the same pattern. Renaming to HttpSettings
+      etc. would deviate from CloudEvents spec. Overrides for these 4 schemas
+      would suppress false positives while keeping PascalCase enforced for all
+      other schemas.
+    discuss_in: Commonalities
+
+# ---------------------------------------------------------------------------
 # Pending rules — in open PRs
 # ---------------------------------------------------------------------------
-# Source: tooling#95 (OWASP Spectral rules)
 
 pending_rules:
   # OWASP rules (tooling#95) implemented in WS07 Phase 1b — see spectral-rules.yaml S-300..S-319

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -191,6 +191,19 @@ gap_rules:
 # ---------------------------------------------------------------------------
 
 fixes:
+  - rule_id: S-016
+    engine_rule: camara-schema-type-check
+    status: partial
+    issue: >
+      Only checks top-level schemas ($.components.schemas.*). Does not recurse
+      into properties, items, or nested schemas. Does not handle combiners
+      (allOf/anyOf/oneOf) as valid alternatives to type.
+    fix: >
+      Rewrite as custom JS function with recursive traversal. Check type
+      presence on all schema nodes, accept combiners as substitute for type,
+      mark combiner children as partial (no type required). Skip $ref nodes.
+      Also recurse into additionalProperties when it is a schema.
+
   - rule_id: P-007
     engine_rule: check-test-file-version
     status: suppressed
@@ -210,19 +223,18 @@ fixes:
 proposed_changes:
   - rule_id: S-211
     engine_rule: oas3-unused-component
-    current_level: warn
-    proposed_level: hint
+    change: Keep Spectral severity (warn), add conditional_level default=hint in metadata
     reason: >
       Spectral does not follow discriminator mappings — schemas referenced
       only via discriminator appear as unused. False positives on subscription
       event schemas (e.g. EventApiSpecific1, EventSubscriptionStarted).
       Unused schemas are cosmetic, not harmful.
-    discuss_in: Commonalities
+    status: done
 
   - rule_id: S-313
     engine_rule: "owasp:api4:2023-string-restricted"
-    current_level: warn
-    proposed_level: hint
+    change: Keep Spectral severity (warn), add conditional_level default=hint + hint text in metadata
+    hint: "Acceptable if free-form field or implementation-dependent — no fix needed."
     reason: >
       Free-text string properties (ErrorInfo.message, CloudEvent.id,
       SubscriptionId, *Description fields) cannot meaningfully have format
@@ -230,19 +242,18 @@ proposed_changes:
       messages). The resource consumption concern is already covered by
       string-limit (maxLength). string-restricted adds noise on fields
       where no actionable fix exists.
-    discuss_in: Commonalities
+    status: done
 
-  - engine_rule: camara-schema-casing-convention
-    rule_id: S-015
-    change: Add overrides for CloudEvents abbreviation prefixes (HTTP, JWT)
+  - rule_id: S-015
+    engine_rule: camara-schema-casing-convention
+    change: >
+      Custom JS function replaces built-in casing: pascal. Exact exception
+      list for 4 CloudEvents schema names (HTTPSettings, HTTPSubscriptionRequest,
+      HTTPSubscriptionResponse, PrivateKeyJWTCredential). r4 ruleset only.
     reason: >
-      CloudEvents convention uses uppercase protocol prefixes in schema names
-      (HTTPSettings, HTTPSubscriptionRequest, HTTPSubscriptionResponse).
-      PrivateKeyJWTCredential follows the same pattern. Renaming to HttpSettings
-      etc. would deviate from CloudEvents spec. Overrides for these 4 schemas
-      would suppress false positives while keeping PascalCase enforced for all
-      other schemas.
-    discuss_in: Commonalities
+      CloudEvents convention uses uppercase protocol prefixes in schema names.
+      Renaming would deviate from CloudEvents spec.
+    status: done
 
 # ---------------------------------------------------------------------------
 # Pending rules — in open PRs

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -123,6 +123,9 @@
 - id: S-211
   engine: spectral
   engine_rule: oas3-unused-component
+  hint: "Spectral does not follow discriminator mappings — verify the schema is truly unused."
+  conditional_level:
+    default: hint
 
 - id: S-212
   engine: spectral
@@ -255,6 +258,9 @@
 - id: S-313
   engine: spectral
   engine_rule: "owasp:api4:2023-string-restricted"
+  hint: "Acceptable if free-form field or implementation-dependent — no fix needed."
+  conditional_level:
+    default: hint
 
 - id: S-314
   engine: spectral

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -306,8 +306,8 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 7, (
-            f"Expected 7 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 9, (
+            f"Expected 9 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -351,6 +351,37 @@ class TestParseSpectralOutput:
         findings = parse_spectral_output(raw, repo_root="/runner/work")
         assert findings[0]["path"] == "code/API_definitions/quality-on-demand.yaml"
 
+    def test_string_restricted_phantom_dropped(self):
+        """Phantom string-restricted findings (no source, range 0:0) are dropped."""
+        phantom = {
+            "code": "owasp:api4:2023-string-restricted",
+            "message": "Schema of type string should specify a format.",
+            "severity": 1,
+            "source": "",
+            "path": ["components", "schemas", "Foo", "properties", "bar"],
+            "range": {"start": {"line": 0, "character": 0},
+                      "end": {"line": 0, "character": 0}},
+        }
+        raw = json.dumps([SAMPLE_SPECTRAL_FINDING, phantom])
+        findings = parse_spectral_output(raw)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "camara-parameter-casing-convention"
+
+    def test_other_rule_sourceless_not_dropped(self):
+        """Sourceless findings from other rules are kept (only string-restricted filtered)."""
+        other = {
+            "code": "owasp:api4:2023-string-limit",
+            "message": "Schema of type string must specify maxLength.",
+            "severity": 1,
+            "source": "",
+            "path": ["components", "schemas", "Foo", "properties", "bar"],
+            "range": {"start": {"line": 0, "character": 0},
+                      "end": {"line": 0, "character": 0}},
+        }
+        raw = json.dumps([other])
+        findings = parse_spectral_output(raw)
+        assert len(findings) == 1
+
     def test_external_file_findings_downgraded_to_hint(self):
         """Findings from common schemas (followed via $ref) become hints."""
         common_finding = {


### PR DESCRIPTION
#### What type of PR is this?

bug, correction

#### What this PR does / why we need it:

Follow-up fixes after OWASP rule integration (#145), based on ReleaseTest validation runs ([dispatch](https://github.com/camaraproject/ReleaseTest/actions/runs/23941828563), [PR](https://github.com/camaraproject/ReleaseTest/actions/runs/23941952580)):

- **Changelog entry**: Add missing OWASP changelog line to `.spectral-r4.yaml` header
- **Phantom findings filter**: Drop sourceless `string-restricted` findings produced by Spectral's internal `$ref` dereferencing (44 phantom warnings observed on ReleaseTest dispatch run)
- **Proposed rule changes**: Track three rule adjustments needing Commonalities discussion in `rule-inventory.yaml`:
  - `oas3-unused-component` → hint (false positives from discriminator mappings)
  - `owasp:api4:2023-string-restricted` → hint (free-text strings can't have format/pattern without backward-compatibility risk; resource consumption already covered by `string-limit`)
  - `camara-schema-casing-convention` → overrides for CloudEvents abbreviation prefixes (`HTTP`, `JWT`)

#### Which issue(s) this PR fixes:

Related: #145 (OWASP rules integration)
Related: [ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448) (validation framework umbrella)

#### Special notes for reviewers:

This PR also serves as a place to collect feedback on the OWASP rule configuration from #145. The severity levels follow [Commonalities Linting-rules.md section 5](https://github.com/camaraproject/Commonalities/blob/main/documentation/Linting-rules.md#5-owasp-api-security-top-10-2023-rules) — proposed deviations are tracked in `rule-inventory.yaml` for upstream discussion.

The phantom findings issue affects only unbundled specs with `$ref` to `code/common/` files. On snapshot branches (bundled specs), no phantoms occur.

#### Changelog input

```
fix: drop phantom string-restricted findings from Spectral $ref dereferencing
```

#### Additional documentation

This section can be blank.

```
docs

```