### PR TITLE
feat(validation): Phase 2b Python gap rules (P-014..P-019)

### DIFF
--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -59,6 +59,35 @@ runs:
       run: npm ci --ignore-scripts
       working-directory: ${{ inputs.tooling_path }}/validation
 
+    - name: Resolve Commonalities version
+      id: resolve-commonalities
+      shell: bash
+      env:
+        REPO_PATH: ${{ inputs.repo_path }}
+      run: |
+        # Extract commonalities_release tag from release-plan.yaml (if present)
+        PLAN_FILE="${REPO_PATH}/release-plan.yaml"
+        if [ -f "$PLAN_FILE" ]; then
+          RELEASE_TAG=$(python3 -c "
+        import yaml, sys
+        try:
+            plan = yaml.safe_load(open('${PLAN_FILE}'))
+            tag = plan.get('dependencies', {}).get('commonalities_release', '')
+            print(tag)
+        except Exception:
+            print('')
+        ")
+          if [ -n "$RELEASE_TAG" ]; then
+            VERSION=$(gh api "repos/camaraproject/Commonalities/contents/VERSION.yaml?ref=${RELEASE_TAG}" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | \
+              python3 -c "import yaml,sys; print(yaml.safe_load(sys.stdin).get('version',''))" 2>/dev/null || echo "")
+            if [ -n "$VERSION" ]; then
+              echo "VALIDATION_COMMONALITIES_VERSION=$VERSION" >> "$GITHUB_ENV"
+              echo "Resolved commonalities_release ${RELEASE_TAG} -> version ${VERSION}"
+            fi
+          fi
+        fi
+
     - name: Run validation orchestrator
       id: run
       shell: bash

--- a/validation/context/context_builder.py
+++ b/validation/context/context_builder.py
@@ -107,6 +107,7 @@ class ValidationContext:
     # Release context (from release-plan.yaml; None if absent)
     target_release_type: Optional[str]
     commonalities_release: Optional[str]
+    commonalities_version: Optional[str]
     icm_release: Optional[str]
 
     # PR-specific (None / False for non-PR triggers)
@@ -262,6 +263,7 @@ def build_validation_context(
     release_metadata_schema_path: Optional[Path] = None,
     workflow_run_url: str = "",
     tooling_ref: str = "",
+    commonalities_version: Optional[str] = None,
 ) -> ValidationContext:
     """Assemble the unified validation context.
 
@@ -337,6 +339,7 @@ def build_validation_context(
         stage=stage,
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
+        commonalities_version=commonalities_version,
         icm_release=icm_release,
         base_ref=base_ref or None,
         is_release_review_pr=is_review,

--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -7,11 +7,17 @@ from __future__ import annotations
 from ._types import CheckDescriptor, CheckScope
 
 from .changelog_checks import check_changelog_format
+from .error_code_checks import check_conflict_deprecated, check_contextcode_format
 from .filename_checks import check_filename_kebab_case, check_filename_matches_api_name
 from .metadata_checks import check_commonalities_version
 from .readme_checks import check_readme_placeholder_removal
-from .release_plan_checks import check_release_plan_semantics
+from .release_plan_checks import check_orphan_api_definitions, check_release_plan_semantics
 from .release_review_checks import check_release_review_file_restriction
+from .subscription_checks import (
+    check_event_type_format,
+    check_sinkcredential_not_in_response,
+    check_subscription_filename,
+)
 from .test_checks import (
     check_test_directory_exists,
     check_test_file_version,
@@ -34,13 +40,19 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-server-url-api-name", CheckScope.API, check_server_url_api_name),
     CheckDescriptor("check-test-files-exist", CheckScope.API, check_test_files_exist),
     CheckDescriptor("check-test-file-version", CheckScope.API, check_test_file_version),
+    CheckDescriptor("check-commonalities-version", CheckScope.API, check_commonalities_version),
+    CheckDescriptor("check-subscription-filename", CheckScope.API, check_subscription_filename),
+    CheckDescriptor("check-event-type-format", CheckScope.API, check_event_type_format),
+    CheckDescriptor("check-sinkcredential-not-in-response", CheckScope.API, check_sinkcredential_not_in_response),
+    CheckDescriptor("check-conflict-deprecated", CheckScope.API, check_conflict_deprecated),
+    CheckDescriptor("check-contextcode-format", CheckScope.API, check_contextcode_format),
     # --- Repo-level checks (run once) ---
     CheckDescriptor("check-test-directory-exists", CheckScope.REPO, check_test_directory_exists),
     CheckDescriptor("check-release-plan-semantics", CheckScope.REPO, check_release_plan_semantics),
     CheckDescriptor("check-changelog-format", CheckScope.REPO, check_changelog_format),
-    CheckDescriptor("check-commonalities-version", CheckScope.API, check_commonalities_version),
     CheckDescriptor("check-readme-placeholder-removal", CheckScope.REPO, check_readme_placeholder_removal),
     CheckDescriptor("check-release-review-file-restriction", CheckScope.REPO, check_release_review_file_restriction),
+    CheckDescriptor("check-orphan-api-definitions", CheckScope.REPO, check_orphan_api_definitions),
 ]
 
 __all__ = ["CHECKS", "CheckDescriptor", "CheckScope"]

--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -8,7 +8,7 @@ from ._types import CheckDescriptor, CheckScope
 
 from .changelog_checks import check_changelog_format
 from .filename_checks import check_filename_kebab_case, check_filename_matches_api_name
-from .metadata_checks import check_license_commonalities_consistency
+from .metadata_checks import check_commonalities_version
 from .readme_checks import check_readme_placeholder_removal
 from .release_plan_checks import check_release_plan_semantics
 from .release_review_checks import check_release_review_file_restriction
@@ -38,7 +38,7 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-test-directory-exists", CheckScope.REPO, check_test_directory_exists),
     CheckDescriptor("check-release-plan-semantics", CheckScope.REPO, check_release_plan_semantics),
     CheckDescriptor("check-changelog-format", CheckScope.REPO, check_changelog_format),
-    CheckDescriptor("check-license-commonalities-consistency", CheckScope.REPO, check_license_commonalities_consistency),
+    CheckDescriptor("check-commonalities-version", CheckScope.API, check_commonalities_version),
     CheckDescriptor("check-readme-placeholder-removal", CheckScope.REPO, check_readme_placeholder_removal),
     CheckDescriptor("check-release-review-file-restriction", CheckScope.REPO, check_release_review_file_restriction),
 ]

--- a/validation/engines/python_checks/_spec_helpers.py
+++ b/validation/engines/python_checks/_spec_helpers.py
@@ -1,0 +1,323 @@
+"""Shared OpenAPI spec traversal helpers for Python checks.
+
+Provides utilities for navigating CAMARA OpenAPI spec structures:
+local $ref resolution, schema property collection, event type
+extraction, and enum value search.
+
+Design constraints:
+  - Only resolves local $ref (starting with ``#/``).
+  - Follows ``allOf`` one level deep — sufficient for CAMARA patterns.
+  - No external I/O — operates on parsed spec dicts only.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Local $ref resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_local_ref(spec: dict, ref: str) -> Optional[dict]:
+    """Resolve a local JSON Reference within a parsed OpenAPI spec.
+
+    Handles ``#/components/schemas/Foo`` style references by walking
+    the spec dict along the path segments.
+
+    Returns ``None`` if the reference is external, malformed, or the
+    target path does not exist.
+    """
+    if not ref or not ref.startswith("#/"):
+        return None
+    parts = ref[2:].split("/")
+    current: object = spec
+    for part in parts:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+        if current is None:
+            return None
+    return current if isinstance(current, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# Schema property collection
+# ---------------------------------------------------------------------------
+
+
+def collect_schema_properties(
+    spec: dict, schema: dict
+) -> Dict[str, dict]:
+    """Collect all property definitions from a schema.
+
+    Walks direct ``properties`` and follows ``allOf`` compositions one
+    level deep (resolving ``$ref`` within ``allOf`` entries).
+
+    Returns a dict mapping property names to their schema definitions.
+    """
+    props: Dict[str, dict] = {}
+
+    # Direct properties
+    direct = schema.get("properties")
+    if isinstance(direct, dict):
+        props.update(direct)
+
+    # allOf compositions
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for entry in all_of:
+            if not isinstance(entry, dict):
+                continue
+            # Resolve $ref if present
+            if "$ref" in entry:
+                resolved = resolve_local_ref(spec, entry["$ref"])
+                if resolved is not None:
+                    sub_props = resolved.get("properties")
+                    if isinstance(sub_props, dict):
+                        props.update(sub_props)
+            else:
+                sub_props = entry.get("properties")
+                if isinstance(sub_props, dict):
+                    props.update(sub_props)
+
+    return props
+
+
+# ---------------------------------------------------------------------------
+# Event type extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_event_types_from_spec(spec: dict) -> List[str]:
+    """Extract all event type enum values from a CAMARA subscription spec.
+
+    Searches ``components/schemas`` for schemas whose name contains
+    ``EventType`` (case-insensitive) and collects their ``enum`` values.
+
+    This covers the standard CAMARA patterns:
+      - ``SubscriptionEventType`` (API-specific events for subscription requests)
+      - ``EventTypeNotification`` (all events including lifecycle)
+      - ``ApiEventType`` (template pattern)
+      - ``SubscriptionLifecycleEventType`` (template pattern)
+
+    Returns a deduplicated list of event type strings.
+    """
+    schemas = spec.get("components", {}).get("schemas", {})
+    if not isinstance(schemas, dict):
+        return []
+
+    event_types: set[str] = set()
+    for schema_name, schema_def in schemas.items():
+        if not isinstance(schema_def, dict):
+            continue
+        if "eventtype" not in schema_name.lower():
+            continue
+        enum_values = schema_def.get("enum")
+        if isinstance(enum_values, list):
+            for val in enum_values:
+                if isinstance(val, str):
+                    event_types.add(val)
+
+    return sorted(event_types)
+
+
+# ---------------------------------------------------------------------------
+# Enum value search
+# ---------------------------------------------------------------------------
+
+
+def find_enum_value_in_schemas(
+    spec: dict, target: str
+) -> List[Tuple[str, List[str]]]:
+    """Search all component schemas for a specific enum value.
+
+    Walks ``components/schemas`` and checks every ``enum`` list
+    (including nested ``properties`` and ``allOf`` compositions).
+
+    Args:
+        spec: Parsed OpenAPI spec dict.
+        target: The enum value to search for (exact match).
+
+    Returns:
+        List of ``(schema_path, enum_values)`` tuples where *target*
+        was found.  *schema_path* is a dot-separated location string.
+    """
+    schemas = spec.get("components", {}).get("schemas", {})
+    if not isinstance(schemas, dict):
+        return []
+
+    results: List[Tuple[str, List[str]]] = []
+    for schema_name, schema_def in schemas.items():
+        if not isinstance(schema_def, dict):
+            continue
+        _search_enum_recursive(
+            spec, schema_def, f"components.schemas.{schema_name}",
+            target, results,
+        )
+    return results
+
+
+def _search_enum_recursive(
+    spec: dict,
+    node: dict,
+    path: str,
+    target: str,
+    results: List[Tuple[str, List[str]]],
+) -> None:
+    """Recursively search a schema node for enums containing *target*."""
+    # Check direct enum
+    enum_values = node.get("enum")
+    if isinstance(enum_values, list) and target in enum_values:
+        results.append((path, list(enum_values)))
+
+    # Check properties
+    props = node.get("properties")
+    if isinstance(props, dict):
+        for prop_name, prop_def in props.items():
+            if isinstance(prop_def, dict):
+                _search_enum_recursive(
+                    spec, prop_def, f"{path}.{prop_name}",
+                    target, results,
+                )
+
+    # Check allOf entries
+    all_of = node.get("allOf")
+    if isinstance(all_of, list):
+        for i, entry in enumerate(all_of):
+            if not isinstance(entry, dict):
+                continue
+            if "$ref" in entry:
+                resolved = resolve_local_ref(spec, entry["$ref"])
+                if resolved is not None:
+                    _search_enum_recursive(
+                        spec, resolved, f"{path}.allOf[{i}]",
+                        target, results,
+                    )
+            else:
+                _search_enum_recursive(
+                    spec, entry, f"{path}.allOf[{i}]",
+                    target, results,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Property name search
+# ---------------------------------------------------------------------------
+
+
+def find_properties_by_name(
+    spec: dict, property_name: str
+) -> List[Tuple[str, dict]]:
+    """Find all schemas in ``components/schemas`` containing a named property.
+
+    Walks top-level schemas and their ``allOf`` compositions (one level).
+
+    Args:
+        spec: Parsed OpenAPI spec dict.
+        property_name: The property name to search for.
+
+    Returns:
+        List of ``(schema_name, property_schema)`` tuples.
+    """
+    schemas = spec.get("components", {}).get("schemas", {})
+    if not isinstance(schemas, dict):
+        return []
+
+    results: List[Tuple[str, dict]] = []
+    for schema_name, schema_def in schemas.items():
+        if not isinstance(schema_def, dict):
+            continue
+        all_props = collect_schema_properties(spec, schema_def)
+        if property_name in all_props:
+            results.append((schema_name, all_props[property_name]))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Response schema iteration
+# ---------------------------------------------------------------------------
+
+
+def iter_response_schemas(
+    spec: dict, path_prefix: str = ""
+) -> Iterable[Tuple[str, str, str, dict]]:
+    """Yield response schemas from OpenAPI paths.
+
+    For each path matching *path_prefix*, yields
+    ``(path, method, status_code, resolved_schema)`` for every
+    response that has ``content.application/json.schema``.
+
+    Schema ``$ref`` is resolved one level.
+
+    Args:
+        spec: Parsed OpenAPI spec dict.
+        path_prefix: Only yield from paths containing this string.
+            Empty string matches all paths.
+    """
+    paths = spec.get("paths")
+    if not isinstance(paths, dict):
+        return
+
+    for path_key, path_item in paths.items():
+        if path_prefix and path_prefix not in path_key:
+            continue
+        if not isinstance(path_item, dict):
+            continue
+
+        for method in ("get", "post", "put", "patch", "delete"):
+            operation = path_item.get(method)
+            if not isinstance(operation, dict):
+                continue
+
+            responses = operation.get("responses")
+            if not isinstance(responses, dict):
+                continue
+
+            for status_code, response_def in responses.items():
+                if not isinstance(response_def, dict):
+                    continue
+
+                # Resolve response-level $ref
+                if "$ref" in response_def:
+                    resolved = resolve_local_ref(spec, response_def["$ref"])
+                    if resolved is None:
+                        continue
+                    response_def = resolved
+
+                content = response_def.get("content", {})
+                if not isinstance(content, dict):
+                    continue
+
+                json_content = content.get("application/json")
+                if not isinstance(json_content, dict):
+                    continue
+
+                schema = json_content.get("schema")
+                if not isinstance(schema, dict):
+                    continue
+
+                # Resolve schema-level $ref
+                if "$ref" in schema:
+                    resolved = resolve_local_ref(spec, schema["$ref"])
+                    if resolved is not None:
+                        schema = resolved
+
+                # Handle array responses (e.g. GET /subscriptions)
+                if schema.get("type") == "array":
+                    items = schema.get("items")
+                    if isinstance(items, dict):
+                        if "$ref" in items:
+                            resolved = resolve_local_ref(spec, items["$ref"])
+                            if resolved is not None:
+                                yield (path_key, method, status_code, resolved)
+                        else:
+                            yield (path_key, method, status_code, items)
+                    continue
+
+                yield (path_key, method, status_code, schema)

--- a/validation/engines/python_checks/error_code_checks.py
+++ b/validation/engines/python_checks/error_code_checks.py
@@ -1,0 +1,141 @@
+"""Error code and contextCode checks.
+
+Validates error code deprecation (CONFLICT) and contextCode naming
+conventions introduced in Commonalities r4.x.
+
+Design doc references:
+  - Design Guide section 3.2: error response table (CONFLICT deprecated)
+  - Design Guide section 3.1.3: contextCode SCREAMING_SNAKE_CASE
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+from validation.context import ValidationContext
+
+from ._spec_helpers import find_enum_value_in_schemas, find_properties_by_name
+from ._types import load_yaml_safe, make_finding
+
+# contextCode values: API_NAME.SPECIFIC_CODE or PLAIN_CODE
+# Both parts in SCREAMING_SNAKE_CASE.
+_SCREAMING_SNAKE_RE = re.compile(
+    r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*"
+    r"(\.[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)?$"
+)
+
+
+# ---------------------------------------------------------------------------
+# P-017 (DG-018): check-conflict-deprecated
+# ---------------------------------------------------------------------------
+
+
+def check_conflict_deprecated(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Warn if the CONFLICT error code is used.
+
+    Design Guide section 3.2: "CONFLICT — Duplication of an existing
+    resource (This Error Code is DEPRECATED)".
+
+    Searches all component schema enums for the value ``"CONFLICT"``.
+    Applicability (post-filter): ``commonalities_release >= r4.0``.
+    """
+    api = context.apis[0]
+    spec = load_yaml_safe(repo_path / api.spec_file)
+    if spec is None:
+        return []
+
+    matches = find_enum_value_in_schemas(spec, "CONFLICT")
+    if not matches:
+        return []
+
+    findings: List[dict] = []
+    for schema_path, _ in matches:
+        findings.append(
+            make_finding(
+                engine_rule="check-conflict-deprecated",
+                level="warn",
+                message=(
+                    f"Error code 'CONFLICT' is deprecated in Commonalities "
+                    f"r4.x — use 'ALREADY_EXISTS' or a specific error code "
+                    f"(found in {schema_path})"
+                ),
+                path=api.spec_file,
+                line=1,
+                api_name=api.api_name,
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# P-018 (DG-011): check-contextcode-format
+# ---------------------------------------------------------------------------
+
+
+def check_contextcode_format(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate contextCode enum values follow SCREAMING_SNAKE_CASE.
+
+    Design Guide section 3.1.3: "API-specific codes following CAMARA
+    conventions (API_NAME.SPECIFIC_CODE in SCREAMING_SNAKE_CASE)".
+
+    The contextCode field is optional. This check only fires when a
+    ``contextCode`` property is found in the spec.
+    Applicability (post-filter): ``commonalities_release >= r4.0``.
+    """
+    api = context.apis[0]
+    spec = load_yaml_safe(repo_path / api.spec_file)
+    if spec is None:
+        return []
+
+    results = find_properties_by_name(spec, "contextCode")
+    if not results:
+        return []
+
+    findings: List[dict] = []
+    for schema_name, prop_schema in results:
+        enum_values = prop_schema.get("enum")
+        if not isinstance(enum_values, list):
+            # contextCode without enum — recommend adding one
+            findings.append(
+                make_finding(
+                    engine_rule="check-contextcode-format",
+                    level="hint",
+                    message=(
+                        f"contextCode in {schema_name} has no enum "
+                        f"constraint — enum is recommended per Design "
+                        f"Guide section 3.1.3"
+                    ),
+                    path=api.spec_file,
+                    line=1,
+                    api_name=api.api_name,
+                )
+            )
+            continue
+
+        # Validate each enum value
+        for val in enum_values:
+            if not isinstance(val, str):
+                continue
+            if not _SCREAMING_SNAKE_RE.match(val):
+                findings.append(
+                    make_finding(
+                        engine_rule="check-contextcode-format",
+                        level="hint",
+                        message=(
+                            f"contextCode value '{val}' in {schema_name} "
+                            f"does not follow SCREAMING_SNAKE_CASE format "
+                            f"(expected API_NAME.SPECIFIC_CODE)"
+                        ),
+                        path=api.spec_file,
+                        line=1,
+                        api_name=api.api_name,
+                    )
+                )
+
+    return findings

--- a/validation/engines/python_checks/metadata_checks.py
+++ b/validation/engines/python_checks/metadata_checks.py
@@ -1,119 +1,165 @@
-"""Metadata consistency checks.
+"""Commonalities version check.
 
-Validates that ``info.license`` and ``info.x-camara-commonalities`` are
-present in all API spec files and consistent across them.
+Validates that ``info.x-camara-commonalities`` is present and contains
+a valid version value appropriate for the branch type.
+
+Design Guide section 5.3.7: "The API SHALL specify the Commonalities
+release version they are compliant to, by including the
+x-camara-commonalities extension field."
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import List
 
 from validation.context import ValidationContext
 
 from ._types import load_yaml_safe, make_finding
 
+_ENGINE_RULE = "check-commonalities-version"
 
-def _extract_metadata(spec: dict) -> tuple[Optional[Any], Optional[Any]]:
-    """Extract license and x-camara-commonalities from a spec."""
-    info = spec.get("info", {})
-    license_val = info.get("license")
-    commonalities_val = info.get("x-camara-commonalities")
-    return license_val, commonalities_val
+# Full semver: 0.7.0, 0.7.0-rc.1, 1.0.0-alpha.2
+_SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<pre>[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*))?$"
+)
+
+# Short form: 0.7, 4.1 (allowed on main/feature only)
+_SHORT_VERSION_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)$"
+)
+
+# Placeholder values allowed on main/feature branches
+_PLACEHOLDERS = frozenset({"wip", "tbd"})
 
 
-def check_license_commonalities_consistency(
+def _is_valid_format(value: str, branch_type: str) -> bool:
+    """Check if the value is a valid x-camara-commonalities format.
+
+    Main/feature: wip, tbd, X.Y, or X.Y.Z[-pre] are all valid.
+    Release/maintenance: only X.Y.Z[-pre] is valid.
+    """
+    if branch_type in ("main", "feature"):
+        if value in _PLACEHOLDERS:
+            return True
+        if _SHORT_VERSION_RE.match(value):
+            return True
+        if _SEMVER_RE.match(value):
+            return True
+        return False
+
+    # release / maintenance — must be full semver
+    return _SEMVER_RE.match(value) is not None
+
+
+def _is_concrete_version(value: str) -> bool:
+    """True if the value is a concrete version (not a placeholder)."""
+    return value not in _PLACEHOLDERS and (
+        _SEMVER_RE.match(value) is not None
+        or _SHORT_VERSION_RE.match(value) is not None
+    )
+
+
+def check_commonalities_version(
     repo_path: Path, context: ValidationContext
 ) -> List[dict]:
-    """Verify license and x-camara-commonalities are present and consistent.
+    """Validate info.x-camara-commonalities presence and value.
 
-    Repo-level check.  Loads all spec files referenced in ``context.apis``,
-    checks that each has ``info.license`` and ``info.x-camara-commonalities``,
-    and verifies the values are identical across all API files.
+    Per-API check (runs once per API in context.apis).
+
+    Checks:
+    1. Field must be present in info object.
+    2. Value must be a valid format for the branch type.
+    3. If a concrete version and context.commonalities_version is set,
+       the values must match.
     """
-    if not context.apis:
+    api = context.apis[0]
+    spec_path = repo_path / api.spec_file
+    spec = load_yaml_safe(spec_path)
+
+    if spec is None:
+        # Missing file — filename check reports this.
         return []
 
-    findings: List[dict] = []
-    first_license: Optional[Any] = None
-    first_commonalities: Optional[Any] = None
-    first_api: Optional[str] = None
+    info = spec.get("info", {})
+    raw_value = info.get("x-camara-commonalities")
 
-    for api in context.apis:
-        spec_path = repo_path / api.spec_file
-        spec = load_yaml_safe(spec_path)
-
-        if spec is None:
-            # Missing file — filename check reports this.
-            continue
-
-        license_val, commonalities_val = _extract_metadata(spec)
-
-        # Check presence.
-        if license_val is None:
-            findings.append(
-                make_finding(
-                    engine_rule="check-license-commonalities-consistency",
-                    level="error",
-                    message=f"info.license is missing in {api.spec_file}",
-                    path=api.spec_file,
-                    line=1,
-                    api_name=api.api_name,
-                )
+    # Check 1: presence
+    if raw_value is None:
+        return [
+            make_finding(
+                engine_rule=_ENGINE_RULE,
+                level="error",
+                message=(
+                    f"info.x-camara-commonalities is missing in "
+                    f"{api.spec_file}"
+                ),
+                path=api.spec_file,
+                line=1,
+                api_name=api.api_name,
             )
-        if commonalities_val is None:
-            findings.append(
+        ]
+
+    value = str(raw_value).strip()
+
+    # Check 2: format validation
+    if not _is_valid_format(value, context.branch_type):
+        if context.branch_type in ("release", "maintenance"):
+            detail = (
+                f"must be a full version (X.Y.Z or X.Y.Z-pre) on "
+                f"{context.branch_type} branch"
+            )
+        else:
+            detail = (
+                "must be 'wip', 'tbd', or a valid version "
+                "(X.Y, X.Y.Z, X.Y.Z-pre)"
+            )
+        return [
+            make_finding(
+                engine_rule=_ENGINE_RULE,
+                level="error",
+                message=(
+                    f"info.x-camara-commonalities '{value}' has invalid "
+                    f"format — {detail}"
+                ),
+                path=api.spec_file,
+                line=1,
+                api_name=api.api_name,
+            )
+        ]
+
+    # Check 3: version mismatch against resolved commonalities_version
+    if (
+        context.commonalities_version
+        and _is_concrete_version(value)
+    ):
+        # Normalize short form for comparison: "0.7" matches "0.7.0"
+        expected = context.commonalities_version
+        actual = value
+        if _SHORT_VERSION_RE.match(actual):
+            actual = f"{actual}.0"
+
+        # Strip pre-release for prefix comparison if short form was used
+        expected_base = expected.split("-")[0]
+        actual_base = actual.split("-")[0]
+
+        if actual_base != expected_base and actual != expected:
+            return [
                 make_finding(
-                    engine_rule="check-license-commonalities-consistency",
-                    level="error",
+                    engine_rule=_ENGINE_RULE,
+                    level="warn",
                     message=(
-                        f"info.x-camara-commonalities is missing in "
-                        f"{api.spec_file}"
+                        f"info.x-camara-commonalities '{value}' does not "
+                        f"match the declared Commonalities version "
+                        f"'{context.commonalities_version}' from "
+                        f"release-plan.yaml"
                     ),
                     path=api.spec_file,
                     line=1,
                     api_name=api.api_name,
                 )
-            )
+            ]
 
-        # Track first values for consistency check.
-        if first_api is None:
-            first_api = api.api_name
-            first_license = license_val
-            first_commonalities = commonalities_val
-            continue
-
-        # Consistency: compare against first API's values.
-        if license_val is not None and first_license is not None:
-            if license_val != first_license:
-                findings.append(
-                    make_finding(
-                        engine_rule="check-license-commonalities-consistency",
-                        level="error",
-                        message=(
-                            f"info.license in {api.spec_file} differs from "
-                            f"{first_api}"
-                        ),
-                        path=api.spec_file,
-                        line=1,
-                        api_name=api.api_name,
-                    )
-                )
-
-        if commonalities_val is not None and first_commonalities is not None:
-            if commonalities_val != first_commonalities:
-                findings.append(
-                    make_finding(
-                        engine_rule="check-license-commonalities-consistency",
-                        level="error",
-                        message=(
-                            f"info.x-camara-commonalities in {api.spec_file} "
-                            f"differs from {first_api}"
-                        ),
-                        path=api.spec_file,
-                        line=1,
-                        api_name=api.api_name,
-                    )
-                )
-
-    return findings
+    return []

--- a/validation/engines/python_checks/release_plan_checks.py
+++ b/validation/engines/python_checks/release_plan_checks.py
@@ -274,3 +274,58 @@ def check_release_plan_semantics(
     findings.extend(_check_file_existence(release_plan, repo_path))
 
     return findings
+
+
+# ---------------------------------------------------------------------------
+# P-019 (NEW-003): Orphan API definitions
+# ---------------------------------------------------------------------------
+
+
+def check_orphan_api_definitions(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Detect YAML files in API_definitions not listed in release-plan.yaml.
+
+    Repo-level check.  Compares YAML file stems in
+    ``code/API_definitions/`` against API names declared in
+    ``release-plan.yaml``.  Files not in the release plan are flagged
+    as potential orphans or naming mismatches.
+    """
+    plan_path = repo_path / _RELEASE_PLAN_PATH
+    release_plan = load_yaml_safe(plan_path)
+    if release_plan is None:
+        return []
+
+    api_dir = repo_path / "code" / "API_definitions"
+    if not api_dir.is_dir():
+        return []
+
+    # Declared API names from release plan
+    apis = release_plan.get("apis", [])
+    declared_names = {
+        api.get("api_name")
+        for api in apis
+        if isinstance(api, dict) and api.get("api_name")
+    }
+
+    # YAML files on disk
+    existing_stems = {
+        f.stem for f in api_dir.iterdir()
+        if f.suffix == ".yaml" and f.is_file()
+    }
+
+    orphans = sorted(existing_stems - declared_names)
+
+    return [
+        make_finding(
+            engine_rule="check-orphan-api-definitions",
+            level="warn",
+            message=(
+                f"API definition file '{name}.yaml' is not listed in "
+                f"release-plan.yaml — possible orphan or naming mismatch"
+            ),
+            path=f"code/API_definitions/{name}.yaml",
+            line=1,
+        )
+        for name in orphans
+    ]

--- a/validation/engines/python_checks/subscription_checks.py
+++ b/validation/engines/python_checks/subscription_checks.py
@@ -1,0 +1,222 @@
+"""Subscription API checks.
+
+Validates naming conventions, event type formats, and response schema
+constraints specific to CAMARA subscription APIs.
+
+Design doc references:
+  - Event Subscription Guide section 2.2: explicit subscription naming
+  - Event Subscription Guide section 2.3: event type format
+  - Event Subscription Guide section 2.2.3: sinkCredential in responses
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+from validation.context import ValidationContext
+
+from ._spec_helpers import (
+    collect_schema_properties,
+    extract_event_types_from_spec,
+    iter_response_schemas,
+    resolve_local_ref,
+)
+from ._types import load_yaml_safe, make_finding
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Event type format: org.camaraproject.<api-name>.<vN>.<event-name>
+_EVENT_TYPE_RE = re.compile(
+    r"^org\.camaraproject\."
+    r"(?P<api_name>[a-z0-9][a-z0-9-]*)"
+    r"\.(?P<event_version>v\d+)"
+    r"\.(?P<event_name>[a-z][a-z0-9-]*)$"
+)
+
+
+# ---------------------------------------------------------------------------
+# P-014 (DG-088): check-subscription-filename
+# ---------------------------------------------------------------------------
+
+
+def check_subscription_filename(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate subscription API filename ends with '-subscriptions'.
+
+    Event Subscription Guide section 2.2: "it is mandatory to append
+    the keyword 'subscriptions' at the end of the API name."
+
+    Only applies to explicit-subscription APIs.
+    """
+    api = context.apis[0]
+
+    if api.api_pattern != "explicit-subscription":
+        return []
+
+    if api.api_name.endswith("-subscriptions"):
+        return []
+
+    return [
+        make_finding(
+            engine_rule="check-subscription-filename",
+            level="warn",
+            message=(
+                f"Explicit subscription API name '{api.api_name}' should "
+                f"end with '-subscriptions' (e.g. "
+                f"'{api.api_name}-subscriptions')"
+            ),
+            path=api.spec_file,
+            line=1,
+            api_name=api.api_name,
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# P-015 (DG-086): check-event-type-format
+# ---------------------------------------------------------------------------
+
+
+def check_event_type_format(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate event type values follow the CAMARA format.
+
+    Event Subscription Guide section 2.3: event type MUST follow
+    ``org.camaraproject.<api-name>.<event-version>.<event-name>``.
+    Event version format is ``vN`` (v0, v1, etc.).
+
+    Applies to explicit-subscription and implicit-subscription APIs.
+    """
+    api = context.apis[0]
+
+    if api.api_pattern not in ("explicit-subscription", "implicit-subscription"):
+        return []
+
+    spec = load_yaml_safe(repo_path / api.spec_file)
+    if spec is None:
+        return []
+
+    event_types = extract_event_types_from_spec(spec)
+    if not event_types:
+        return [
+            make_finding(
+                engine_rule="check-event-type-format",
+                level="hint",
+                message=(
+                    f"No event type enum values found in {api.spec_file} "
+                    f"— subscription APIs should define EventType schemas"
+                ),
+                path=api.spec_file,
+                line=1,
+                api_name=api.api_name,
+            )
+        ]
+
+    findings: List[dict] = []
+    for event_type in event_types:
+        m = _EVENT_TYPE_RE.match(event_type)
+        if m is None:
+            findings.append(
+                make_finding(
+                    engine_rule="check-event-type-format",
+                    level="error",
+                    message=(
+                        f"Event type '{event_type}' does not match expected "
+                        f"format 'org.camaraproject.<api-name>.<vN>.<event-name>'"
+                    ),
+                    path=api.spec_file,
+                    line=1,
+                    api_name=api.api_name,
+                )
+            )
+            continue
+
+        # Verify api-name segment matches the API name from context
+        type_api_name = m.group("api_name")
+        if type_api_name != api.api_name:
+            findings.append(
+                make_finding(
+                    engine_rule="check-event-type-format",
+                    level="error",
+                    message=(
+                        f"Event type '{event_type}' has api-name segment "
+                        f"'{type_api_name}' which does not match API name "
+                        f"'{api.api_name}'"
+                    ),
+                    path=api.spec_file,
+                    line=1,
+                    api_name=api.api_name,
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# P-016 (DG-092): check-sinkcredential-not-in-response
+# ---------------------------------------------------------------------------
+
+
+def check_sinkcredential_not_in_response(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate sinkCredential does not appear in subscription responses.
+
+    Event Subscription Guide section 2.2.3: "The sinkCredential MUST
+    NOT be present in POST and GET responses."
+
+    Inspects 2xx response schemas for paths containing ``/subscriptions``
+    and checks for ``sinkCredential`` in their properties (including
+    ``allOf`` compositions).
+    """
+    api = context.apis[0]
+
+    if api.api_pattern != "explicit-subscription":
+        return []
+
+    spec = load_yaml_safe(repo_path / api.spec_file)
+    if spec is None:
+        return []
+
+    findings: List[dict] = []
+    seen_schemas: set[str] = set()
+
+    for path, method, status_code, schema in iter_response_schemas(
+        spec, "/subscriptions"
+    ):
+        # Only check 2xx success responses
+        if not status_code.startswith("2"):
+            continue
+
+        # Collect properties from the resolved schema
+        all_props = collect_schema_properties(spec, schema)
+        if "sinkCredential" in all_props:
+            # Deduplicate: same underlying schema may appear in multiple
+            # responses (e.g. POST 201 and GET 200 both use Subscription)
+            schema_id = id(schema)
+            if schema_id in seen_schemas:
+                continue
+            seen_schemas.add(schema_id)
+
+            findings.append(
+                make_finding(
+                    engine_rule="check-sinkcredential-not-in-response",
+                    level="error",
+                    message=(
+                        f"sinkCredential found in {method.upper()} "
+                        f"{path} {status_code} response schema — "
+                        f"sinkCredential MUST NOT appear in responses"
+                    ),
+                    path=api.spec_file,
+                    line=1,
+                    api_name=api.api_name,
+                )
+            )
+
+    return findings

--- a/validation/orchestrator.py
+++ b/validation/orchestrator.py
@@ -86,6 +86,7 @@ class OrchestratorArgs:
     workflow_run_url: str
     tooling_ref: str
     commit_sha: str
+    commonalities_version: Optional[str]
 
 
 def _env(name: str, default: str = "") -> str:
@@ -132,6 +133,7 @@ def parse_args() -> OrchestratorArgs:
         workflow_run_url=_env("WORKFLOW_RUN_URL"),
         tooling_ref=_env("TOOLING_REF"),
         commit_sha=_env("COMMIT_SHA"),
+        commonalities_version=_env("COMMONALITIES_VERSION") or None,
     )
 
 
@@ -429,6 +431,7 @@ def main() -> int:
         release_metadata_schema_path=paths.release_metadata_schema,
         workflow_run_url=args.workflow_run_url,
         tooling_ref=args.tooling_ref,
+        commonalities_version=args.commonalities_version,
     )
     logger.info(
         "Context: branch=%s trigger=%s profile=%s release_review=%s apis=%d",

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -94,12 +94,14 @@
   conditional_level:
     default: warn
 
-# P-011: check-license-commonalities-consistency (muted — likely to be retired)
+# P-011: check-commonalities-version (DG-028 rewrite)
+# Validates info.x-camara-commonalities presence and version format.
+# Error for missing or invalid format; warn for version mismatch.
 - id: P-011
   engine: python
-  engine_rule: check-license-commonalities-consistency
+  engine_rule: check-commonalities-version
   conditional_level:
-    default: muted
+    default: error
 
 # P-012: check-release-review-file-restriction
 - id: P-012

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -118,3 +118,61 @@
   engine_rule: check-readme-placeholder-removal
   conditional_level:
     default: warn
+
+# P-014: check-subscription-filename (DG-088)
+# Explicit subscription API names must end with '-subscriptions'.
+- id: P-014
+  engine: python
+  engine_rule: check-subscription-filename
+  applicability:
+    api_pattern: [explicit-subscription]
+  conditional_level:
+    default: warn
+
+# P-015: check-event-type-format (DG-086)
+# Event types must follow org.camaraproject.<api-name>.<vN>.<event-name>.
+- id: P-015
+  engine: python
+  engine_rule: check-event-type-format
+  applicability:
+    api_pattern: [explicit-subscription, implicit-subscription]
+  conditional_level:
+    default: error
+
+# P-016: check-sinkcredential-not-in-response (DG-092)
+# sinkCredential must not appear in subscription 2xx response schemas.
+- id: P-016
+  engine: python
+  engine_rule: check-sinkcredential-not-in-response
+  applicability:
+    api_pattern: [explicit-subscription]
+  conditional_level:
+    default: error
+
+# P-017: check-conflict-deprecated (DG-018)
+# CONFLICT error code is deprecated in Commonalities r4.x.
+- id: P-017
+  engine: python
+  engine_rule: check-conflict-deprecated
+  applicability:
+    commonalities_release: ">=r4.0"
+  conditional_level:
+    default: warn
+
+# P-018: check-contextcode-format (DG-011)
+# contextCode enum values should follow SCREAMING_SNAKE_CASE.
+- id: P-018
+  engine: python
+  engine_rule: check-contextcode-format
+  applicability:
+    commonalities_release: ">=r4.0"
+  conditional_level:
+    default: hint
+
+# P-019: check-orphan-api-definitions (NEW-003)
+# YAML files in API_definitions not listed in release-plan.yaml.
+- id: P-019
+  engine: python
+  engine_rule: check-orphan-api-definitions
+  conditional_level:
+    default: warn

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -11,18 +11,18 @@
 #   pending     — in open PRs, not yet merged
 
 version: 1
-generated: 2026-03-26
+generated: 2026-04-03
 
 summary:
-  total_implemented: 116
-  total_gap: 25
+  total_implemented: 123
+  total_gap: 17
   total_manual: 25
   total_pending: 0
   total_tested: 0
   by_engine:
     spectral: 66
     gherkin: 25
-    python: 12
+    python: 19
     yamllint: 13
 
 # ---------------------------------------------------------------------------
@@ -77,16 +77,6 @@ gap_rules:
     priority: medium
     notes: Value check (not just presence). Spectral license-url only checks existence. Previously v0_6 (V6-006)
 
-  - audit_id: DG-028
-    description: x-camara-commonalities MUST specify valid version
-    target_engine: python
-    priority: medium
-    notes: >
-      Rewrite P-011. Presence check + value validation. On main: wip, tbd,
-      X.Y (e.g. 0.7), or X.Y.Z (e.g. 0.7.0) allowed — if X.Y/X.Y.Z then
-      must match declared commonalities_release. On release: real version
-      required, must match commonalities_release. Previously v0_6 (V6-007)
-
   - audit_id: DG-015
     description: "API-specific error: API_NAME.SPECIFIC_CODE format"
     target_engine: spectral
@@ -137,42 +127,57 @@ gap_rules:
     priority: low
     notes: api_pattern subscription only
 
-  # Python gaps (new checks needed)
+  # Python gaps — implemented in Phase 2b
   - audit_id: DG-011
     description: contextCode SCREAMING_SNAKE_CASE format (r4.x)
     target_engine: python
-    priority: low
+    status: implemented
+    rule_id: P-018
 
   - audit_id: DG-018
     description: CONFLICT error code deprecated (r4.x)
     target_engine: python
-    priority: low
+    status: implemented
+    rule_id: P-017
+
+  - audit_id: DG-028
+    description: x-camara-commonalities MUST specify valid version
+    target_engine: python
+    status: implemented
+    rule_id: P-011
+    notes: Rewrite of original P-011 (license/commonalities consistency)
 
   - audit_id: DG-086
     description: Event type format org.camaraproject validation (subscription)
     target_engine: python
-    priority: medium
+    status: implemented
+    rule_id: P-015
 
   - audit_id: DG-088
     description: Subscription API filename convention
     target_engine: python
-    priority: medium
+    status: implemented
+    rule_id: P-014
 
   - audit_id: DG-092
     description: sinkCredential not in responses
     target_engine: python
-    priority: medium
+    status: implemented
+    rule_id: P-016
 
+  # Python gaps — deferred
   - audit_id: DG-095
     description: Event version independence from API version
     target_engine: python
-    priority: low
+    status: deferred
+    notes: "No actionable static check — event version format already validated by P-015 (DG-086)"
 
   # New rules (not from audit — identified during implementation)
   - audit_id: NEW-001
     description: README.md placeholder must be removed from API_definitions/ when spec files are present
     target_engine: python
-    priority: medium
+    status: implemented
+    rule_id: P-013
 
   - audit_id: NEW-002
     description: "apiRoot variable: default and description MUST match Design Guide values"
@@ -183,8 +188,8 @@ gap_rules:
   - audit_id: NEW-003
     description: "Orphan API definitions: YAML files in code/API_definitions/ not listed in release-plan.yaml"
     target_engine: python
-    priority: low
-    notes: "Compare filenames against release-plan.yaml APIs. Also detect missing files (declared but absent)."
+    status: implemented
+    rule_id: P-019
 
 # ---------------------------------------------------------------------------
 # Fixes needed — implemented rules with incorrect behavior

--- a/validation/tests/test_context_builder.py
+++ b/validation/tests/test_context_builder.py
@@ -211,6 +211,7 @@ class TestValidationContextToDict:
             stage="enabled",
             target_release_type="pre-release-rc",
             commonalities_release="r4.1",
+            commonalities_version=None,
             icm_release=None,
             base_ref="main",
             is_release_review_pr=False,
@@ -234,7 +235,8 @@ class TestValidationContextToDict:
         d = sample_context.to_dict()
         expected_keys = {
             "repository", "branch_type", "trigger_type", "profile", "stage",
-            "target_release_type", "commonalities_release", "icm_release",
+            "target_release_type", "commonalities_release",
+            "commonalities_version", "icm_release",
             "base_ref", "is_release_review_pr", "release_plan_changed",
             "pr_number", "apis", "workflow_run_url", "tooling_ref",
         }

--- a/validation/tests/test_output_check_run.py
+++ b/validation/tests/test_output_check_run.py
@@ -28,6 +28,7 @@ def _make_context(
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_output_commit_status.py
+++ b/validation/tests/test_output_commit_status.py
@@ -27,6 +27,7 @@ def _make_context(
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_output_diagnostics.py
+++ b/validation/tests/test_output_diagnostics.py
@@ -24,6 +24,7 @@ def _make_context() -> ValidationContext:
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_output_pr_comment.py
+++ b/validation/tests/test_output_pr_comment.py
@@ -24,6 +24,7 @@ def _make_context(
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -31,6 +31,7 @@ def _make_context(
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_postfilter_conditions.py
+++ b/validation/tests/test_postfilter_conditions.py
@@ -36,6 +36,7 @@ def _make_context(
         stage="enabled",
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=is_release_review_pr,

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -39,6 +39,7 @@ def _make_context(
         stage="enabled",
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=is_release_review_pr,

--- a/validation/tests/test_postfilter_levels.py
+++ b/validation/tests/test_postfilter_levels.py
@@ -36,6 +36,7 @@ def _make_context(
         stage="enabled",
         target_release_type=target_release_type,
         commonalities_release=commonalities_release,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_adapter.py
+++ b/validation/tests/test_python_adapter.py
@@ -34,6 +34,7 @@ def _make_context(
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_checks_changelog.py
+++ b/validation/tests/test_python_checks_changelog.py
@@ -36,6 +36,7 @@ def _make_context(
         stage="enabled",
         target_release_type=target_release_type,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_checks_error_codes.py
+++ b/validation/tests/test_python_checks_error_codes.py
@@ -1,0 +1,225 @@
+"""Unit tests for error code checks (P-017, P-018)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from validation.context import ApiContext, ValidationContext
+from validation.engines.python_checks.error_code_checks import (
+    check_conflict_deprecated,
+    check_contextcode_format,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_context(api_name: str = "quality-on-demand") -> ValidationContext:
+    api = ApiContext(
+        api_name=api_name,
+        target_api_version="1.0.0",
+        target_api_status="public",
+        target_api_maturity="stable",
+        api_pattern="request-response",
+        spec_file=f"code/API_definitions/{api_name}.yaml",
+    )
+    return ValidationContext(
+        repository="TestRepo",
+        branch_type="main",
+        trigger_type="dispatch",
+        profile="advisory",
+        stage="enabled",
+        target_release_type=None,
+        commonalities_release="r4.1",
+        commonalities_version=None,
+        icm_release=None,
+        base_ref=None,
+        is_release_review_pr=False,
+        release_plan_changed=None,
+        pr_number=None,
+        apis=(api,),
+        workflow_run_url="",
+        tooling_ref="",
+    )
+
+
+def _write_spec(
+    tmp_path: Path,
+    api_name: str = "quality-on-demand",
+    spec_content: dict | None = None,
+) -> None:
+    if spec_content is None:
+        spec_content = {"openapi": "3.0.3", "info": {"title": "Test", "version": "wip"}, "paths": {}}
+    spec_dir = tmp_path / "code" / "API_definitions"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / f"{api_name}.yaml").write_text(
+        yaml.dump(spec_content, default_flow_style=False), encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# P-017: check-conflict-deprecated
+# ---------------------------------------------------------------------------
+
+
+class TestCheckConflictDeprecated:
+    def test_no_conflict_ok(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {
+                "schemas": {
+                    "ErrorCode": {"type": "string", "enum": ["INVALID_ARGUMENT", "NOT_FOUND"]}
+                }
+            },
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        assert check_conflict_deprecated(tmp_path, _make_context()) == []
+
+    def test_conflict_in_enum_warn(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {
+                "schemas": {
+                    "ErrorInfo": {
+                        "type": "object",
+                        "properties": {
+                            "code": {"type": "string", "enum": ["INVALID_ARGUMENT", "CONFLICT"]},
+                        },
+                    }
+                }
+            },
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        findings = check_conflict_deprecated(tmp_path, _make_context())
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert "deprecated" in findings[0]["message"].lower()
+
+    def test_conflict_in_top_level_enum(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {
+                "schemas": {
+                    "Code409": {"type": "string", "enum": ["ABORTED", "ALREADY_EXISTS", "CONFLICT"]}
+                }
+            },
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        findings = check_conflict_deprecated(tmp_path, _make_context())
+        assert len(findings) >= 1
+        assert all(f["level"] == "warn" for f in findings)
+
+    def test_missing_spec(self, tmp_path: Path):
+        assert check_conflict_deprecated(tmp_path, _make_context()) == []
+
+    def test_no_schemas(self, tmp_path: Path):
+        spec = {"openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {}}
+        _write_spec(tmp_path, spec_content=spec)
+        assert check_conflict_deprecated(tmp_path, _make_context()) == []
+
+
+# ---------------------------------------------------------------------------
+# P-018: check-contextcode-format
+# ---------------------------------------------------------------------------
+
+
+class TestCheckContextcodeFormat:
+    def test_no_contextcode_ok(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {"schemas": {"Foo": {"properties": {"bar": {"type": "string"}}}}},
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        assert check_contextcode_format(tmp_path, _make_context()) == []
+
+    def test_valid_screaming_snake_ok(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {
+                "schemas": {
+                    "Outcome": {
+                        "properties": {
+                            "contextCode": {
+                                "type": "string",
+                                "enum": [
+                                    "COMMON.REGIONAL_PRIVACY_RESTRICTION",
+                                    "CARRIER_BILLING.PAYMENT_DENIED",
+                                    "NOT_AVAILABLE",
+                                ],
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        assert check_contextcode_format(tmp_path, _make_context()) == []
+
+    def test_invalid_camel_case_hint(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {
+                "schemas": {
+                    "Outcome": {
+                        "properties": {
+                            "contextCode": {
+                                "type": "string",
+                                "enum": ["apiName.specificCode", "VALID_CODE"],
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        findings = check_contextcode_format(tmp_path, _make_context())
+        assert len(findings) == 1
+        assert findings[0]["level"] == "hint"
+        assert "apiName.specificCode" in findings[0]["message"]
+
+    def test_contextcode_without_enum_hint(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {
+                "schemas": {
+                    "Outcome": {
+                        "properties": {
+                            "contextCode": {"type": "string"},
+                        }
+                    }
+                }
+            },
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        findings = check_contextcode_format(tmp_path, _make_context())
+        assert len(findings) == 1
+        assert findings[0]["level"] == "hint"
+        assert "no enum" in findings[0]["message"]
+
+    def test_missing_spec(self, tmp_path: Path):
+        assert check_contextcode_format(tmp_path, _make_context()) == []
+
+    def test_mixed_valid_invalid(self, tmp_path: Path):
+        spec = {
+            "openapi": "3.0.3", "info": {"title": "T", "version": "wip"}, "paths": {},
+            "components": {
+                "schemas": {
+                    "Outcome": {
+                        "properties": {
+                            "contextCode": {
+                                "type": "string",
+                                "enum": ["VALID_CODE", "invalid-code", "ALSO.VALID"],
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        _write_spec(tmp_path, spec_content=spec)
+        findings = check_contextcode_format(tmp_path, _make_context())
+        assert len(findings) == 1  # Only invalid-code
+        assert "invalid-code" in findings[0]["message"]

--- a/validation/tests/test_python_checks_filename.py
+++ b/validation/tests/test_python_checks_filename.py
@@ -35,6 +35,7 @@ def _make_context(api_name: str) -> ValidationContext:
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_checks_metadata.py
+++ b/validation/tests/test_python_checks_metadata.py
@@ -1,15 +1,15 @@
-"""Unit tests for validation.engines.python_checks.metadata_checks."""
+"""Unit tests for validation.engines.python_checks.metadata_checks (DG-028)."""
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
-import pytest
 import yaml
 
 from validation.context import ApiContext, ValidationContext
 from validation.engines.python_checks.metadata_checks import (
-    check_license_commonalities_consistency,
+    check_commonalities_version,
 )
 
 
@@ -18,34 +18,34 @@ from validation.engines.python_checks.metadata_checks import (
 # ---------------------------------------------------------------------------
 
 
-def _make_api(name: str) -> ApiContext:
-    return ApiContext(
-        api_name=name,
+def _make_context(
+    api_name: str = "quality-on-demand",
+    branch_type: str = "main",
+    commonalities_version: Optional[str] = None,
+) -> ValidationContext:
+    api = ApiContext(
+        api_name=api_name,
         target_api_version="1.0.0",
         target_api_status="public",
         target_api_maturity="stable",
         api_pattern="request-response",
-        spec_file=f"code/API_definitions/{name}.yaml",
+        spec_file=f"code/API_definitions/{api_name}.yaml",
     )
-
-
-def _make_context(api_names: list[str]) -> ValidationContext:
-    apis = tuple(_make_api(n) for n in api_names)
     return ValidationContext(
         repository="TestRepo",
-        branch_type="main",
+        branch_type=branch_type,
         trigger_type="dispatch",
         profile="advisory",
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
-        commonalities_version=None,
+        commonalities_version=commonalities_version,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,
         release_plan_changed=None,
         pr_number=None,
-        apis=apis,
+        apis=(api,),
         workflow_run_url="",
         tooling_ref="",
     )
@@ -53,27 +53,26 @@ def _make_context(api_names: list[str]) -> ValidationContext:
 
 def _write_spec(
     tmp_path: Path,
-    api_name: str,
-    license_val: dict | None = None,
-    commonalities_val: str | None = None,
+    api_name: str = "quality-on-demand",
+    commonalities_value: object = "0.7.0",
+    include_field: bool = True,
 ) -> None:
     spec: dict = {
         "openapi": "3.0.3",
-        "info": {"title": api_name, "version": "1.0.0"},
+        "info": {
+            "title": "Test API",
+            "version": "1.0.0",
+        },
+        "paths": {},
     }
-    if license_val is not None:
-        spec["info"]["license"] = license_val
-    if commonalities_val is not None:
-        spec["info"]["x-camara-commonalities"] = commonalities_val
-    api_dir = tmp_path / "code" / "API_definitions"
-    api_dir.mkdir(parents=True, exist_ok=True)
-    (api_dir / f"{api_name}.yaml").write_text(
-        yaml.dump(spec, default_flow_style=False)
+    if include_field:
+        spec["info"]["x-camara-commonalities"] = commonalities_value
+
+    spec_dir = tmp_path / "code" / "API_definitions"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / f"{api_name}.yaml").write_text(
+        yaml.dump(spec, default_flow_style=False), encoding="utf-8"
     )
-
-
-LICENSE_A = {"name": "Apache 2.0", "url": "https://www.apache.org/licenses/LICENSE-2.0"}
-LICENSE_B = {"name": "MIT", "url": "https://opensource.org/licenses/MIT"}
 
 
 # ---------------------------------------------------------------------------
@@ -81,61 +80,181 @@ LICENSE_B = {"name": "MIT", "url": "https://opensource.org/licenses/MIT"}
 # ---------------------------------------------------------------------------
 
 
-class TestCheckLicenseCommonalitiesConsistency:
-    def test_no_apis(self, tmp_path: Path):
-        ctx = _make_context([])
-        assert check_license_commonalities_consistency(tmp_path, ctx) == []
+class TestCheckCommonalitiesVersion:
 
-    def test_single_api_all_present(self, tmp_path: Path):
-        _write_spec(tmp_path, "qod", license_val=LICENSE_A, commonalities_val="r4.1")
-        ctx = _make_context(["qod"])
-        assert check_license_commonalities_consistency(tmp_path, ctx) == []
+    # --- Presence ---
 
-    def test_single_api_missing_license(self, tmp_path: Path):
-        _write_spec(tmp_path, "qod", commonalities_val="r4.1")
-        ctx = _make_context(["qod"])
-        findings = check_license_commonalities_consistency(tmp_path, ctx)
+    def test_missing_field_error(self, tmp_path: Path):
+        _write_spec(tmp_path, include_field=False)
+        ctx = _make_context()
+        findings = check_commonalities_version(tmp_path, ctx)
         assert len(findings) == 1
-        assert "license" in findings[0]["message"]
+        assert findings[0]["level"] == "error"
+        assert "missing" in findings[0]["message"]
 
-    def test_single_api_missing_commonalities(self, tmp_path: Path):
-        _write_spec(tmp_path, "qod", license_val=LICENSE_A)
-        ctx = _make_context(["qod"])
-        findings = check_license_commonalities_consistency(tmp_path, ctx)
+    def test_missing_field_error_on_release(self, tmp_path: Path):
+        _write_spec(tmp_path, include_field=False)
+        ctx = _make_context(branch_type="release")
+        findings = check_commonalities_version(tmp_path, ctx)
         assert len(findings) == 1
-        assert "x-camara-commonalities" in findings[0]["message"]
+        assert findings[0]["level"] == "error"
 
-    def test_single_api_both_missing(self, tmp_path: Path):
-        _write_spec(tmp_path, "qod")
-        ctx = _make_context(["qod"])
-        findings = check_license_commonalities_consistency(tmp_path, ctx)
-        assert len(findings) == 2
+    # --- Main branch: valid formats ---
 
-    def test_two_apis_consistent(self, tmp_path: Path):
-        _write_spec(tmp_path, "api-a", license_val=LICENSE_A, commonalities_val="r4.1")
-        _write_spec(tmp_path, "api-b", license_val=LICENSE_A, commonalities_val="r4.1")
-        ctx = _make_context(["api-a", "api-b"])
-        assert check_license_commonalities_consistency(tmp_path, ctx) == []
+    def test_wip_on_main_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="wip")
+        ctx = _make_context(branch_type="main")
+        assert check_commonalities_version(tmp_path, ctx) == []
 
-    def test_two_apis_license_mismatch(self, tmp_path: Path):
-        _write_spec(tmp_path, "api-a", license_val=LICENSE_A, commonalities_val="r4.1")
-        _write_spec(tmp_path, "api-b", license_val=LICENSE_B, commonalities_val="r4.1")
-        ctx = _make_context(["api-a", "api-b"])
-        findings = check_license_commonalities_consistency(tmp_path, ctx)
+    def test_tbd_on_main_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="tbd")
+        ctx = _make_context(branch_type="main")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_short_version_on_main_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7")
+        ctx = _make_context(branch_type="main")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_full_version_on_main_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7.0")
+        ctx = _make_context(branch_type="main")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_prerelease_on_main_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7.0-rc.1")
+        ctx = _make_context(branch_type="main")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    # --- Main branch: invalid formats ---
+
+    def test_garbage_on_main_error(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="foo")
+        ctx = _make_context(branch_type="main")
+        findings = check_commonalities_version(tmp_path, ctx)
         assert len(findings) == 1
-        assert "license" in findings[0]["message"]
-        assert "differs" in findings[0]["message"]
+        assert findings[0]["level"] == "error"
+        assert "invalid format" in findings[0]["message"]
 
-    def test_two_apis_commonalities_mismatch(self, tmp_path: Path):
-        _write_spec(tmp_path, "api-a", license_val=LICENSE_A, commonalities_val="r4.1")
-        _write_spec(tmp_path, "api-b", license_val=LICENSE_A, commonalities_val="r3.4")
-        ctx = _make_context(["api-a", "api-b"])
-        findings = check_license_commonalities_consistency(tmp_path, ctx)
+    def test_empty_string_on_main_error(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="")
+        ctx = _make_context(branch_type="main")
+        findings = check_commonalities_version(tmp_path, ctx)
         assert len(findings) == 1
-        assert "x-camara-commonalities" in findings[0]["message"]
-        assert "differs" in findings[0]["message"]
+        assert findings[0]["level"] == "error"
 
-    def test_missing_spec_file_skipped(self, tmp_path: Path):
-        """Missing spec file is silently skipped (filename check reports)."""
-        ctx = _make_context(["qod"])
-        assert check_license_commonalities_consistency(tmp_path, ctx) == []
+    # --- Feature branch: same as main ---
+
+    def test_wip_on_feature_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="wip")
+        ctx = _make_context(branch_type="feature")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_full_version_on_feature_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7.0")
+        ctx = _make_context(branch_type="feature")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_garbage_on_feature_error(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="xyz")
+        ctx = _make_context(branch_type="feature")
+        findings = check_commonalities_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+
+    # --- Release branch: valid formats ---
+
+    def test_full_version_on_release_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7.0")
+        ctx = _make_context(branch_type="release")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_prerelease_on_release_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7.0-rc.1")
+        ctx = _make_context(branch_type="release")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    # --- Release branch: invalid formats ---
+
+    def test_wip_on_release_error(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="wip")
+        ctx = _make_context(branch_type="release")
+        findings = check_commonalities_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert "full version" in findings[0]["message"]
+
+    def test_tbd_on_release_error(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="tbd")
+        ctx = _make_context(branch_type="release")
+        findings = check_commonalities_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+
+    def test_short_version_on_release_error(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7")
+        ctx = _make_context(branch_type="release")
+        findings = check_commonalities_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+
+    # --- Maintenance branch: same as release ---
+
+    def test_wip_on_maintenance_error(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="wip")
+        ctx = _make_context(branch_type="maintenance")
+        findings = check_commonalities_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+
+    # --- Version mismatch ---
+
+    def test_version_match_ok(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.7.0")
+        ctx = _make_context(commonalities_version="0.7.0")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_version_mismatch_warn(self, tmp_path: Path):
+        _write_spec(tmp_path, commonalities_value="0.6.0")
+        ctx = _make_context(commonalities_version="0.7.0")
+        findings = check_commonalities_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert "does not match" in findings[0]["message"]
+
+    def test_short_version_matches_full(self, tmp_path: Path):
+        """Short form 0.7 should match 0.7.0."""
+        _write_spec(tmp_path, commonalities_value="0.7")
+        ctx = _make_context(commonalities_version="0.7.0")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_prerelease_matches_exact(self, tmp_path: Path):
+        """0.7.0-rc.1 in spec matches 0.7.0-rc.1 from context."""
+        _write_spec(tmp_path, commonalities_value="0.7.0-rc.1")
+        ctx = _make_context(commonalities_version="0.7.0-rc.1")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_no_commonalities_version_skips_mismatch(self, tmp_path: Path):
+        """When context has no commonalities_version, skip mismatch check."""
+        _write_spec(tmp_path, commonalities_value="0.7.0")
+        ctx = _make_context(commonalities_version=None)
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_wip_skips_mismatch_check(self, tmp_path: Path):
+        """Placeholder values don't trigger mismatch check."""
+        _write_spec(tmp_path, commonalities_value="wip")
+        ctx = _make_context(commonalities_version="0.7.0")
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    # --- Edge cases ---
+
+    def test_missing_spec_file(self, tmp_path: Path):
+        ctx = _make_context()
+        assert check_commonalities_version(tmp_path, ctx) == []
+
+    def test_numeric_value(self, tmp_path: Path):
+        """YAML may parse bare 0.7 as float — should be handled via str()."""
+        _write_spec(tmp_path, commonalities_value=0.7)
+        ctx = _make_context(branch_type="main")
+        # 0.7 as float becomes "0.7" as string — valid short form
+        assert check_commonalities_version(tmp_path, ctx) == []

--- a/validation/tests/test_python_checks_metadata.py
+++ b/validation/tests/test_python_checks_metadata.py
@@ -39,6 +39,7 @@ def _make_context(api_names: list[str]) -> ValidationContext:
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_checks_readme.py
+++ b/validation/tests/test_python_checks_readme.py
@@ -24,6 +24,7 @@ def _make_context() -> ValidationContext:
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_checks_release_plan.py
+++ b/validation/tests/test_python_checks_release_plan.py
@@ -13,6 +13,7 @@ from validation.engines.python_checks.release_plan_checks import (
     _check_file_existence,
     _check_release_type_consistency,
     _check_track_consistency,
+    check_orphan_api_definitions,
     check_release_plan_semantics,
 )
 
@@ -254,3 +255,60 @@ class TestCheckReleasePlanSemantics:
         findings = check_release_plan_semantics(tmp_path, ctx)
         # meta_release missing (track) + draft in public-release (type) = 2
         assert len(findings) >= 2
+
+
+# ---------------------------------------------------------------------------
+# P-019: check-orphan-api-definitions
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOrphanApiDefinitions:
+    def test_no_orphans(self, tmp_path: Path):
+        plan = _make_plan(apis=[{"api_name": "qod", "target_api_status": "alpha"}])
+        _write_release_plan(tmp_path, plan)
+        api_dir = tmp_path / "code" / "API_definitions"
+        api_dir.mkdir(parents=True)
+        (api_dir / "qod.yaml").touch()
+        findings = check_orphan_api_definitions(tmp_path, _make_context())
+        assert findings == []
+
+    def test_orphan_file_warn(self, tmp_path: Path):
+        plan = _make_plan(apis=[{"api_name": "qod", "target_api_status": "alpha"}])
+        _write_release_plan(tmp_path, plan)
+        api_dir = tmp_path / "code" / "API_definitions"
+        api_dir.mkdir(parents=True)
+        (api_dir / "qod.yaml").touch()
+        (api_dir / "old-api.yaml").touch()
+        findings = check_orphan_api_definitions(tmp_path, _make_context())
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert "old-api" in findings[0]["message"]
+
+    def test_multiple_orphans(self, tmp_path: Path):
+        plan = _make_plan(apis=[{"api_name": "qod", "target_api_status": "alpha"}])
+        _write_release_plan(tmp_path, plan)
+        api_dir = tmp_path / "code" / "API_definitions"
+        api_dir.mkdir(parents=True)
+        (api_dir / "qod.yaml").touch()
+        (api_dir / "orphan-a.yaml").touch()
+        (api_dir / "orphan-b.yaml").touch()
+        findings = check_orphan_api_definitions(tmp_path, _make_context())
+        assert len(findings) == 2
+
+    def test_no_release_plan(self, tmp_path: Path):
+        assert check_orphan_api_definitions(tmp_path, _make_context()) == []
+
+    def test_no_api_definitions_dir(self, tmp_path: Path):
+        plan = _make_plan(apis=[{"api_name": "qod", "target_api_status": "alpha"}])
+        _write_release_plan(tmp_path, plan)
+        assert check_orphan_api_definitions(tmp_path, _make_context()) == []
+
+    def test_non_yaml_files_ignored(self, tmp_path: Path):
+        plan = _make_plan(apis=[{"api_name": "qod", "target_api_status": "alpha"}])
+        _write_release_plan(tmp_path, plan)
+        api_dir = tmp_path / "code" / "API_definitions"
+        api_dir.mkdir(parents=True)
+        (api_dir / "qod.yaml").touch()
+        (api_dir / "README.md").touch()
+        findings = check_orphan_api_definitions(tmp_path, _make_context())
+        assert findings == []

--- a/validation/tests/test_python_checks_release_plan.py
+++ b/validation/tests/test_python_checks_release_plan.py
@@ -31,6 +31,7 @@ def _make_context() -> ValidationContext:
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_checks_release_review.py
+++ b/validation/tests/test_python_checks_release_review.py
@@ -31,6 +31,7 @@ def _make_context(
         stage="enabled",
         target_release_type="public-release",
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=base_ref,
         is_release_review_pr=is_release_review,

--- a/validation/tests/test_python_checks_subscription.py
+++ b/validation/tests/test_python_checks_subscription.py
@@ -1,0 +1,394 @@
+"""Unit tests for subscription checks (P-014, P-015, P-016)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from validation.context import ApiContext, ValidationContext
+from validation.engines.python_checks.subscription_checks import (
+    check_event_type_format,
+    check_sinkcredential_not_in_response,
+    check_subscription_filename,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_context(
+    api_name: str = "device-status-subscriptions",
+    api_pattern: str = "explicit-subscription",
+) -> ValidationContext:
+    api = ApiContext(
+        api_name=api_name,
+        target_api_version="0.1.0",
+        target_api_status="alpha",
+        target_api_maturity="initial",
+        api_pattern=api_pattern,
+        spec_file=f"code/API_definitions/{api_name}.yaml",
+    )
+    return ValidationContext(
+        repository="TestRepo",
+        branch_type="main",
+        trigger_type="dispatch",
+        profile="advisory",
+        stage="enabled",
+        target_release_type=None,
+        commonalities_release=None,
+        commonalities_version=None,
+        icm_release=None,
+        base_ref=None,
+        is_release_review_pr=False,
+        release_plan_changed=None,
+        pr_number=None,
+        apis=(api,),
+        workflow_run_url="",
+        tooling_ref="",
+    )
+
+
+def _write_spec(
+    tmp_path: Path,
+    api_name: str = "device-status-subscriptions",
+    spec_content: dict | None = None,
+) -> None:
+    if spec_content is None:
+        spec_content = {"openapi": "3.0.3", "info": {"title": "Test", "version": "wip"}, "paths": {}}
+
+    spec_dir = tmp_path / "code" / "API_definitions"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / f"{api_name}.yaml").write_text(
+        yaml.dump(spec_content, default_flow_style=False), encoding="utf-8"
+    )
+
+
+def _subscription_spec_with_events(
+    api_name: str,
+    event_types: list[str],
+) -> dict:
+    """Build a minimal subscription spec with event type enums."""
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Test", "version": "wip"},
+        "paths": {"/subscriptions": {"post": {"responses": {"201": {}}}}},
+        "components": {
+            "schemas": {
+                "SubscriptionEventType": {
+                    "type": "string",
+                    "enum": event_types,
+                }
+            }
+        },
+    }
+
+
+def _subscription_spec_with_response(
+    response_properties: dict,
+) -> dict:
+    """Build a subscription spec with a response schema."""
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Test", "version": "wip"},
+        "paths": {
+            "/subscriptions": {
+                "post": {
+                    "responses": {
+                        "201": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Subscription"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Subscription": {
+                    "type": "object",
+                    "properties": response_properties,
+                }
+            }
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# P-014: check-subscription-filename
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSubscriptionFilename:
+    def test_explicit_with_suffix_ok(self, tmp_path: Path):
+        ctx = _make_context(api_name="device-status-subscriptions")
+        assert check_subscription_filename(tmp_path, ctx) == []
+
+    def test_explicit_without_suffix_warn(self, tmp_path: Path):
+        ctx = _make_context(api_name="device-status")
+        findings = check_subscription_filename(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert "-subscriptions" in findings[0]["message"]
+
+    def test_implicit_no_suffix_ok(self, tmp_path: Path):
+        ctx = _make_context(api_name="device-status", api_pattern="implicit-subscription")
+        assert check_subscription_filename(tmp_path, ctx) == []
+
+    def test_request_response_skip(self, tmp_path: Path):
+        ctx = _make_context(api_name="device-status", api_pattern="request-response")
+        assert check_subscription_filename(tmp_path, ctx) == []
+
+
+# ---------------------------------------------------------------------------
+# P-015: check-event-type-format
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEventTypeFormat:
+    def test_valid_event_types(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_events(api_name, [
+            f"org.camaraproject.{api_name}.v0.status-changed",
+            f"org.camaraproject.{api_name}.v0.subscription-ended",
+        ])
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_event_type_format(tmp_path, ctx) == []
+
+    def test_wrong_api_name_error(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_events(api_name, [
+            "org.camaraproject.wrong-api.v0.status-changed",
+        ])
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_event_type_format(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert "does not match" in findings[0]["message"]
+
+    def test_missing_version_error(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_events(api_name, [
+            f"org.camaraproject.{api_name}.status-changed",
+        ])
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_event_type_format(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+
+    def test_invalid_version_format_error(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_events(api_name, [
+            f"org.camaraproject.{api_name}.version1.status-changed",
+        ])
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_event_type_format(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+
+    def test_non_subscription_skip(self, tmp_path: Path):
+        ctx = _make_context(api_pattern="request-response")
+        assert check_event_type_format(tmp_path, ctx) == []
+
+    def test_no_event_types_hint(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        _write_spec(tmp_path, api_name=api_name)
+        ctx = _make_context(api_name=api_name)
+        findings = check_event_type_format(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "hint"
+
+    def test_mixed_valid_invalid(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_events(api_name, [
+            f"org.camaraproject.{api_name}.v0.status-changed",
+            "invalid-event-type",
+        ])
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_event_type_format(tmp_path, ctx)
+        assert len(findings) == 1  # Only the invalid one
+        assert "invalid-event-type" in findings[0]["message"]
+
+    def test_implicit_subscription_checked(self, tmp_path: Path):
+        api_name = "device-status"
+        spec = _subscription_spec_with_events(api_name, [
+            f"org.camaraproject.{api_name}.v0.status-changed",
+        ])
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name, api_pattern="implicit-subscription")
+        assert check_event_type_format(tmp_path, ctx) == []
+
+    def test_missing_spec_file(self, tmp_path: Path):
+        ctx = _make_context()
+        assert check_event_type_format(tmp_path, ctx) == []
+
+
+# ---------------------------------------------------------------------------
+# P-016: check-sinkcredential-not-in-response
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSinkCredentialNotInResponse:
+    def test_clean_response_ok(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_response({
+            "id": {"type": "string"},
+            "sink": {"type": "string"},
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+
+    def test_sinkcredential_in_response_error(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_response({
+            "id": {"type": "string"},
+            "sink": {"type": "string"},
+            "sinkCredential": {"$ref": "#/components/schemas/SinkCredential"},
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_sinkcredential_not_in_response(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert "sinkCredential" in findings[0]["message"]
+
+    def test_sinkcredential_in_request_only_ok(self, tmp_path: Path):
+        """sinkCredential in request schema but not in response — OK."""
+        api_name = "device-status-subscriptions"
+        spec = {
+            "openapi": "3.0.3",
+            "info": {"title": "Test", "version": "wip"},
+            "paths": {
+                "/subscriptions": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/SubscriptionRequest"}
+                                }
+                            }
+                        },
+                        "responses": {
+                            "201": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Subscription"}
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "SubscriptionRequest": {
+                        "type": "object",
+                        "properties": {
+                            "sink": {"type": "string"},
+                            "sinkCredential": {"type": "object"},
+                        },
+                    },
+                    "Subscription": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "sink": {"type": "string"},
+                        },
+                    },
+                }
+            },
+        }
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+
+    def test_non_subscription_skip(self, tmp_path: Path):
+        ctx = _make_context(api_pattern="request-response")
+        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+
+    def test_sinkcredential_via_allof_error(self, tmp_path: Path):
+        """sinkCredential inherited via allOf is still caught."""
+        api_name = "device-status-subscriptions"
+        spec = {
+            "openapi": "3.0.3",
+            "info": {"title": "Test", "version": "wip"},
+            "paths": {
+                "/subscriptions": {
+                    "post": {
+                        "responses": {
+                            "201": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Subscription"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "BaseSubscription": {
+                        "type": "object",
+                        "properties": {
+                            "sinkCredential": {"type": "object"},
+                        },
+                    },
+                    "Subscription": {
+                        "allOf": [
+                            {"$ref": "#/components/schemas/BaseSubscription"},
+                            {
+                                "type": "object",
+                                "properties": {"id": {"type": "string"}},
+                            },
+                        ]
+                    },
+                }
+            },
+        }
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_sinkcredential_not_in_response(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+
+    def test_missing_spec_file(self, tmp_path: Path):
+        ctx = _make_context()
+        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+
+    def test_no_subscription_paths_ok(self, tmp_path: Path):
+        """Spec has no /subscriptions path — no findings."""
+        api_name = "device-status-subscriptions"
+        spec = {"openapi": "3.0.3", "info": {"title": "Test", "version": "wip"}, "paths": {"/other": {}}}
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+
+    def test_external_ref_sinkcredential_detected(self, tmp_path: Path):
+        """sinkCredential with external $ref is still detected by name."""
+        api_name = "device-status-subscriptions"
+        spec = _subscription_spec_with_response({
+            "id": {"type": "string"},
+            "sinkCredential": {
+                "$ref": "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
+            },
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_sinkcredential_not_in_response(tmp_path, ctx)
+        assert len(findings) == 1

--- a/validation/tests/test_python_checks_test.py
+++ b/validation/tests/test_python_checks_test.py
@@ -43,6 +43,7 @@ def _make_context(
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -42,6 +42,7 @@ def _make_context(
         stage="enabled",
         target_release_type=None,
         commonalities_release=None,
+        commonalities_version=None,
         icm_release=None,
         base_ref=None,
         is_release_review_pr=False,

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 13
+        assert counts["python"] == 19
         assert counts["spectral"] == 66
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13

--- a/validation/tests/test_spec_helpers.py
+++ b/validation/tests/test_spec_helpers.py
@@ -1,0 +1,476 @@
+"""Unit tests for validation.engines.python_checks._spec_helpers."""
+
+from __future__ import annotations
+
+from validation.engines.python_checks._spec_helpers import (
+    collect_schema_properties,
+    extract_event_types_from_spec,
+    find_enum_value_in_schemas,
+    find_properties_by_name,
+    iter_response_schemas,
+    resolve_local_ref,
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_local_ref
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLocalRef:
+    def test_simple_ref(self):
+        spec = {"components": {"schemas": {"Foo": {"type": "object"}}}}
+        result = resolve_local_ref(spec, "#/components/schemas/Foo")
+        assert result == {"type": "object"}
+
+    def test_nested_ref(self):
+        spec = {"components": {"responses": {"NotFound": {"description": "nf"}}}}
+        result = resolve_local_ref(spec, "#/components/responses/NotFound")
+        assert result == {"description": "nf"}
+
+    def test_missing_path(self):
+        spec = {"components": {"schemas": {}}}
+        assert resolve_local_ref(spec, "#/components/schemas/Missing") is None
+
+    def test_external_ref(self):
+        assert resolve_local_ref({}, "../common/Foo.yaml#/bar") is None
+
+    def test_empty_ref(self):
+        assert resolve_local_ref({}, "") is None
+
+    def test_non_dict_target(self):
+        spec = {"components": {"schemas": {"Foo": "not-a-dict"}}}
+        assert resolve_local_ref(spec, "#/components/schemas/Foo") is None
+
+
+# ---------------------------------------------------------------------------
+# collect_schema_properties
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSchemaProperties:
+    def test_direct_properties(self):
+        spec = {}
+        schema = {"properties": {"name": {"type": "string"}, "age": {"type": "integer"}}}
+        props = collect_schema_properties(spec, schema)
+        assert set(props.keys()) == {"name", "age"}
+
+    def test_allof_inline(self):
+        spec = {}
+        schema = {
+            "allOf": [
+                {"properties": {"base": {"type": "string"}}},
+                {"properties": {"extra": {"type": "integer"}}},
+            ]
+        }
+        props = collect_schema_properties(spec, schema)
+        assert set(props.keys()) == {"base", "extra"}
+
+    def test_allof_with_ref(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Base": {"properties": {"id": {"type": "string"}}}
+                }
+            }
+        }
+        schema = {
+            "allOf": [
+                {"$ref": "#/components/schemas/Base"},
+                {"properties": {"extra": {"type": "integer"}}},
+            ]
+        }
+        props = collect_schema_properties(spec, schema)
+        assert set(props.keys()) == {"id", "extra"}
+
+    def test_mixed_direct_and_allof(self):
+        spec = {}
+        schema = {
+            "properties": {"direct": {"type": "string"}},
+            "allOf": [{"properties": {"composed": {"type": "integer"}}}],
+        }
+        props = collect_schema_properties(spec, schema)
+        assert set(props.keys()) == {"direct", "composed"}
+
+    def test_external_ref_in_allof(self):
+        """External $ref in allOf is skipped (returns None from resolve)."""
+        spec = {}
+        schema = {
+            "allOf": [
+                {"$ref": "../common/Foo.yaml#/components/schemas/Bar"},
+                {"properties": {"local": {"type": "string"}}},
+            ]
+        }
+        props = collect_schema_properties(spec, schema)
+        assert set(props.keys()) == {"local"}
+
+    def test_empty_schema(self):
+        assert collect_schema_properties({}, {}) == {}
+
+
+# ---------------------------------------------------------------------------
+# extract_event_types_from_spec
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEventTypes:
+    def test_subscription_event_type(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "SubscriptionEventType": {
+                        "type": "string",
+                        "enum": [
+                            "org.camaraproject.device-status.v0.roaming-on",
+                            "org.camaraproject.device-status.v0.roaming-off",
+                        ],
+                    }
+                }
+            }
+        }
+        result = extract_event_types_from_spec(spec)
+        assert len(result) == 2
+        assert "org.camaraproject.device-status.v0.roaming-on" in result
+
+    def test_multiple_event_type_schemas(self):
+        """Both SubscriptionEventType and EventTypeNotification are found."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "SubscriptionEventType": {
+                        "type": "string",
+                        "enum": ["org.camaraproject.foo.v0.bar"],
+                    },
+                    "EventTypeNotification": {
+                        "type": "string",
+                        "enum": [
+                            "org.camaraproject.foo.v0.bar",
+                            "org.camaraproject.foo.v0.subscription-ended",
+                        ],
+                    },
+                }
+            }
+        }
+        result = extract_event_types_from_spec(spec)
+        assert len(result) == 2  # deduplicated
+
+    def test_api_event_type_template_pattern(self):
+        """Template uses ApiEventType schema name."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "ApiEventType": {
+                        "type": "string",
+                        "enum": [
+                            "org.camaraproject.api-name.v0.event-type1",
+                            "org.camaraproject.api-name.v0.event-type2",
+                        ],
+                    },
+                    "SubscriptionLifecycleEventType": {
+                        "type": "string",
+                        "enum": [
+                            "org.camaraproject.api-name.v0.subscription-started",
+                            "org.camaraproject.api-name.v0.subscription-ended",
+                        ],
+                    },
+                }
+            }
+        }
+        result = extract_event_types_from_spec(spec)
+        assert len(result) == 4
+
+    def test_no_event_type_schemas(self):
+        spec = {"components": {"schemas": {"Foo": {"type": "object"}}}}
+        assert extract_event_types_from_spec(spec) == []
+
+    def test_no_components(self):
+        assert extract_event_types_from_spec({}) == []
+
+    def test_schema_without_enum(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "EventTypeNotification": {"type": "string"}
+                }
+            }
+        }
+        assert extract_event_types_from_spec(spec) == []
+
+
+# ---------------------------------------------------------------------------
+# find_enum_value_in_schemas
+# ---------------------------------------------------------------------------
+
+
+class TestFindEnumValueInSchemas:
+    def test_find_in_top_level_enum(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "ErrorCode": {"type": "string", "enum": ["INVALID", "CONFLICT", "NOT_FOUND"]}
+                }
+            }
+        }
+        results = find_enum_value_in_schemas(spec, "CONFLICT")
+        assert len(results) == 1
+        assert "ErrorCode" in results[0][0]
+
+    def test_find_in_nested_property(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "ErrorInfo": {
+                        "type": "object",
+                        "properties": {
+                            "code": {
+                                "type": "string",
+                                "enum": ["INVALID", "CONFLICT"],
+                            }
+                        },
+                    }
+                }
+            }
+        }
+        results = find_enum_value_in_schemas(spec, "CONFLICT")
+        assert len(results) == 1
+        assert "code" in results[0][0]
+
+    def test_not_found(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "ErrorCode": {"type": "string", "enum": ["INVALID", "NOT_FOUND"]}
+                }
+            }
+        }
+        assert find_enum_value_in_schemas(spec, "CONFLICT") == []
+
+    def test_find_in_allof_ref(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Base": {
+                        "properties": {
+                            "status": {"type": "string", "enum": ["OK", "CONFLICT"]}
+                        }
+                    },
+                    "Extended": {
+                        "allOf": [{"$ref": "#/components/schemas/Base"}]
+                    },
+                }
+            }
+        }
+        results = find_enum_value_in_schemas(spec, "CONFLICT")
+        # Found in Base directly and in Extended via allOf
+        assert len(results) >= 1
+
+    def test_empty_spec(self):
+        assert find_enum_value_in_schemas({}, "CONFLICT") == []
+
+
+# ---------------------------------------------------------------------------
+# find_properties_by_name
+# ---------------------------------------------------------------------------
+
+
+class TestFindPropertiesByName:
+    def test_direct_property(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Subscription": {
+                        "properties": {
+                            "sinkCredential": {"$ref": "#/components/schemas/SinkCredential"},
+                            "sink": {"type": "string"},
+                        }
+                    }
+                }
+            }
+        }
+        results = find_properties_by_name(spec, "sinkCredential")
+        assert len(results) == 1
+        assert results[0][0] == "Subscription"
+
+    def test_property_via_allof(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Base": {
+                        "properties": {"sinkCredential": {"type": "object"}}
+                    },
+                    "Extended": {
+                        "allOf": [
+                            {"$ref": "#/components/schemas/Base"},
+                            {"properties": {"extra": {"type": "string"}}},
+                        ]
+                    },
+                }
+            }
+        }
+        results = find_properties_by_name(spec, "sinkCredential")
+        assert len(results) == 2  # Found in both Base and Extended
+
+    def test_property_not_found(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Foo": {"properties": {"bar": {"type": "string"}}}
+                }
+            }
+        }
+        assert find_properties_by_name(spec, "sinkCredential") == []
+
+    def test_external_ref_property(self):
+        """Property with external $ref is still found by name."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "SubscriptionRequest": {
+                        "properties": {
+                            "sinkCredential": {
+                                "$ref": "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        results = find_properties_by_name(spec, "sinkCredential")
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# iter_response_schemas
+# ---------------------------------------------------------------------------
+
+
+class TestIterResponseSchemas:
+    def test_simple_response(self):
+        spec = {
+            "paths": {
+                "/subscriptions": {
+                    "post": {
+                        "responses": {
+                            "201": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"type": "object", "properties": {"id": {"type": "string"}}}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        results = list(iter_response_schemas(spec, "/subscriptions"))
+        assert len(results) == 1
+        path, method, code, schema = results[0]
+        assert path == "/subscriptions"
+        assert method == "post"
+        assert code == "201"
+        assert "id" in schema.get("properties", {})
+
+    def test_ref_response_schema(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Subscription": {"type": "object", "properties": {"id": {"type": "string"}}}
+                }
+            },
+            "paths": {
+                "/subscriptions/{id}": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Subscription"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        results = list(iter_response_schemas(spec, "/subscriptions"))
+        assert len(results) == 1
+        assert results[0][3].get("properties", {}).get("id") is not None
+
+    def test_array_response(self):
+        """GET /subscriptions returns array — items are yielded."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "Subscription": {"type": "object", "properties": {"id": {"type": "string"}}}
+                }
+            },
+            "paths": {
+                "/subscriptions": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "array",
+                                            "items": {"$ref": "#/components/schemas/Subscription"},
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        results = list(iter_response_schemas(spec, "/subscriptions"))
+        assert len(results) == 1
+        assert "id" in results[0][3].get("properties", {})
+
+    def test_path_prefix_filter(self):
+        spec = {
+            "paths": {
+                "/subscriptions": {
+                    "get": {
+                        "responses": {
+                            "200": {"content": {"application/json": {"schema": {"type": "object"}}}}
+                        }
+                    }
+                },
+                "/other": {
+                    "get": {
+                        "responses": {
+                            "200": {"content": {"application/json": {"schema": {"type": "object"}}}}
+                        }
+                    }
+                },
+            }
+        }
+        results = list(iter_response_schemas(spec, "/subscriptions"))
+        assert len(results) == 1
+
+    def test_no_paths(self):
+        assert list(iter_response_schemas({}, "/subscriptions")) == []
+
+    def test_error_responses_included(self):
+        """Error responses (4xx) are also yielded when matching path."""
+        spec = {
+            "paths": {
+                "/subscriptions": {
+                    "post": {
+                        "responses": {
+                            "201": {
+                                "content": {"application/json": {"schema": {"type": "object"}}}
+                            },
+                            "400": {
+                                "content": {"application/json": {"schema": {"type": "object"}}}
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        results = list(iter_response_schemas(spec, "/subscriptions"))
+        assert len(results) == 2


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Implements WS07 Phase 2b: 6 new Python-based validation checks for CAMARA design guide rules that require context-dependent logic or spec traversal beyond what Spectral supports. Also rewrites P-011 (x-camara-commonalities version validation) with branch-type-aware format checking and version mismatch detection.

**New checks:**
- **P-014** (DG-088): Subscription API filename must end with `-subscriptions`
- **P-015** (DG-086): Event type format `org.camaraproject.<api-name>.<vN>.<event-name>`
- **P-016** (DG-092): `sinkCredential` must not appear in subscription response schemas
- **P-017** (DG-018): `CONFLICT` error code deprecated warning (r4.x)
- **P-018** (DG-011): `contextCode` enum SCREAMING_SNAKE_CASE format (r4.x)
- **P-019** (NEW-003): Orphan API definitions not listed in release-plan.yaml

**P-011 rewrite** (DG-028): `check-commonalities-version` replaces the muted `check-license-commonalities-consistency`. Validates `info.x-camara-commonalities` presence, format by branch type (main/feature accept wip/tbd/version; release requires full semver), and version match against resolved `commonalities_version`.

**Infrastructure:**
- `commonalities_version` field added to `ValidationContext` — resolved from `commonalities_release` tag via GitHub API (fetches `VERSION.yaml` from Commonalities repo at release tag ref)
- `_spec_helpers.py` — shared OpenAPI spec traversal utilities (local $ref resolution, schema property collection, event type extraction, enum search)

**Test results:** 751 passed (was 663, +88 new)

**Deferred:** DG-095 (event version independence) — no actionable static check; format already covered by P-015.

#### Which issue(s) this PR fixes:

Part of [ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448) (validation framework v1)

#### Special notes for reviewers:

- Subscription checks handle both current inline schemas and the upcoming `$ref`-based pattern from Commonalities restructuring (PR#606)
- Post-filter applicability conditions gate subscription rules to `api_pattern: [explicit-subscription]` and r4.x rules to `commonalities_release: ">=r4.0"`
- The `commonalities_version` resolution step in `action.yml` uses `gh api` to fetch `VERSION.yaml` — requires read access to the public Commonalities repo (already available in workflow context)

#### Changelog input

```
feat(validation): add 6 Python gap rule checks (P-014..P-019), rewrite P-011 commonalities version check, add commonalities_version to validation context
```

#### Additional documentation

```
docs
```