### PR TITLE
chore: sync main into validation-framework (create-github-app-token v2→v3)

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -423,7 +423,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: steps.decide.outputs.action == 'post_comment' && vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -799,7 +799,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -872,7 +872,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -982,7 +982,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -1110,7 +1110,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -1189,7 +1189,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -1327,7 +1327,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -1546,7 +1546,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -1787,7 +1787,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -1896,7 +1896,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -2067,7 +2067,7 @@ jobs:
       - name: Generate App Token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
#### What type of PR is this?

* repository management

#### What this PR does / why we need it:

Merges `main` into `validation-framework` to incorporate the dependabot
bump of `actions/create-github-app-token` from v2 to v3 (#141).

This is done in preparation for assigning the `v1-rc` tag on the
validation-framework branch. Repositories that opt into validation v1-rc
will also switch the release-automation reusable workflow to the v1-rc
version, so the caller workflow in validation-framework must include the
same action version currently on main.

No validation-framework code is touched by this merge. The only change
is `.github/workflows/release-automation-reusable.yml` (the action
version bump from #141).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Straightforward sync merge — single file changed, no conflicts expected.
After merge, `validation-framework` will be ready for the `v1-rc` tag.