### PR TITLE
feat(validation): add Phase 2a Spectral gap rules (S-018..S-035)

### DIFF
--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -11,6 +11,9 @@
 # - 21.07.2025: Added camara-schema-type-check rule
 # - 12.01.2026: camara-discriminator-use deprecated
 # - 03.04.2026: Added OWASP API Security Top 10 2023 rules (Linting-rules.md section 5)
+# - 07.04.2026: Added Phase 2a gap rules (S-018..S-035): license, contact, tags,
+#   apiRoot, 403, error codes, subscription, format descriptions, required props,
+#   array items description, notification content-type
 
 
 # Note: @stoplight/spectral-owasp-ruleset is installed via validation/package.json.
@@ -25,6 +28,11 @@ functions:
   - camara-security-no-secrets-in-path-or-query-parameters
   - camara-schema-casing-convention
   - camara-schema-type-check
+  - camara-format-description-check
+  - camara-error-code-dot-format
+  - camara-required-properties-exist
+  - camara-array-items-description
+  - camara-notification-content-type
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -292,6 +300,212 @@ rules:
     given: "$.components.schemas.*"
     then:
       function: camara-schema-type-check
+    recommended: true
+
+  # ===== Phase 2a Gap Rules (Design Guide + Subscription Guide) =====
+
+  # --- Group A: Simple field checks ---
+
+  camara-license-name:
+    description: "info.license.name MUST be 'Apache 2.0'."
+    message: "License name must be exactly 'Apache 2.0', got '{{value}}'."
+    severity: error
+    given: $.info.license.name
+    then:
+      function: pattern
+      functionOptions:
+        match: "^Apache 2\\.0$"
+    recommended: true
+
+  camara-license-url-value:
+    description: "info.license.url MUST be the Apache 2.0 license URL."
+    message: "License URL must be 'https://www.apache.org/licenses/LICENSE-2.0.html', got '{{value}}'."
+    severity: error
+    given: $.info.license.url
+    then:
+      function: pattern
+      functionOptions:
+        match: "^https://www\\.apache\\.org/licenses/LICENSE-2\\.0\\.html$"
+    recommended: true
+
+  camara-no-contact:
+    description: "info.contact MUST NOT be present in CAMARA API specifications."
+    message: "info.contact must not be present. CAMARA APIs do not use individual contact information."
+    severity: warn
+    given: $.info
+    then:
+      field: contact
+      function: falsy
+    recommended: true
+
+  camara-tag-name-title-case:
+    description: "Tag names SHOULD follow Title Case convention (each word capitalized, separated by spaces)."
+    message: "Tag name '{{value}}' is not Title Case. Use e.g. 'Quality On Demand' instead of 'quality-on-demand'."
+    severity: hint
+    given: $.tags[*].name
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[A-Z][a-zA-Z0-9]*(\\s[A-Z][a-zA-Z0-9]*)*$"
+    recommended: true
+
+  camara-api-root-default:
+    description: "apiRoot variable default SHOULD be 'http://localhost:9091'."
+    message: "apiRoot default should be 'http://localhost:9091', got '{{value}}'."
+    severity: hint
+    given: $.servers[*].variables.apiRoot.default
+    then:
+      function: pattern
+      functionOptions:
+        match: "^http://localhost:9091$"
+    recommended: true
+
+  camara-api-root-description:
+    description: "apiRoot variable description SHOULD match the standard CAMARA text."
+    message: "apiRoot description does not match the standard CAMARA text."
+    severity: hint
+    given: $.servers[*].variables.apiRoot.description
+    then:
+      function: pattern
+      functionOptions:
+        match: "^API root, defined by the service provider, e\\.g\\. `api\\.example\\.com` or `api\\.example\\.com/somepath`$"
+    recommended: true
+
+  camara-response-403:
+    description: "All API operations MUST document a 403 Forbidden response."
+    message: "Operation is missing a 403 response definition."
+    severity: warn
+    given: "$.paths[*][get,put,post,delete,patch].responses"
+    then:
+      field: "403"
+      function: truthy
+    recommended: true
+
+  # --- Group B: Error code checks ---
+
+  camara-error-code-not-numeric:
+    description: "Error code enum values MUST NOT be purely numeric."
+    message: "Error code '{{value}}' must not be numeric. Use descriptive string codes like INVALID_ARGUMENT."
+    severity: error
+    given:
+      - "$.paths.*.*.responses.*.content.*.schema.allOf[*].properties.code.enum[*]"
+      - "$.components.responses.*.content.*.schema.allOf[*].properties.code.enum[*]"
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: "^\\d+$"
+    recommended: true
+
+  camara-error-code-screaming-snake-case:
+    description: "Error code enum values MUST be SCREAMING_SNAKE_CASE, optionally with API_NAME prefix separated by dot."
+    message: "Error code '{{value}}' is not SCREAMING_SNAKE_CASE (optionally API_NAME.CODE)."
+    severity: warn
+    given:
+      - "$.paths.*.*.responses.*.content.*.schema.allOf[*].properties.code.enum[*]"
+      - "$.components.responses.*.content.*.schema.allOf[*].properties.code.enum[*]"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*(\\.[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)?$"
+    recommended: true
+
+  camara-error-code-api-specific-format:
+    description: "API-specific error codes with dots MUST follow API_NAME.SPECIFIC_CODE format."
+    message: "{{error}}"
+    severity: warn
+    given:
+      - "$.paths.*.*.responses.*.content.*.schema.allOf[*].properties.code.enum[*]"
+      - "$.components.responses.*.content.*.schema.allOf[*].properties.code.enum[*]"
+    then:
+      function: camara-error-code-dot-format
+    recommended: true
+
+  # --- Group C: Subscription schema checks ---
+
+  camara-cloudevent-specversion:
+    description: "CloudEvent specversion MUST be constrained to enum ['1.0']."
+    message: "specversion must be '1.0', got '{{value}}'."
+    severity: hint
+    given: "$.components.schemas.*.properties.specversion.enum[0]"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^1\\.0$"
+    recommended: true
+
+  camara-subscription-protocol-http:
+    description: "Protocol enum MUST contain only 'HTTP' (only HTTP is allowed for now)."
+    message: "Protocol enum should contain only 'HTTP'. Found '{{value}}'."
+    severity: hint
+    given: "$.components.schemas.Protocol.enum[*]"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^HTTP$"
+    recommended: true
+
+  camara-subscription-sink-https:
+    description: "The 'sink' property MUST have a pattern enforcing HTTPS."
+    message: "sink property must have a pattern enforcing HTTPS (e.g. '^https:\\/\\/.+$')."
+    severity: warn
+    given: "$.components.schemas.*.properties.sink.pattern"
+    then:
+      function: pattern
+      functionOptions:
+        match: "https"
+    recommended: true
+
+  camara-notification-content-type:
+    description: "Notification callback request body MUST use 'application/cloudevents+json' content type."
+    message: "{{error}}"
+    severity: warn
+    given: "$.paths.*.*.callbacks.*.*.post.requestBody.content"
+    then:
+      function: camara-notification-content-type
+    recommended: true
+
+  # --- Group D: Custom JS function rules ---
+
+  camara-datetime-rfc3339-description:
+    description: "Properties with format 'date-time' MUST have a description mentioning RFC 3339."
+    message: "{{error}}"
+    severity: hint
+    given: "$.components.schemas.*"
+    then:
+      function: camara-format-description-check
+      functionOptions:
+        format: "date-time"
+        requiredText: "RFC\\s*3339"
+    recommended: true
+
+  camara-duration-rfc3339-description:
+    description: "Properties with format 'duration' MUST have a description mentioning RFC 3339."
+    message: "{{error}}"
+    severity: hint
+    given: "$.components.schemas.*"
+    then:
+      function: camara-format-description-check
+      functionOptions:
+        format: "duration"
+        requiredText: "RFC\\s*3339"
+    recommended: true
+
+  camara-required-properties-exist:
+    description: "Every property listed in 'required' MUST be defined in 'properties'."
+    message: "{{error}}"
+    severity: warn
+    given: "$.components.schemas.*"
+    then:
+      function: camara-required-properties-exist
+    recommended: true
+
+  camara-array-items-description:
+    description: "Array 'items' MUST have a description when defined inline (not $ref)."
+    message: "{{error}}"
+    severity: warn
+    given: "$.components.schemas.*"
+    then:
+      function: camara-array-items-description
     recommended: true
 
   # ===== OWASP API Security Top 10 2023 =====

--- a/linting/config/lint_function/camara-array-items-description.js
+++ b/linting/config/lint_function/camara-array-items-description.js
@@ -1,0 +1,41 @@
+// CAMARA Project - support function for Spectral linter
+// Checks that inline array 'items' schemas have a 'description' field.
+// Items that are $ref are skipped (the target schema should have its
+// own description).
+
+export default (schema, _options, context) => {
+  const errors = [];
+
+  function check(node, path) {
+    if (!node || typeof node !== "object" || node.$ref) return;
+
+    if (node.type === "array" && node.items) {
+      if (typeof node.items === "object" && !node.items.$ref && !node.items.description) {
+        errors.push({
+          message: `Array items must have a description`,
+          path: [...path, "items"]
+        });
+      }
+    }
+
+    if (node.properties) {
+      for (const [key, value] of Object.entries(node.properties)) {
+        check(value, [...path, "properties", key]);
+      }
+    }
+    if (node.items && typeof node.items === "object" && !node.items.$ref) {
+      check(node.items, [...path, "items"]);
+    }
+    if (typeof node.additionalProperties === "object" && node.additionalProperties !== null) {
+      check(node.additionalProperties, [...path, "additionalProperties"]);
+    }
+    for (const combiner of ["allOf", "anyOf", "oneOf"]) {
+      if (node[combiner]) {
+        node[combiner].forEach((sub, i) => check(sub, [...path, combiner, i]));
+      }
+    }
+  }
+
+  check(schema, context.path);
+  return errors;
+};

--- a/linting/config/lint_function/camara-error-code-dot-format.js
+++ b/linting/config/lint_function/camara-error-code-dot-format.js
@@ -1,0 +1,17 @@
+// CAMARA Project - support function for Spectral linter
+// Validates that error codes containing a dot follow the
+// API_NAME.SPECIFIC_CODE format (both segments in SCREAMING_SNAKE_CASE).
+// Non-dot codes are silently skipped (they are common codes).
+
+const DOT_FORMAT = /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*\.[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/;
+
+export default (input) => {
+  if (typeof input !== "string") return;
+  if (!input.includes(".")) return;
+
+  if (!DOT_FORMAT.test(input)) {
+    return [{
+      message: `API-specific error code '${input}' must follow API_NAME.SPECIFIC_CODE format (SCREAMING_SNAKE_CASE on both sides of the dot)`
+    }];
+  }
+};

--- a/linting/config/lint_function/camara-format-description-check.js
+++ b/linting/config/lint_function/camara-format-description-check.js
@@ -1,0 +1,46 @@
+// CAMARA Project - support function for Spectral linter
+// Checks that properties with a specific format have descriptions
+// containing required text (e.g. date-time must mention RFC 3339).
+//
+// Options:
+//   format:       the format value to match (e.g. "date-time", "duration")
+//   requiredText: regex pattern to search for in description (e.g. "RFC\\s*3339")
+
+export default (schema, options, context) => {
+  const errors = [];
+  const { format, requiredText } = options;
+  const re = new RegExp(requiredText, "i");
+
+  function check(node, path) {
+    if (!node || typeof node !== "object" || node.$ref) return;
+
+    if (node.format === format) {
+      if (!node.description || !re.test(node.description)) {
+        errors.push({
+          message: `Property with format '${format}' must have a description mentioning ${requiredText.replace(/\\\\/g, "\\")}`,
+          path
+        });
+      }
+    }
+
+    if (node.properties) {
+      for (const [key, value] of Object.entries(node.properties)) {
+        check(value, [...path, "properties", key]);
+      }
+    }
+    if (node.items && typeof node.items === "object" && !node.items.$ref) {
+      check(node.items, [...path, "items"]);
+    }
+    if (typeof node.additionalProperties === "object" && node.additionalProperties !== null) {
+      check(node.additionalProperties, [...path, "additionalProperties"]);
+    }
+    for (const combiner of ["allOf", "anyOf", "oneOf"]) {
+      if (node[combiner]) {
+        node[combiner].forEach((sub, i) => check(sub, [...path, combiner, i]));
+      }
+    }
+  }
+
+  check(schema, context.path);
+  return errors;
+};

--- a/linting/config/lint_function/camara-notification-content-type.js
+++ b/linting/config/lint_function/camara-notification-content-type.js
@@ -1,0 +1,14 @@
+// CAMARA Project - support function for Spectral linter
+// Checks that callback POST requestBody content includes the
+// 'application/cloudevents+json' media type key.
+
+export default (content) => {
+  if (!content || typeof content !== "object") return;
+
+  const keys = Object.keys(content);
+  if (!keys.includes("application/cloudevents+json")) {
+    return [{
+      message: `Notification callback content type must include 'application/cloudevents+json', found: ${keys.join(", ") || "(empty)"}`
+    }];
+  }
+};

--- a/linting/config/lint_function/camara-required-properties-exist.js
+++ b/linting/config/lint_function/camara-required-properties-exist.js
@@ -1,0 +1,44 @@
+// CAMARA Project - support function for Spectral linter
+// Checks that every entry in a schema's 'required' array has a
+// corresponding key in 'properties'. Only checks nodes where both
+// 'required' and 'properties' coexist (avoids false positives on
+// allOf partial fragments that have 'required' without 'properties').
+
+export default (schema, _options, context) => {
+  const errors = [];
+
+  function check(node, path) {
+    if (!node || typeof node !== "object" || node.$ref) return;
+
+    if (Array.isArray(node.required) && node.properties) {
+      for (const name of node.required) {
+        if (!(name in node.properties)) {
+          errors.push({
+            message: `Required property '${name}' is not defined in 'properties'`,
+            path: [...path, "required"]
+          });
+        }
+      }
+    }
+
+    if (node.properties) {
+      for (const [key, value] of Object.entries(node.properties)) {
+        check(value, [...path, "properties", key]);
+      }
+    }
+    if (node.items && typeof node.items === "object" && !node.items.$ref) {
+      check(node.items, [...path, "items"]);
+    }
+    if (typeof node.additionalProperties === "object" && node.additionalProperties !== null) {
+      check(node.additionalProperties, [...path, "additionalProperties"]);
+    }
+    for (const combiner of ["allOf", "anyOf", "oneOf"]) {
+      if (node[combiner]) {
+        node[combiner].forEach((sub, i) => check(sub, [...path, combiner, i]));
+      }
+    }
+  }
+
+  check(schema, context.path);
+  return errors;
+};

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -11,16 +11,16 @@
 #   pending     — in open PRs, not yet merged
 
 version: 1
-generated: 2026-04-03
+generated: 2026-04-07
 
 summary:
-  total_implemented: 123
-  total_gap: 17
+  total_implemented: 141
+  total_gap: 0
   total_manual: 25
   total_pending: 0
   total_tested: 0
   by_engine:
-    spectral: 66
+    spectral: 84
     gherkin: 25
     python: 19
     yamllint: 13
@@ -38,94 +38,102 @@ summary:
 # Source: private-dev-docs/validation-framework/reviews/commonalities-design-guide-audit.md
 
 gap_rules:
-  # Spectral gaps (new rules needed)
+  # Spectral gaps — implemented in Phase 2a
   - audit_id: DG-003
     description: date-time description RFC 3339 format
     target_engine: spectral
-    priority: low
+    status: implemented
+    rule_id: S-028
 
   - audit_id: DG-004
     description: duration description RFC 3339 format
     target_engine: spectral
-    priority: low
+    status: implemented
+    rule_id: S-029
 
   - audit_id: DG-008
     description: "Object: required properties MUST exist in properties"
     target_engine: spectral
-    priority: medium
+    status: implemented
+    rule_id: S-030
 
   - audit_id: DG-013
     description: Error code MUST NOT be numeric
     target_engine: spectral
-    priority: medium
+    status: implemented
+    rule_id: S-025
 
   - audit_id: DG-014
     description: Error code MUST be SCREAMING_SNAKE_CASE (r4.x)
     target_engine: spectral
-    priority: medium
-    notes: commonalities_release >=r4.0
-
-  - audit_id: DG-026
-    description: "info.license.name MUST be 'Apache 2.0'"
-    target_engine: spectral
-    priority: medium
-    notes: Static value check, previously v0_6 only (V6-005)
-
-  - audit_id: DG-027
-    description: info.license.url MUST be Apache License URL
-    target_engine: spectral
-    priority: medium
-    notes: Value check (not just presence). Spectral license-url only checks existence. Previously v0_6 (V6-006)
+    status: implemented
+    rule_id: S-026
 
   - audit_id: DG-015
     description: "API-specific error: API_NAME.SPECIFIC_CODE format"
     target_engine: spectral
-    priority: medium
+    status: implemented
+    rule_id: S-027
 
   - audit_id: DG-017
     description: All APIs MUST document 403 response
     target_engine: spectral
-    priority: medium
+    status: implemented
+    rule_id: S-024
+
+  - audit_id: DG-026
+    description: "info.license.name MUST be 'Apache 2.0'"
+    target_engine: spectral
+    status: implemented
+    rule_id: S-018
+
+  - audit_id: DG-027
+    description: info.license.url MUST be Apache License URL
+    target_engine: spectral
+    status: implemented
+    rule_id: S-019
 
   - audit_id: DG-032
     description: info.contact MUST be absent
     target_engine: spectral
-    priority: low
+    status: implemented
+    rule_id: S-020
 
   - audit_id: DG-041
     description: Tag names Title Case convention
     target_engine: spectral
-    priority: low
+    status: implemented
+    rule_id: S-021
 
   - audit_id: DG-058
     description: Array items MUST have description (r4.x)
     target_engine: spectral
-    priority: medium
-    notes: commonalities_release >=r4.0
+    status: implemented
+    rule_id: S-031
 
   - audit_id: DG-087
     description: "specversion MUST be '1.0' (subscription)"
     target_engine: spectral
-    priority: low
-    notes: api_pattern subscription only
+    status: implemented
+    rule_id: S-032
 
   - audit_id: DG-090
     description: "protocol MUST be 'HTTP' (subscription)"
     target_engine: spectral
-    priority: low
-    notes: api_pattern subscription only
+    status: implemented
+    rule_id: S-033
 
   - audit_id: DG-091
     description: sink MUST use HTTPS (subscription)
     target_engine: spectral
-    priority: low
-    notes: api_pattern subscription only
+    status: implemented
+    rule_id: S-034
 
   - audit_id: DG-094
     description: Notification content-type cloudevents+json (subscription)
     target_engine: spectral
-    priority: low
-    notes: api_pattern subscription only
+    status: implemented
+    rule_id: S-035
 
   # Python gaps — implemented in Phase 2b
   - audit_id: DG-011
@@ -182,8 +190,8 @@ gap_rules:
   - audit_id: NEW-002
     description: "apiRoot variable: default and description MUST match Design Guide values"
     target_engine: spectral
-    priority: low
-    notes: "Hint level. Standard values: default 'http://localhost:9091', description 'API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`'"
+    status: implemented
+    rule_id: S-022, S-023
 
   - audit_id: NEW-003
     description: "Orphan API definitions: YAML files in code/API_definitions/ not listed in release-plan.yaml"

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -74,6 +74,93 @@
   engine: spectral
   engine_rule: camara-security-no-secrets-in-path-or-query-parameters
 
+# ===== Phase 2a gap rules (S-018+) =====
+
+- id: S-018
+  engine: spectral
+  engine_rule: camara-license-name
+
+- id: S-019
+  engine: spectral
+  engine_rule: camara-license-url-value
+
+- id: S-020
+  engine: spectral
+  engine_rule: camara-no-contact
+
+- id: S-021
+  engine: spectral
+  engine_rule: camara-tag-name-title-case
+
+- id: S-022
+  engine: spectral
+  engine_rule: camara-api-root-default
+
+- id: S-023
+  engine: spectral
+  engine_rule: camara-api-root-description
+
+- id: S-024
+  engine: spectral
+  engine_rule: camara-response-403
+  hint: "All operations must document a 403 Forbidden response (CAMARA Design Guide section 3.2)."
+
+- id: S-025
+  engine: spectral
+  engine_rule: camara-error-code-not-numeric
+
+- id: S-026
+  engine: spectral
+  engine_rule: camara-error-code-screaming-snake-case
+  applicability:
+    commonalities_release: ">=r4.0"
+
+- id: S-027
+  engine: spectral
+  engine_rule: camara-error-code-api-specific-format
+
+- id: S-028
+  engine: spectral
+  engine_rule: camara-datetime-rfc3339-description
+
+- id: S-029
+  engine: spectral
+  engine_rule: camara-duration-rfc3339-description
+
+- id: S-030
+  engine: spectral
+  engine_rule: camara-required-properties-exist
+
+- id: S-031
+  engine: spectral
+  engine_rule: camara-array-items-description
+  applicability:
+    commonalities_release: ">=r4.0"
+
+- id: S-032
+  engine: spectral
+  engine_rule: camara-cloudevent-specversion
+  applicability:
+    api_pattern: [implicit-subscription, explicit-subscription]
+
+- id: S-033
+  engine: spectral
+  engine_rule: camara-subscription-protocol-http
+  applicability:
+    api_pattern: [implicit-subscription, explicit-subscription]
+
+- id: S-034
+  engine: spectral
+  engine_rule: camara-subscription-sink-https
+  applicability:
+    api_pattern: [implicit-subscription, explicit-subscription]
+
+- id: S-035
+  engine: spectral
+  engine_rule: camara-notification-content-type
+  applicability:
+    api_pattern: [implicit-subscription, explicit-subscription]
+
 # ===== Built-in OAS rules (S-200+) =====
 
 - id: S-200

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -78,7 +78,7 @@ class TestStructuralIntegrity:
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
         assert counts["python"] == 19
-        assert counts["spectral"] == 66
+        assert counts["spectral"] == 84
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
 
@@ -306,8 +306,8 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 9, (
-            f"Expected 9 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 10, (
+            f"Expected 10 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (

--- a/validation/tests/test_spectral_gap_rules.py
+++ b/validation/tests/test_spectral_gap_rules.py
@@ -1,0 +1,598 @@
+"""Tests for Phase 2a Spectral gap rules (S-018..S-035).
+
+Tests create minimal OpenAPI YAML fixtures, run Spectral with the r4 ruleset,
+and verify that expected rules fire (or don't fire) on them.  Each test targets
+a specific rule by checking for its rule code in the Spectral JSON output.
+
+Requires: Node.js + Spectral CLI (installed via validation/package.json).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths & helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_RULESET = _REPO_ROOT / "linting" / "config" / ".spectral-r4.yaml"
+_NODE_MODULES = _REPO_ROOT / "validation" / "node_modules"
+
+
+def _run_spectral(yaml_content: str) -> list[dict]:
+    """Write *yaml_content* to a temp file, lint it with Spectral, return findings."""
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        tmp_path = f.name
+
+    env = {
+        "PATH": subprocess.os.environ.get("PATH", ""),
+        "NODE_PATH": str(_NODE_MODULES),
+        "HOME": subprocess.os.environ.get("HOME", ""),
+    }
+    result = subprocess.run(
+        [
+            "node",
+            str(_NODE_MODULES / ".bin" / "spectral"),
+            "lint",
+            tmp_path,
+            "-r", str(_RULESET),
+            "--format", "json",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    Path(tmp_path).unlink(missing_ok=True)
+    if result.stdout.strip():
+        return json.loads(result.stdout)
+    return []
+
+
+def _codes(findings: list[dict]) -> set[str]:
+    """Extract the set of rule codes from Spectral findings."""
+    return {f["code"] for f in findings}
+
+
+def _findings_for(findings: list[dict], code: str) -> list[dict]:
+    """Filter findings to a specific rule code."""
+    return [f for f in findings if f["code"] == code]
+
+
+# ---------------------------------------------------------------------------
+# Minimal valid spec (passes all rules)
+# ---------------------------------------------------------------------------
+
+_VALID_SPEC = """\
+openapi: 3.0.3
+info:
+  title: Test API
+  description: A test API
+  version: wip
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  x-camara-commonalities: 0.7.0
+externalDocs:
+  description: Product documentation at CAMARA
+  url: https://github.com/camaraproject/TestAPI
+servers:
+  - url: "{apiRoot}/test-api/vwip"
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: "API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`"
+tags:
+  - name: Test API
+security:
+  - openId:
+    - test-api:read
+paths:
+  /test:
+    get:
+      tags:
+        - Test API
+      summary: Get test
+      description: Get test description
+      operationId: getTest
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ErrorInfo"
+                  - type: object
+                    properties:
+                      code:
+                        enum:
+                          - UNAUTHENTICATED
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ErrorInfo"
+                  - type: object
+                    properties:
+                      code:
+                        enum:
+                          - PERMISSION_DENIED
+components:
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+  schemas:
+    ErrorInfo:
+      type: object
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: HTTP response status code
+        code:
+          type: string
+          maxLength: 96
+          description: A human-readable code to describe the error
+        message:
+          type: string
+          maxLength: 512
+          description: A human-readable description of what the event represents
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def valid_findings():
+    """Findings from the minimal valid spec — baseline for 'no false positives'."""
+    return _run_spectral(_VALID_SPEC)
+
+
+class TestGroupA:
+    """Group A: Simple field checks."""
+
+    def test_valid_spec_no_license_findings(self, valid_findings):
+        codes = _codes(valid_findings)
+        assert "camara-license-name" not in codes
+        assert "camara-license-url-value" not in codes
+
+    def test_license_name_wrong(self):
+        spec = _VALID_SPEC.replace("name: Apache 2.0", "name: MIT")
+        findings = _run_spectral(spec)
+        assert "camara-license-name" in _codes(findings)
+
+    def test_license_url_wrong(self):
+        spec = _VALID_SPEC.replace(
+            "url: https://www.apache.org/licenses/LICENSE-2.0.html",
+            "url: https://opensource.org/licenses/MIT",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-license-url-value" in _codes(findings)
+
+    def test_no_contact_passes(self, valid_findings):
+        assert "camara-no-contact" not in _codes(valid_findings)
+
+    def test_contact_present_fails(self):
+        spec = _VALID_SPEC.replace(
+            "  x-camara-commonalities: 0.7.0",
+            "  contact:\n    name: Foo\n  x-camara-commonalities: 0.7.0",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-no-contact" in _codes(findings)
+
+    def test_tag_title_case_passes(self, valid_findings):
+        assert "camara-tag-name-title-case" not in _codes(valid_findings)
+
+    def test_tag_title_case_fails(self):
+        spec = _VALID_SPEC.replace("name: Test API", "name: test api")
+        findings = _run_spectral(spec)
+        assert "camara-tag-name-title-case" in _codes(findings)
+
+    def test_api_root_default_passes(self, valid_findings):
+        assert "camara-api-root-default" not in _codes(valid_findings)
+
+    def test_api_root_default_fails(self):
+        spec = _VALID_SPEC.replace(
+            "default: http://localhost:9091",
+            "default: http://localhost:8080",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-api-root-default" in _codes(findings)
+
+    def test_api_root_description_passes(self, valid_findings):
+        assert "camara-api-root-description" not in _codes(valid_findings)
+
+    def test_response_403_passes(self, valid_findings):
+        assert "camara-response-403" not in _codes(valid_findings)
+
+    def test_response_403_missing(self):
+        # Remove the 403 response block
+        spec = _VALID_SPEC.replace(
+            '        "403":\n'
+            "          description: Forbidden\n"
+            "          content:\n"
+            "            application/json:\n"
+            "              schema:\n"
+            "                allOf:\n"
+            '                  - $ref: "#/components/schemas/ErrorInfo"\n'
+            "                  - type: object\n"
+            "                    properties:\n"
+            "                      code:\n"
+            "                        enum:\n"
+            "                          - PERMISSION_DENIED",
+            "",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-response-403" in _codes(findings)
+
+
+class TestGroupB:
+    """Group B: Error code checks."""
+
+    def test_valid_error_codes_pass(self, valid_findings):
+        codes = _codes(valid_findings)
+        assert "camara-error-code-not-numeric" not in codes
+        assert "camara-error-code-screaming-snake-case" not in codes
+        assert "camara-error-code-api-specific-format" not in codes
+
+    def test_numeric_error_code_fails(self):
+        # Must quote the value so YAML parses it as a string, not integer
+        spec = _VALID_SPEC.replace("- UNAUTHENTICATED", '- "401"')
+        findings = _run_spectral(spec)
+        assert "camara-error-code-not-numeric" in _codes(findings)
+
+    def test_non_screaming_snake_case_fails(self):
+        spec = _VALID_SPEC.replace("- UNAUTHENTICATED", "- unauthenticated")
+        findings = _run_spectral(spec)
+        assert "camara-error-code-screaming-snake-case" in _codes(findings)
+
+    def test_api_specific_code_valid(self):
+        spec = _VALID_SPEC.replace(
+            "- PERMISSION_DENIED", "- TEST_API.PERMISSION_DENIED"
+        )
+        findings = _run_spectral(spec)
+        assert "camara-error-code-api-specific-format" not in _codes(findings)
+
+    def test_api_specific_code_bad_format(self):
+        spec = _VALID_SPEC.replace(
+            "- PERMISSION_DENIED", "- test.permission_denied"
+        )
+        findings = _run_spectral(spec)
+        assert "camara-error-code-api-specific-format" in _codes(findings)
+
+
+class TestGroupC:
+    """Group C: Subscription schema checks."""
+
+    _SUBSCRIPTION_SPEC = """\
+    openapi: 3.0.3
+    info:
+      title: Test Subscriptions
+      description: Test
+      version: wip
+      license:
+        name: Apache 2.0
+        url: https://www.apache.org/licenses/LICENSE-2.0.html
+      x-camara-commonalities: 0.7.0
+    externalDocs:
+      description: Product documentation at CAMARA
+      url: https://github.com/camaraproject/TestAPI
+    servers:
+      - url: "{apiRoot}/test-subscriptions/vwip"
+        variables:
+          apiRoot:
+            default: http://localhost:9091
+            description: "API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`"
+    tags:
+      - name: Test Subscription
+    security:
+      - openId:
+        - test:read
+    paths:
+      /subscriptions:
+        post:
+          tags:
+            - Test Subscription
+          summary: Create subscription
+          description: Create a subscription
+          operationId: createSubscription
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/SubscriptionRequest"
+          callbacks:
+            notifications:
+              "{$request.body#/sink}":
+                post:
+                  summary: Notification callback
+                  description: Notification callback
+                  operationId: postNotification
+                  requestBody:
+                    required: true
+                    content:
+                      application/cloudevents+json:
+                        schema:
+                          $ref: "#/components/schemas/CloudEvent"
+                  responses:
+                    "204":
+                      description: No Content
+                  security:
+                    - {}
+          responses:
+            "201":
+              description: Created
+            "401":
+              description: Unauthorized
+            "403":
+              description: Forbidden
+    components:
+      securitySchemes:
+        openId:
+          type: openIdConnect
+          openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      schemas:
+        Protocol:
+          type: string
+          enum:
+            - HTTP
+          description: Delivery protocol
+        SubscriptionRequest:
+          type: object
+          required:
+            - sink
+            - protocol
+          properties:
+            protocol:
+              $ref: "#/components/schemas/Protocol"
+            sink:
+              type: string
+              format: uri
+              maxLength: 2048
+              pattern: "^https:\\\\/\\\\/.+$"
+              description: The address to which events shall be delivered
+        CloudEvent:
+          type: object
+          required:
+            - id
+            - source
+            - specversion
+            - type
+            - time
+          properties:
+            id:
+              type: string
+              description: Event identifier
+              minLength: 1
+            source:
+              type: string
+              format: uri-reference
+              minLength: 1
+              description: Event source
+            type:
+              type: string
+              description: Event type
+              minLength: 1
+            specversion:
+              type: string
+              description: CloudEvents version
+              enum:
+                - "1.0"
+            datacontenttype:
+              type: string
+              description: Content type
+              enum:
+                - application/json
+            time:
+              type: string
+              format: date-time
+              description: "Timestamp. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone."
+            data:
+              type: object
+              description: Event payload
+    """
+
+    def test_specversion_valid(self):
+        findings = _run_spectral(self._SUBSCRIPTION_SPEC)
+        assert "camara-cloudevent-specversion" not in _codes(findings)
+
+    def test_specversion_wrong(self):
+        spec = self._SUBSCRIPTION_SPEC.replace(
+            'enum:\n                - "1.0"',
+            'enum:\n                - "2.0"',
+        )
+        findings = _run_spectral(spec)
+        assert "camara-cloudevent-specversion" in _codes(findings)
+
+    def test_protocol_http_only_passes(self):
+        findings = _run_spectral(self._SUBSCRIPTION_SPEC)
+        assert "camara-subscription-protocol-http" not in _codes(findings)
+
+    def test_protocol_non_http_fails(self):
+        spec = self._SUBSCRIPTION_SPEC.replace(
+            "enum:\n            - HTTP\n          description: Delivery protocol",
+            "enum:\n            - HTTP\n            - MQTT3\n          description: Delivery protocol",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-subscription-protocol-http" in _codes(findings)
+
+    def test_sink_https_passes(self):
+        findings = _run_spectral(self._SUBSCRIPTION_SPEC)
+        assert "camara-subscription-sink-https" not in _codes(findings)
+
+    def test_notification_content_type_passes(self):
+        findings = _run_spectral(self._SUBSCRIPTION_SPEC)
+        assert "camara-notification-content-type" not in _codes(findings)
+
+    def test_notification_content_type_wrong(self):
+        spec = self._SUBSCRIPTION_SPEC.replace(
+            "application/cloudevents+json:", "application/json:"
+        )
+        findings = _run_spectral(spec)
+        assert "camara-notification-content-type" in _codes(findings)
+
+
+class TestGroupD:
+    """Group D: Custom JS function rules."""
+
+    def test_datetime_rfc3339_passes(self):
+        # 4-space indent puts schema under components.schemas (sibling of ErrorInfo)
+        spec = _VALID_SPEC + (
+            "    TimestampSchema:\n"
+            "      type: object\n"
+            "      properties:\n"
+            "        createdAt:\n"
+            "          type: string\n"
+            "          format: date-time\n"
+            '          description: "Created timestamp. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone."\n'
+        )
+        findings = _run_spectral(spec)
+        assert "camara-datetime-rfc3339-description" not in _codes(findings)
+
+    def test_datetime_rfc3339_fails(self):
+        spec = _VALID_SPEC + (
+            "    TimestampSchema:\n"
+            "      type: object\n"
+            "      properties:\n"
+            "        createdAt:\n"
+            "          type: string\n"
+            "          format: date-time\n"
+            '          description: "A timestamp"\n'
+        )
+        findings = _run_spectral(spec)
+        assert "camara-datetime-rfc3339-description" in _codes(findings)
+
+    def test_duration_rfc3339_fails(self):
+        spec = _VALID_SPEC + (
+            "    DurationSchema:\n"
+            "      type: object\n"
+            "      properties:\n"
+            "        maxDuration:\n"
+            "          type: string\n"
+            "          format: duration\n"
+            '          description: "How long it takes"\n'
+        )
+        findings = _run_spectral(spec)
+        assert "camara-duration-rfc3339-description" in _codes(findings)
+
+    def test_required_properties_pass(self, valid_findings):
+        assert "camara-required-properties-exist" not in _codes(valid_findings)
+
+    def test_required_properties_fail(self):
+        spec = _VALID_SPEC + (
+            "    BadSchema:\n"
+            "      type: object\n"
+            "      required:\n"
+            "        - name\n"
+            "        - age\n"
+            "        - missing_field\n"
+            "      properties:\n"
+            "        name:\n"
+            "          type: string\n"
+            "          description: Name\n"
+            "        age:\n"
+            "          type: integer\n"
+            "          format: int32\n"
+            "          minimum: 0\n"
+            "          maximum: 200\n"
+            "          description: Age\n"
+        )
+        findings = _run_spectral(spec)
+        assert "camara-required-properties-exist" in _codes(findings)
+
+    def test_required_properties_allof_no_false_positive(self):
+        """allOf fragments with required but no properties should not fire."""
+        spec = _VALID_SPEC + (
+            "    ExtendedError:\n"
+            "      allOf:\n"
+            '        - $ref: "#/components/schemas/ErrorInfo"\n'
+            "        - type: object\n"
+            "          required:\n"
+            "            - detail\n"
+            "          properties:\n"
+            "            detail:\n"
+            "              type: string\n"
+            "              description: Additional detail\n"
+        )
+        findings = _run_spectral(spec)
+        allof_findings = [
+            f for f in _findings_for(findings, "camara-required-properties-exist")
+            if "ExtendedError" in str(f.get("path", []))
+        ]
+        assert len(allof_findings) == 0
+
+    def test_array_items_description_passes(self):
+        spec = _VALID_SPEC + (
+            "    ListSchema:\n"
+            "      type: object\n"
+            "      properties:\n"
+            "        items_list:\n"
+            "          type: array\n"
+            "          description: A list\n"
+            "          items:\n"
+            "            type: string\n"
+            "            description: An item\n"
+        )
+        findings = _run_spectral(spec)
+        items_findings = [
+            f for f in _findings_for(findings, "camara-array-items-description")
+            if "ListSchema" in str(f.get("path", []))
+        ]
+        assert len(items_findings) == 0
+
+    def test_array_items_description_fails(self):
+        spec = _VALID_SPEC + (
+            "    ListSchema:\n"
+            "      type: object\n"
+            "      properties:\n"
+            "        items_list:\n"
+            "          type: array\n"
+            "          description: A list\n"
+            "          items:\n"
+            "            type: string\n"
+        )
+        findings = _run_spectral(spec)
+        assert "camara-array-items-description" in _codes(findings)
+
+    def test_array_items_ref_skipped(self):
+        """$ref items should be skipped (target schema has own description)."""
+        spec = _VALID_SPEC + (
+            "    ListSchema:\n"
+            "      type: object\n"
+            "      properties:\n"
+            "        errors:\n"
+            "          type: array\n"
+            "          description: List of errors\n"
+            "          items:\n"
+            '            $ref: "#/components/schemas/ErrorInfo"\n'
+        )
+        findings = _run_spectral(spec)
+        items_findings = [
+            f for f in _findings_for(findings, "camara-array-items-description")
+            if "ListSchema" in str(f.get("path", []))
+        ]
+        assert len(items_findings) == 0


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Implements all 17 remaining Spectral gap rules from the design guide audit as 18 rule definitions (S-018..S-035) in `.spectral-r4.yaml`. This closes all Spectral gaps identified in the [design guide audit](https://github.com/camaraproject/ReleaseManagement/pull/447) and is the last prerequisite for the `v1-rc` tag.

**Rules added (18 definitions):**
- **License**: name must be "Apache 2.0" (S-018), URL must be Apache URL (S-019)
- **Info**: contact must be absent (S-020)
- **Tags**: Title Case convention (S-021)
- **apiRoot**: default value (S-022), description text (S-023)
- **Responses**: 403 must be documented (S-024)
- **Error codes**: not numeric (S-025), SCREAMING_SNAKE_CASE r4.x (S-026), API_NAME.CODE dot format (S-027)
- **Format descriptions**: date-time RFC 3339 (S-028), duration RFC 3339 (S-029)
- **Schema structure**: required properties must exist (S-030), array items description r4.x (S-031)
- **Subscription**: specversion 1.0 (S-032), protocol HTTP only (S-033), sink HTTPS (S-034), notification content-type (S-035)

**5 new custom JS functions** for checks requiring recursive schema traversal or conditional logic.

**33 new tests** validating all rules against positive and negative YAML fixtures via Spectral CLI.

#### Which issue(s) this PR fixes:

Contributes to [ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448) (validation framework v1 umbrella)

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

- Rules are added to `.spectral-r4.yaml` only (not r3.4 or fallback). Cherry-picking to r3.4 will be a separate action.
- Two r4.x-only rules (S-026 error code casing, S-031 array items description) have `applicability.commonalities_release: ">=r4.0"` in their metadata for post-filter gating.
- Four subscription rules have `applicability.api_pattern` metadata — they fire on all specs but findings are suppressed by the post-filter for non-subscription APIs.
- NEW-002 (apiRoot) splits into two rules (S-022 + S-023) for cleaner separation of default and description checks.

#### Changelog input

```
 release-note
Add 18 Spectral gap rules (S-018..S-035) to r4.x ruleset covering license, contact, tags, apiRoot, 403 responses, error code format, format descriptions, schema structure, and subscription patterns.
```

#### Additional documentation

```
docs
Design guide audit: https://github.com/camaraproject/ReleaseManagement/pull/447
```