### PR TITLE
fix(release-automation): caller template references v1-rc

### DIFF
--- a/release_automation/workflows/release-automation-caller.yml
+++ b/release_automation/workflows/release-automation-caller.yml
@@ -80,5 +80,5 @@ jobs:
        github.event.pull_request.merged == true &&
        startsWith(github.event.pull_request.base.ref, 'release-snapshot/'))
 
-    uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@ra-v1-rc
+    uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@v1-rc
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Updates the `uses:` line in `release_automation/workflows/release-automation-caller.yml`
from `@ra-v1-rc` to `@v1-rc`.

The onboarding campaign deploys this template verbatim, so the ref must
already be correct at the tag version that consumers install from. With
the wrong ref, repositories onboarded via `v1-rc` would still call into
the older `ra-v1-rc` reusable workflow (v0.3.0) instead of the
validation-framework branch version they expect.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

One-line change. The `v1-rc` tag will be moved forward to include this
fix after merge, before the VF caller dark deployment runs.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

```
docs
NONE
```