### PR TITLE
refactor: simplify state derivation interface and remove snapshot history placeholders

### DIFF
--- a/release_automation/docs/technical-architecture.md
+++ b/release_automation/docs/technical-architecture.md
@@ -179,7 +179,7 @@ class ReleaseState(Enum):
 
 - `ReleaseStateManager` — Derives state and reads snapshot metadata from artifacts
 - `SnapshotInfo` — Data read from `release-metadata.yaml` on the snapshot branch (snapshot ID, branches, APIs with calculated versions, dependencies)
-- `ReleaseInfoResult` — Return type from `get_current_release_info()`, includes either state data or a `ConfigurationError`
+- `ReleaseInfoResult` — Return type from `derive_state()`, includes either state data or a `ConfigurationError`
 
 ### 2.2 Version Calculator (`version_calculator.py`)
 

--- a/release_automation/scripts/issue_manager.py
+++ b/release_automation/scripts/issue_manager.py
@@ -2,40 +2,14 @@
 Issue manager for CAMARA release automation.
 
 This module provides functionality for managing Release Issue content,
-including updating reserved sections, maintaining snapshot history,
-and generating standardized titles.
+including updating reserved sections and generating standardized titles.
 """
 
 import re
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from . import config
-
-
-@dataclass
-class SnapshotHistoryEntry:
-    """
-    Represents an entry in the snapshot history table.
-
-    Note: HISTORY section is deferred to backlog (not MVP).
-    This dataclass is preserved for future implementation.
-
-    Attributes:
-        snapshot_id: Unique identifier (e.g., "r4.1-abc1234")
-        status: Either "Current" or "Discarded"
-        created_at: ISO timestamp when snapshot was created
-        discarded_at: ISO timestamp when discarded (if applicable)
-        reason: Reason for discarding (if applicable)
-        release_review_branch: The release-review branch name
-    """
-    snapshot_id: str
-    status: str  # "Current" or "Discarded"
-    created_at: str
-    discarded_at: Optional[str] = None
-    reason: Optional[str] = None
-    release_review_branch: str = ""
 
 
 class IssueManager:
@@ -52,9 +26,6 @@ class IssueManager:
         - STATE: Current release state, timestamp, and active artifact links
         - CONFIG: Release configuration (APIs, dependencies)
         - ACTIONS: Valid actions for the current state
-
-    Note: HISTORY section has been deferred to backlog (not MVP).
-    The comment trail serves as the audit log.
     """
 
     # Pattern for matching sections (use .format(name=section_name))
@@ -112,103 +83,6 @@ class IssueManager:
         pattern = self.SECTION_PATTERN.format(name=section)
         match = re.search(pattern, body, flags=re.DOTALL)
         return match.group(1) if match else None
-
-    def append_to_history(self, body: str, entry: SnapshotHistoryEntry) -> str:
-        """
-        Add a new entry to the snapshot history table.
-
-        Note: HISTORY section is deferred to backlog (not MVP).
-        This method is preserved for future implementation.
-
-        The entry is inserted after the table header row.
-
-        Args:
-            body: The current issue body
-            entry: Snapshot history entry to add
-
-        Returns:
-            Updated issue body with new history row
-        """
-        # Format the new row
-        discarded = entry.discarded_at or "—"
-        reason = entry.reason or "—"
-
-        new_row = (
-            f"| `{entry.snapshot_id}` | **{entry.status}** | "
-            f"{entry.created_at} | {discarded} | {reason} | "
-            f"`{entry.release_review_branch}` |"
-        )
-
-        # Find the HISTORY section and the table header
-        # Table format:
-        # | Snapshot | Status | Created | Discarded | Reason | Review Branch |
-        # |----------|--------|---------|-----------|--------|---------------|
-        # | ... rows ... |
-
-        history_content = self.get_section_content(body, "HISTORY")
-        if history_content is None:
-            return body
-
-        # Find the header separator line (|---...|) and insert after it
-        lines = history_content.split('\n')
-        insert_index = None
-
-        for i, line in enumerate(lines):
-            # Look for the separator line (contains |---|)
-            if re.match(r'\s*\|[-|]+\|\s*$', line):
-                insert_index = i + 1
-                break
-
-        if insert_index is None:
-            # No table found, just append at the end
-            new_content = history_content.rstrip() + '\n' + new_row
-        else:
-            # Insert the new row after the separator
-            lines.insert(insert_index, new_row)
-            new_content = '\n'.join(lines)
-
-        return self.update_section(body, "HISTORY", new_content)
-
-    def mark_snapshot_discarded(
-        self,
-        body: str,
-        snapshot_id: str,
-        reason: str
-    ) -> str:
-        """
-        Update an existing snapshot entry from 'Current' to 'Discarded'.
-
-        Note: HISTORY section is deferred to backlog (not MVP).
-        This method is preserved for future implementation.
-
-        Finds the row with the matching snapshot_id and updates:
-        - Status: Current → Discarded
-        - Discarded: — → current timestamp
-        - Reason: — → provided reason
-
-        Args:
-            body: The current issue body
-            snapshot_id: The snapshot ID to update
-            reason: Reason for discarding
-
-        Returns:
-            Updated issue body with modified history row
-        """
-        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
-
-        # Pattern to match the specific row
-        # | `snapshot_id` | **Current** | created_at | — | — | `branch` |
-        pattern = (
-            rf"\| `{re.escape(snapshot_id)}` \| \*\*Current\*\* \| "
-            rf"([^|]+) \| — \| — \| ([^|]+) \|"
-        )
-
-        replacement = (
-            f"| `{snapshot_id}` | Discarded | "
-            f"\\1| {timestamp} | {reason} | \\2|"
-        )
-
-        return re.sub(pattern, replacement, body)
 
     def generate_title(
         self,
@@ -422,7 +296,6 @@ class IssueManager:
         Generate a complete issue body template for a new Release Issue.
 
         This creates the initial structure with all reserved sections.
-        The HISTORY section has been deferred to backlog (not MVP).
 
         Args:
             release_tag: Release tag (e.g., "r4.1")

--- a/release_automation/scripts/issue_sync.py
+++ b/release_automation/scripts/issue_sync.py
@@ -147,11 +147,20 @@ class IssueSyncManager:
         self.ensure_labels_exist()
 
         # Derive current state
-        state = state_override or self.state_manager.derive_state(
-            release_tag,
-            retry_draft_release=True,
-        )
-        context_source = "override" if state_override else "re-derived"
+        if state_override:
+            state = state_override
+            context_source = "override"
+        else:
+            release_info = self.state_manager.derive_state(
+                retry_draft_release=True,
+            )
+            if not release_info.success:
+                return SyncResult(
+                    action="none",
+                    reason=f"config_error: {release_info.config_error.message}",
+                )
+            state = release_info.state
+            context_source = "re-derived"
         print(
             f"Issue sync effective context: source={context_source}, "
             f"state={state.value}, "

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -480,7 +480,13 @@ class SnapshotCreator:
         errors = []
 
         # Check current state
-        state = self.state_manager.derive_state(release_tag)
+        release_info = self.state_manager.derive_state()
+        if not release_info.success:
+            errors.append(
+                f"Configuration error: {release_info.config_error.message}"
+            )
+            return errors
+        state = release_info.state
 
         if state == ReleaseState.PUBLISHED:
             errors.append(

--- a/release_automation/scripts/state_manager.py
+++ b/release_automation/scripts/state_manager.py
@@ -93,9 +93,9 @@ class ConfigurationError:
 @dataclass
 class ReleaseInfoResult:
     """
-    Result of get_current_release_info() call.
+    Result of derive_state() call.
 
-    This replaces the plain dict return type to distinguish between:
+    Distinguishes between:
     - Success: Valid state derived from repository artifacts
     - Error: Configuration problem that prevents state derivation
 
@@ -110,6 +110,7 @@ class ReleaseInfoResult:
     config_error: Optional[ConfigurationError] = None
     release_issue_number: Optional[int] = None  # GitHub issue number if found
     release_type: Optional[str] = None  # Release type if available
+    meta_release: Optional[str] = None  # Meta-release name (e.g., "Sync26")
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -128,6 +129,7 @@ class ReleaseInfoResult:
                 "config_error_type": None,
                 "release_issue_number": self.release_issue_number,
                 "release_type": self.release_type,
+                "meta_release": self.meta_release,
             }
         else:
             return {
@@ -139,6 +141,7 @@ class ReleaseInfoResult:
                 "config_error_type": self.config_error.error_type if self.config_error else "unknown",
                 "release_issue_number": None,
                 "release_type": None,
+                "meta_release": None,
             }
 
 
@@ -162,55 +165,119 @@ class ReleaseStateManager:
 
     def derive_state(
         self,
-        release_tag: str,
         retry_draft_release: bool = False
-    ) -> ReleaseState:
+    ) -> ReleaseInfoResult:
         """
-        Derive the current release state from repository artifacts.
+        Derive the current release state and tag from repository artifacts.
 
-        The derivation follows this priority order:
-        1. If tag exists → PUBLISHED
-        2. If snapshot branch exists:
+        This is the single entry point for state derivation. It determines
+        the release_tag from the authoritative source and derives the state:
+
+        1. Read and validate release-plan.yaml (config errors → failure)
+        2. If tag exists → PUBLISHED
+        3. If snapshot branch exists:
+           - Read release_tag from release-metadata.yaml on snapshot
            - If draft release exists → DRAFT_READY
            - Otherwise → SNAPSHOT_ACTIVE
-        3. If release-plan.yaml defines this release:
-           - If target_release_type is "none" → NOT_PLANNED
-           - Otherwise → PLANNED
-        4. Default → NOT_PLANNED
+        4. If release-plan.yaml target_release_type != "none" → PLANNED
+        5. Otherwise → NOT_PLANNED
 
         Args:
-            release_tag: Release tag to check (e.g., "r4.1")
-            retry_draft_release: Retry draft-release detection for eventual consistency
+            retry_draft_release: Retry draft-release detection for eventual
+                consistency (useful when called right after draft creation)
 
         Returns:
-            Current ReleaseState for the given release tag
+            ReleaseInfoResult with either:
+                - success=True: release_tag, state, snapshot_branch, source
+                - success=False: config_error with details
         """
-        # Step 1: Check if tag exists → PUBLISHED
-        if self.gh.tag_exists(release_tag):
-            return ReleaseState.PUBLISHED
+        # Step 1: Read and validate release-plan.yaml
+        plan, config_error = self._read_release_plan_with_validation()
 
-        # Step 2: Check for snapshot branch
-        snapshot_branches = self.gh.list_branches(f"{config.SNAPSHOT_BRANCH_PREFIX}{release_tag}-*")
+        if config_error:
+            return ReleaseInfoResult(success=False, config_error=config_error)
+
+        plan_release_tag = plan["repository"]["target_release_tag"]
+        plan_release_type = plan["repository"].get("target_release_type")
+        meta_release = plan["repository"].get("meta_release")
+
+        # Step 2: Check if tag exists → PUBLISHED
+        if self.gh.tag_exists(plan_release_tag):
+            return ReleaseInfoResult(
+                success=True,
+                release_tag=plan_release_tag,
+                state=ReleaseState.PUBLISHED,
+                snapshot_branch=None,
+                source="tag",
+                release_issue_number=self.find_release_issue(plan_release_tag),
+                release_type=plan_release_type,
+                meta_release=meta_release,
+            )
+
+        # Step 3: Check for snapshot branches
+        snapshot_branches = self.gh.list_branches(
+            f"{config.SNAPSHOT_BRANCH_PREFIX}{plan_release_tag}-*"
+        )
 
         if snapshot_branches:
-            # Step 3: Check for draft release
-            if self._draft_release_exists(release_tag, retry=retry_draft_release):
-                return ReleaseState.DRAFT_READY
-            return ReleaseState.SNAPSHOT_ACTIVE
+            snapshot_branch = snapshot_branches[0].name
+            metadata = self._read_release_metadata(snapshot_branch)
 
-        # Step 4: No snapshot - check release-plan.yaml for PLANNED state
-        plan = self._read_release_plan()
-        if plan:
-            target_tag = plan.get("repository", {}).get("target_release_tag")
-            release_type = plan.get("repository", {}).get("target_release_type")
+            if metadata:
+                metadata_release_tag = metadata.get(
+                    "repository", {}
+                ).get("release_tag")
+                metadata_release_type = metadata.get(
+                    "repository", {}
+                ).get("release_type")
+            else:
+                # Fall back to extracting from branch name
+                snapshot_id = snapshot_branch.replace(
+                    config.SNAPSHOT_BRANCH_PREFIX, ""
+                )
+                metadata_release_tag = (
+                    snapshot_id.split("-")[0] if "-" in snapshot_id
+                    else snapshot_id
+                )
+                metadata_release_type = None
 
-            if target_tag == release_tag:
-                if release_type and release_type.lower() != "none":
-                    return ReleaseState.PLANNED
-                elif release_type and release_type.lower() == "none":
-                    return ReleaseState.NOT_PLANNED
+            effective_tag = metadata_release_tag or plan_release_tag
 
-        return ReleaseState.NOT_PLANNED
+            # Check for draft release
+            if self._draft_release_exists(
+                effective_tag, retry=retry_draft_release
+            ):
+                state = ReleaseState.DRAFT_READY
+            else:
+                state = ReleaseState.SNAPSHOT_ACTIVE
+
+            return ReleaseInfoResult(
+                success=True,
+                release_tag=effective_tag,
+                state=state,
+                snapshot_branch=snapshot_branch,
+                source="release-metadata.yaml",
+                release_issue_number=self.find_release_issue(effective_tag),
+                release_type=metadata_release_type,
+                meta_release=meta_release,
+            )
+
+        # Step 4: No snapshot — use release-plan.yaml state
+        if plan_release_type and plan_release_type.lower() != "none":
+            state = ReleaseState.PLANNED
+        else:
+            state = ReleaseState.NOT_PLANNED
+
+        return ReleaseInfoResult(
+            success=True,
+            release_tag=plan_release_tag,
+            state=state,
+            snapshot_branch=None,
+            source="release-plan.yaml",
+            release_issue_number=self.find_release_issue(plan_release_tag),
+            release_type=plan_release_type,
+            meta_release=meta_release,
+        )
 
     def _draft_release_exists(self, release_tag: str, retry: bool = False) -> bool:
         """
@@ -363,100 +430,6 @@ class ReleaseStateManager:
 
         return None
 
-    def get_current_release_info(self) -> ReleaseInfoResult:
-        """
-        Get the current release tag and state from repository artifacts.
-
-        This method determines the release_tag from the authoritative source:
-        - If a snapshot branch exists: from release-metadata.yaml on the snapshot
-        - Otherwise: from release-plan.yaml on main branch
-
-        The state is derived accordingly:
-        - PUBLISHED: if tag exists
-        - DRAFT_READY: if snapshot branch and draft release exist
-        - SNAPSHOT_ACTIVE: if snapshot branch exists
-        - PLANNED: if release-plan.yaml has target_release_type != none
-        - NOT_PLANNED: if release-plan.yaml has target_release_type == none or missing
-
-        Configuration errors are returned as error results, NOT as NOT_PLANNED state.
-
-        Returns:
-            ReleaseInfoResult with either:
-                - success=True: release_tag, state, snapshot_branch, source
-                - success=False: config_error with details
-        """
-        # First, try to read release-plan.yaml and handle configuration errors
-        plan, config_error = self._read_release_plan_with_validation()
-
-        if config_error:
-            return ReleaseInfoResult(success=False, config_error=config_error)
-
-        # At this point, plan is valid with all required fields
-        plan_release_tag = plan["repository"]["target_release_tag"]
-        plan_release_type = plan["repository"].get("target_release_type")
-
-        # Check if the planned release is already published
-        if self.gh.tag_exists(plan_release_tag):
-            return ReleaseInfoResult(
-                success=True,
-                release_tag=plan_release_tag,
-                state=ReleaseState.PUBLISHED,
-                snapshot_branch=None,
-                source="tag",
-                release_issue_number=self.find_release_issue(plan_release_tag),
-                release_type=plan_release_type
-            )
-
-        # Check for any snapshot branches for the planned release
-        snapshot_branches = self.gh.list_branches(f"{config.SNAPSHOT_BRANCH_PREFIX}{plan_release_tag}-*")
-
-        if snapshot_branches:
-            # Snapshot exists - read release_tag from release-metadata.yaml
-            snapshot_branch = snapshot_branches[0].name
-            metadata = self._read_release_metadata(snapshot_branch)
-
-            if metadata:
-                metadata_release_tag = metadata.get("repository", {}).get("release_tag")
-            else:
-                # Fall back to extracting from branch name
-                # release-snapshot/r4.1-abc1234 → r4.1
-                snapshot_id = snapshot_branch.replace(config.SNAPSHOT_BRANCH_PREFIX, "")
-                metadata_release_tag = snapshot_id.split("-")[0] if "-" in snapshot_id else snapshot_id
-
-            # Determine if draft ready
-            if self.gh.draft_release_exists(metadata_release_tag or plan_release_tag):
-                state = ReleaseState.DRAFT_READY
-            else:
-                state = ReleaseState.SNAPSHOT_ACTIVE
-
-            effective_tag = metadata_release_tag or plan_release_tag
-            return ReleaseInfoResult(
-                success=True,
-                release_tag=effective_tag,
-                state=state,
-                snapshot_branch=snapshot_branch,
-                source="release-metadata.yaml",
-                release_issue_number=self.find_release_issue(effective_tag),
-                release_type=snapshot.release_type if 'snapshot' in locals() and snapshot else None
-            )
-
-        # No snapshot - use release-plan.yaml state
-        if plan_release_type and plan_release_type.lower() != "none":
-            state = ReleaseState.PLANNED
-        else:
-            # target_release_type is "none" or missing - intentional NOT_PLANNED
-            state = ReleaseState.NOT_PLANNED
-
-        return ReleaseInfoResult(
-            success=True,
-            release_tag=plan_release_tag,
-            state=state,
-            snapshot_branch=None,
-            source="release-plan.yaml",
-            release_issue_number=self.find_release_issue(plan_release_tag),
-            release_type=plan_release_type
-        )
-
     def _read_release_plan_with_validation(
         self, ref: str = "main"
     ) -> tuple[Optional[dict], Optional[ConfigurationError]]:
@@ -523,26 +496,6 @@ class ReleaseStateManager:
             )
 
         return plan, None
-
-    def _read_release_plan(self, ref: str = "main") -> Optional[dict]:
-        """
-        Read and parse release-plan.yaml from the repository.
-
-        Args:
-            ref: Branch, tag, or commit to read from
-
-        Returns:
-            Parsed YAML content as dict, or None if file doesn't exist or is invalid
-        """
-        content = self.gh.get_file_content(config.RELEASE_PLAN_FILE, ref)
-        if not content:
-            return None
-
-        try:
-            return yaml.safe_load(content)
-        except yaml.YAMLError as e:
-            print(f"Warning: Failed to parse release-plan.yaml from {ref}: {e}")
-            return None
 
     def _read_release_metadata(self, ref: str) -> Optional[dict]:
         """

--- a/release_automation/tests/test_issue_manager.py
+++ b/release_automation/tests/test_issue_manager.py
@@ -8,43 +8,7 @@ import pytest
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-from release_automation.scripts.issue_manager import (
-    IssueManager,
-    SnapshotHistoryEntry,
-)
-
-
-class TestSnapshotHistoryEntry:
-    """Tests for SnapshotHistoryEntry dataclass."""
-
-    def test_create_current_entry(self):
-        """Test creating an entry for a current snapshot."""
-        entry = SnapshotHistoryEntry(
-            snapshot_id="r4.1-abc1234",
-            status="Current",
-            created_at="2026-01-30 10:00",
-            release_review_branch="release-review/r4.1-abc1234"
-        )
-
-        assert entry.snapshot_id == "r4.1-abc1234"
-        assert entry.status == "Current"
-        assert entry.discarded_at is None
-        assert entry.reason is None
-
-    def test_create_discarded_entry(self):
-        """Test creating an entry for a discarded snapshot."""
-        entry = SnapshotHistoryEntry(
-            snapshot_id="r4.1-abc1234",
-            status="Discarded",
-            created_at="2026-01-30 10:00",
-            discarded_at="2026-01-30 12:00",
-            reason="API validation failed",
-            release_review_branch="release-review/r4.1-abc1234"
-        )
-
-        assert entry.status == "Discarded"
-        assert entry.discarded_at == "2026-01-30 12:00"
-        assert entry.reason == "API validation failed"
+from release_automation.scripts.issue_manager import IssueManager
 
 
 class TestIssueManagerUpdateSection:
@@ -144,107 +108,6 @@ class TestIssueManagerGetSectionContent:
         content = manager.get_section_content(body, "STATE")
 
         assert content is None
-
-
-class TestIssueManagerAppendToHistory:
-    """Tests for append_to_history method."""
-
-    def test_append_first_entry(self):
-        """Test appending the first entry to an empty history table."""
-        manager = IssueManager()
-
-        body = """<!-- BEGIN:HISTORY -->
-| Snapshot | Status | Created | Discarded | Reason | Review Branch |
-|----------|--------|---------|-----------|--------|---------------|
-<!-- END:HISTORY -->"""
-
-        entry = SnapshotHistoryEntry(
-            snapshot_id="r4.1-abc1234",
-            status="Current",
-            created_at="2026-01-30 10:00",
-            release_review_branch="release-review/r4.1-abc1234"
-        )
-
-        result = manager.append_to_history(body, entry)
-
-        assert "`r4.1-abc1234`" in result
-        assert "**Current**" in result
-        assert "2026-01-30 10:00" in result
-        assert "`release-review/r4.1-abc1234`" in result
-
-    def test_append_second_entry(self):
-        """Test appending a second entry (newest at top)."""
-        manager = IssueManager()
-
-        body = """<!-- BEGIN:HISTORY -->
-| Snapshot | Status | Created | Discarded | Reason | Review Branch |
-|----------|--------|---------|-----------|--------|---------------|
-| `r4.1-abc1234` | Discarded | 2026-01-29 10:00 | 2026-01-29 12:00 | Failed | `release-review/r4.1-abc1234` |
-<!-- END:HISTORY -->"""
-
-        entry = SnapshotHistoryEntry(
-            snapshot_id="r4.1-def5678",
-            status="Current",
-            created_at="2026-01-30 10:00",
-            release_review_branch="release-review/r4.1-def5678"
-        )
-
-        result = manager.append_to_history(body, entry)
-
-        # New entry should be present
-        assert "`r4.1-def5678`" in result
-        # Old entry should still be present
-        assert "`r4.1-abc1234`" in result
-        # New entry should appear before old entry
-        new_pos = result.find("r4.1-def5678")
-        old_pos = result.find("r4.1-abc1234")
-        assert new_pos < old_pos
-
-    def test_append_with_defaults_for_optional_fields(self):
-        """Test that optional fields default to em-dash."""
-        manager = IssueManager()
-
-        body = """<!-- BEGIN:HISTORY -->
-| Snapshot | Status | Created | Discarded | Reason | Review Branch |
-|----------|--------|---------|-----------|--------|---------------|
-<!-- END:HISTORY -->"""
-
-        entry = SnapshotHistoryEntry(
-            snapshot_id="r4.1-abc1234",
-            status="Current",
-            created_at="2026-01-30 10:00",
-            release_review_branch="release-review/r4.1-abc1234"
-            # discarded_at and reason are None
-        )
-
-        result = manager.append_to_history(body, entry)
-
-        # Should have em-dashes for discarded and reason
-        assert "| — |" in result
-
-
-class TestIssueManagerMarkSnapshotDiscarded:
-    """Tests for mark_snapshot_discarded method."""
-
-    @patch('release_automation.scripts.issue_manager.datetime')
-    def test_mark_discarded(self, mock_datetime):
-        """Test marking a snapshot as discarded."""
-        mock_datetime.now.return_value = datetime(2026, 1, 30, 12, 0, tzinfo=timezone.utc)
-
-        manager = IssueManager()
-
-        body = """| `r4.1-abc1234` | **Current** | 2026-01-30 10:00 | — | — | `release-review/r4.1-abc1234` |"""
-
-        result = manager.mark_snapshot_discarded(
-            body,
-            snapshot_id="r4.1-abc1234",
-            reason="Validation failed"
-        )
-
-        assert "Discarded" in result
-        assert "2026-01-30 12:00" in result
-        assert "Validation failed" in result
-        assert "**Current**" not in result
 
 
 class TestIssueManagerGenerateTitle:
@@ -514,25 +377,6 @@ old
         result = manager.update_section(body, "STATE", new_content)
 
         assert new_content in result
-
-    def test_history_without_table_structure(self):
-        """Test appending to history when table structure is missing."""
-        manager = IssueManager()
-
-        body = """<!-- BEGIN:HISTORY -->
-Some malformed content without table
-<!-- END:HISTORY -->"""
-
-        entry = SnapshotHistoryEntry(
-            snapshot_id="r4.1-abc1234",
-            status="Current",
-            created_at="2026-01-30 10:00",
-            release_review_branch="release-review/r4.1-abc1234"
-        )
-
-        # Should not crash, just append
-        result = manager.append_to_history(body, entry)
-        assert "`r4.1-abc1234`" in result
 
     def test_get_section_with_nested_comments(self):
         """Test getting section that might have nested HTML comments."""

--- a/release_automation/tests/test_issue_sync.py
+++ b/release_automation/tests/test_issue_sync.py
@@ -13,7 +13,7 @@ from release_automation.scripts.issue_sync import (
     WORKFLOW_MARKER,
     REQUIRED_LABELS,
 )
-from release_automation.scripts.state_manager import ReleaseState
+from release_automation.scripts.state_manager import ReleaseInfoResult, ReleaseState
 
 
 class TestSyncResult:
@@ -181,7 +181,9 @@ class TestSyncReleaseIssue:
             }
         }
 
-        state_manager.derive_state.return_value = ReleaseState.PLANNED
+        state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=True, state=ReleaseState.PLANNED,
+            release_tag="r4.1", source="release-plan.yaml")
         gh.search_issues.return_value = []
         gh.create_issue.return_value = {"number": 1, "title": "Release r4.1 (RC)"}
         issue_manager.generate_title.return_value = "Release r4.1 (RC) — Sync26"
@@ -204,7 +206,9 @@ class TestSyncReleaseIssue:
             }
         }
 
-        state_manager.derive_state.return_value = ReleaseState.PLANNED
+        state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=True, state=ReleaseState.PLANNED,
+            release_tag="r4.1", source="release-plan.yaml")
         gh.search_issues.return_value = [
             {
                 "number": 1,
@@ -234,7 +238,9 @@ class TestSyncReleaseIssue:
             }
         }
 
-        state_manager.derive_state.return_value = ReleaseState.SNAPSHOT_ACTIVE
+        state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=True, state=ReleaseState.SNAPSHOT_ACTIVE,
+            release_tag="r4.1", source="release-metadata.yaml")
         gh.search_issues.return_value = [
             {
                 "number": 1,
@@ -265,7 +271,9 @@ class TestSyncReleaseIssue:
             }
         }
 
-        state_manager.derive_state.return_value = ReleaseState.NOT_PLANNED
+        state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=True, state=ReleaseState.NOT_PLANNED,
+            release_tag="r4.1", source="release-plan.yaml")
         gh.search_issues.return_value = []
 
         result = manager.sync_release_issue(release_plan)
@@ -708,7 +716,9 @@ class TestSyncReleaseIssueWithLabels:
         gh = MagicMock()
         state_manager = MagicMock()
         gh.get_label.return_value = None  # All labels missing
-        state_manager.derive_state.return_value = ReleaseState.NOT_PLANNED
+        state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=True, state=ReleaseState.NOT_PLANNED,
+            release_tag="r4.1", source="release-plan.yaml")
         gh.search_issues.return_value = []
 
         manager = IssueSyncManager(gh, state_manager, MagicMock(), MagicMock())

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -22,7 +22,7 @@ from release_automation.scripts.snapshot_creator import (
     InvalidStateError,
     TransformationError,
 )
-from release_automation.scripts.state_manager import ReleaseState
+from release_automation.scripts.state_manager import ReleaseInfoResult, ReleaseState
 from release_automation.scripts.mechanical_transformer import TransformationResult
 from release_automation.scripts.git_operations import PullRequestInfo, GitOperationsError
 
@@ -89,7 +89,9 @@ def mock_metadata_generator():
 def mock_state_manager():
     """Create a mock ReleaseStateManager."""
     mgr = Mock()
-    mgr.derive_state.return_value = ReleaseState.PLANNED
+    mgr.derive_state.return_value = ReleaseInfoResult(
+        success=True, state=ReleaseState.PLANNED,
+        release_tag="r4.1", source="release-plan.yaml")
     return mgr
 
 
@@ -267,9 +269,16 @@ class TestGenerateSnapshotId:
 class TestValidatePreconditions:
     """Tests for precondition validation."""
 
+    def _make_result(self, state):
+        """Helper to create a ReleaseInfoResult for a given state."""
+        return ReleaseInfoResult(
+            success=True, state=state,
+            release_tag="r4.1", source="release-plan.yaml")
+
     def test_valid_planned_state(self, snapshot_creator, mock_state_manager):
         """Test validation passes for PLANNED state."""
-        mock_state_manager.derive_state.return_value = ReleaseState.PLANNED
+        mock_state_manager.derive_state.return_value = self._make_result(
+            ReleaseState.PLANNED)
 
         errors = snapshot_creator.validate_preconditions("r4.1")
 
@@ -277,7 +286,8 @@ class TestValidatePreconditions:
 
     def test_invalid_published_state(self, snapshot_creator, mock_state_manager):
         """Test validation fails for PUBLISHED state."""
-        mock_state_manager.derive_state.return_value = ReleaseState.PUBLISHED
+        mock_state_manager.derive_state.return_value = self._make_result(
+            ReleaseState.PUBLISHED)
 
         errors = snapshot_creator.validate_preconditions("r4.1")
 
@@ -286,7 +296,8 @@ class TestValidatePreconditions:
 
     def test_invalid_snapshot_active_state(self, snapshot_creator, mock_state_manager):
         """Test validation fails for SNAPSHOT_ACTIVE state."""
-        mock_state_manager.derive_state.return_value = ReleaseState.SNAPSHOT_ACTIVE
+        mock_state_manager.derive_state.return_value = self._make_result(
+            ReleaseState.SNAPSHOT_ACTIVE)
 
         errors = snapshot_creator.validate_preconditions("r4.1")
 
@@ -295,7 +306,8 @@ class TestValidatePreconditions:
 
     def test_invalid_draft_ready_state(self, snapshot_creator, mock_state_manager):
         """Test validation fails for DRAFT_READY state."""
-        mock_state_manager.derive_state.return_value = ReleaseState.DRAFT_READY
+        mock_state_manager.derive_state.return_value = self._make_result(
+            ReleaseState.DRAFT_READY)
 
         errors = snapshot_creator.validate_preconditions("r4.1")
 
@@ -304,12 +316,28 @@ class TestValidatePreconditions:
 
     def test_invalid_not_planned_state(self, snapshot_creator, mock_state_manager):
         """Test validation fails for NOT_PLANNED state."""
-        mock_state_manager.derive_state.return_value = ReleaseState.NOT_PLANNED
+        mock_state_manager.derive_state.return_value = self._make_result(
+            ReleaseState.NOT_PLANNED)
 
         errors = snapshot_creator.validate_preconditions("r4.1")
 
         assert len(errors) == 1
         assert "not planned" in errors[0]
+
+    def test_config_error_returns_error(self, snapshot_creator, mock_state_manager):
+        """Test that config errors from derive_state() are surfaced."""
+        from release_automation.scripts.state_manager import ConfigurationError
+        mock_state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=False,
+            config_error=ConfigurationError(
+                error_type="missing_file",
+                message="No release-plan.yaml found",
+                file_path="release-plan.yaml"))
+
+        errors = snapshot_creator.validate_preconditions("r4.1")
+
+        assert len(errors) == 1
+        assert "Configuration error" in errors[0]
 
 
 # --- Tests for create_snapshot ---
@@ -374,7 +402,9 @@ class TestCreateSnapshot:
         sample_release_plan,
     ):
         """Test that validation failure returns early without creating snapshot."""
-        mock_state_manager.derive_state.return_value = ReleaseState.PUBLISHED
+        mock_state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=True, state=ReleaseState.PUBLISHED,
+            release_tag="r4.1", source="tag")
 
         config = SnapshotConfig(release_tag="r4.1")
         result = snapshot_creator.create_snapshot(sample_release_plan, config)

--- a/release_automation/tests/test_state_manager.py
+++ b/release_automation/tests/test_state_manager.py
@@ -40,62 +40,84 @@ def state_manager(mock_github_client):
 
 
 class TestDeriveState:
-    """Tests for derive_state method."""
+    """Tests for derive_state method.
+
+    Verifies state derivation priority:
+    1. Config validation (errors → failure)
+    2. PUBLISHED (tag exists)
+    3. DRAFT_READY (snapshot + draft release)
+    4. SNAPSHOT_ACTIVE (snapshot, no draft)
+    5. PLANNED / NOT_PLANNED (from release-plan.yaml)
+    """
+
+    VALID_PLAN = """
+repository:
+  target_release_tag: r4.1
+  target_release_type: initial
+"""
 
     def test_published_when_tag_exists(self, state_manager, mock_github_client):
         """Tag exists → PUBLISHED state."""
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
         mock_github_client.tag_exists.return_value = True
 
-        state = state_manager.derive_state("r4.1")
+        result = state_manager.derive_state()
 
-        assert state == ReleaseState.PUBLISHED
-        mock_github_client.tag_exists.assert_called_once_with("r4.1")
+        assert result.success
+        assert result.state == ReleaseState.PUBLISHED
+        assert result.release_tag == "r4.1"
+        assert result.source == "tag"
 
     def test_draft_ready_when_snapshot_and_draft_release(
         self, state_manager, mock_github_client
     ):
         """Snapshot branch + draft release → DRAFT_READY state."""
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
         mock_github_client.tag_exists.return_value = False
         mock_github_client.list_branches.return_value = [
             Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
         ]
         mock_github_client.draft_release_exists.return_value = True
 
-        state = state_manager.derive_state("r4.1")
+        result = state_manager.derive_state()
 
-        assert state == ReleaseState.DRAFT_READY
-        mock_github_client.list_branches.assert_called_once_with(
-            "release-snapshot/r4.1-*"
-        )
-        mock_github_client.draft_release_exists.assert_called_once_with("r4.1")
+        assert result.success
+        assert result.state == ReleaseState.DRAFT_READY
+        assert result.source == "release-metadata.yaml"
 
     def test_snapshot_active_when_snapshot_no_draft(
         self, state_manager, mock_github_client
     ):
         """Snapshot branch exists, no draft release → SNAPSHOT_ACTIVE state."""
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
         mock_github_client.tag_exists.return_value = False
         mock_github_client.list_branches.return_value = [
             Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
         ]
         mock_github_client.draft_release_exists.return_value = False
 
-        state = state_manager.derive_state("r4.1")
+        result = state_manager.derive_state()
 
-        assert state == ReleaseState.SNAPSHOT_ACTIVE
+        assert result.success
+        assert result.state == ReleaseState.SNAPSHOT_ACTIVE
+        assert result.snapshot_branch == "release-snapshot/r4.1-abc1234"
 
     @patch("release_automation.scripts.state_manager.time.sleep")
     def test_draft_ready_retries_when_enabled(
         self, mock_sleep, state_manager, mock_github_client
     ):
         """Draft release detection retries before concluding DRAFT_READY."""
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
+        mock_github_client.tag_exists.return_value = False
         mock_github_client.list_branches.return_value = [
             Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
         ]
         mock_github_client.draft_release_exists.side_effect = [False, False, True]
 
-        state = state_manager.derive_state("r4.1", retry_draft_release=True)
+        result = state_manager.derive_state(retry_draft_release=True)
 
-        assert state == ReleaseState.DRAFT_READY
+        assert result.success
+        assert result.state == ReleaseState.DRAFT_READY
         assert mock_github_client.draft_release_exists.call_count == 3
         assert mock_sleep.call_count == 2
 
@@ -104,32 +126,34 @@ class TestDeriveState:
         self, mock_sleep, state_manager, mock_github_client
     ):
         """Retry exhaustion falls back to SNAPSHOT_ACTIVE."""
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
+        mock_github_client.tag_exists.return_value = False
         mock_github_client.list_branches.return_value = [
             Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
         ]
         mock_github_client.draft_release_exists.side_effect = [False, False, False]
 
-        state = state_manager.derive_state("r4.1", retry_draft_release=True)
+        result = state_manager.derive_state(retry_draft_release=True)
 
-        assert state == ReleaseState.SNAPSHOT_ACTIVE
+        assert result.success
+        assert result.state == ReleaseState.SNAPSHOT_ACTIVE
         assert mock_github_client.draft_release_exists.call_count == 3
         assert mock_sleep.call_count == 2
 
     def test_planned_when_release_plan_defines_release(
         self, state_manager, mock_github_client
     ):
-        """release-plan.yaml with matching target → PLANNED state."""
+        """release-plan.yaml with valid release type → PLANNED state."""
         mock_github_client.tag_exists.return_value = False
         mock_github_client.list_branches.return_value = []
-        mock_github_client.get_file_content.return_value = """
-repository:
-  target_release_tag: r4.1
-  target_release_type: initial
-"""
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
 
-        state = state_manager.derive_state("r4.1")
+        result = state_manager.derive_state()
 
-        assert state == ReleaseState.PLANNED
+        assert result.success
+        assert result.state == ReleaseState.PLANNED
+        assert result.release_tag == "r4.1"
+        assert result.source == "release-plan.yaml"
 
     def test_not_planned_when_release_type_is_none(
         self, state_manager, mock_github_client
@@ -143,59 +167,47 @@ repository:
   target_release_type: none
 """
 
-        state = state_manager.derive_state("r4.1")
+        result = state_manager.derive_state()
 
-        assert state == ReleaseState.NOT_PLANNED
+        assert result.success
+        assert result.state == ReleaseState.NOT_PLANNED
+        assert result.release_tag == "r4.1"
 
-    def test_not_planned_when_tag_mismatch(self, state_manager, mock_github_client):
-        """release-plan.yaml with different tag → NOT_PLANNED state."""
+    def test_includes_meta_release(self, state_manager, mock_github_client):
+        """meta_release from release-plan.yaml is included in result."""
         mock_github_client.tag_exists.return_value = False
         mock_github_client.list_branches.return_value = []
         mock_github_client.get_file_content.return_value = """
 repository:
-  target_release_tag: r5.0
+  target_release_tag: r4.1
   target_release_type: initial
+  meta_release: Sync26
 """
 
-        state = state_manager.derive_state("r4.1")
+        result = state_manager.derive_state()
 
-        assert state == ReleaseState.NOT_PLANNED
+        assert result.success
+        assert result.meta_release == "Sync26"
 
-    def test_not_planned_when_no_release_plan(self, state_manager, mock_github_client):
-        """No release-plan.yaml → NOT_PLANNED state."""
-        mock_github_client.tag_exists.return_value = False
-        mock_github_client.list_branches.return_value = []
-        mock_github_client.get_file_content.return_value = None
-
-        state = state_manager.derive_state("r4.1")
-
-        assert state == ReleaseState.NOT_PLANNED
-
-    def test_not_planned_when_malformed_yaml(self, state_manager, mock_github_client):
-        """Malformed release-plan.yaml → NOT_PLANNED state."""
-        mock_github_client.tag_exists.return_value = False
-        mock_github_client.list_branches.return_value = []
-        mock_github_client.get_file_content.return_value = "{{invalid yaml::"
-
-        state = state_manager.derive_state("r4.1")
-
-        assert state == ReleaseState.NOT_PLANNED
-
-    def test_not_planned_when_missing_repository_section(
+    def test_snapshot_uses_metadata_release_tag(
         self, state_manager, mock_github_client
     ):
-        """release-plan.yaml without repository section → NOT_PLANNED state."""
+        """Snapshot path reads release_tag from release-metadata.yaml."""
+        mock_github_client.get_file_content.side_effect = [
+            self.VALID_PLAN,  # release-plan.yaml (validation)
+            "repository:\n  release_tag: r4.1\n  release_type: pre-release-rc",
+        ]
         mock_github_client.tag_exists.return_value = False
-        mock_github_client.list_branches.return_value = []
-        mock_github_client.get_file_content.return_value = """
-apis:
-  - name: quality-on-demand
-    version: 1.0.0
-"""
+        mock_github_client.list_branches.return_value = [
+            Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
+        ]
+        mock_github_client.draft_release_exists.return_value = False
 
-        state = state_manager.derive_state("r4.1")
+        result = state_manager.derive_state()
 
-        assert state == ReleaseState.NOT_PLANNED
+        assert result.success
+        assert result.release_tag == "r4.1"
+        assert result.release_type == "pre-release-rc"
 
 
 class TestGetCurrentSnapshot:
@@ -295,60 +307,58 @@ class TestGetSnapshotHistory:
 class TestStateTransitions:
     """Integration tests for state transition scenarios."""
 
-    def test_full_lifecycle_happy_path(self, mock_github_client):
-        """Test state transitions through the happy path."""
-        manager = ReleaseStateManager(mock_github_client)
-
-        # Initial state: PLANNED
-        mock_github_client.get_file_content.return_value = """
+    VALID_PLAN = """
 repository:
   target_release_tag: r4.1
   target_release_type: initial
 """
-        assert manager.derive_state("r4.1") == ReleaseState.PLANNED
+
+    def test_full_lifecycle_happy_path(self, mock_github_client):
+        """Test state transitions through the happy path."""
+        manager = ReleaseStateManager(mock_github_client)
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
+
+        # Initial state: PLANNED
+        assert manager.derive_state().state == ReleaseState.PLANNED
 
         # After /create-snapshot: SNAPSHOT_ACTIVE
         mock_github_client.list_branches.return_value = [
             Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
         ]
-        assert manager.derive_state("r4.1") == ReleaseState.SNAPSHOT_ACTIVE
+        assert manager.derive_state().state == ReleaseState.SNAPSHOT_ACTIVE
 
         # After PR merge creates draft: DRAFT_READY
         mock_github_client.draft_release_exists.return_value = True
-        assert manager.derive_state("r4.1") == ReleaseState.DRAFT_READY
+        assert manager.derive_state().state == ReleaseState.DRAFT_READY
 
         # After release published: PUBLISHED
         mock_github_client.tag_exists.return_value = True
-        assert manager.derive_state("r4.1") == ReleaseState.PUBLISHED
+        assert manager.derive_state().state == ReleaseState.PUBLISHED
 
     def test_discard_and_retry_path(self, mock_github_client):
         """Test state transitions through discard and retry path."""
         manager = ReleaseStateManager(mock_github_client)
+        mock_github_client.get_file_content.return_value = self.VALID_PLAN
 
         # Start with SNAPSHOT_ACTIVE
-        mock_github_client.get_file_content.return_value = """
-repository:
-  target_release_tag: r4.1
-  target_release_type: initial
-"""
         mock_github_client.list_branches.return_value = [
             Branch(name="release-snapshot/r4.1-abc1234", sha="abc1234")
         ]
-        assert manager.derive_state("r4.1") == ReleaseState.SNAPSHOT_ACTIVE
+        assert manager.derive_state().state == ReleaseState.SNAPSHOT_ACTIVE
 
         # After /discard-snapshot: back to PLANNED
         mock_github_client.list_branches.return_value = []
-        assert manager.derive_state("r4.1") == ReleaseState.PLANNED
+        assert manager.derive_state().state == ReleaseState.PLANNED
 
         # New /create-snapshot: SNAPSHOT_ACTIVE again
         mock_github_client.list_branches.return_value = [
             Branch(name="release-snapshot/r4.1-def5678", sha="def5678")
         ]
-        assert manager.derive_state("r4.1") == ReleaseState.SNAPSHOT_ACTIVE
+        assert manager.derive_state().state == ReleaseState.SNAPSHOT_ACTIVE
 
 
-class TestGetCurrentReleaseInfoErrors:
-    """Tests for get_current_release_info() configuration error handling.
+class TestDeriveStateErrors:
+    """Tests for derive_state() configuration error handling.
 
     Configuration errors should return error results, not NOT_PLANNED state.
     """
@@ -357,7 +367,7 @@ class TestGetCurrentReleaseInfoErrors:
         """Missing release-plan.yaml returns config error, not NOT_PLANNED."""
         mock_github_client.get_file_content.return_value = None
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert not result.success
         assert result.config_error is not None
@@ -370,7 +380,7 @@ class TestGetCurrentReleaseInfoErrors:
         """Malformed YAML returns config error, not NOT_PLANNED."""
         mock_github_client.get_file_content.return_value = "{{invalid yaml:: missing"
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert not result.success
         assert result.config_error is not None
@@ -382,7 +392,7 @@ class TestGetCurrentReleaseInfoErrors:
         """Empty YAML (null) returns config error."""
         mock_github_client.get_file_content.return_value = ""
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert not result.success
         assert result.config_error is not None
@@ -396,7 +406,7 @@ class TestGetCurrentReleaseInfoErrors:
 apis:
   - api_name: quality-on-demand
 """
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert not result.success
         assert result.config_error is not None
@@ -411,7 +421,7 @@ apis:
 repository:
   target_release_type: initial
 """
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert not result.success
         assert result.config_error is not None
@@ -430,7 +440,7 @@ repository:
         mock_github_client.list_branches.return_value = []
         mock_github_client.tag_exists.return_value = False
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert result.success
         assert result.state == ReleaseState.NOT_PLANNED
@@ -448,7 +458,7 @@ repository:
         mock_github_client.list_branches.return_value = []
         mock_github_client.tag_exists.return_value = False
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert result.success
         assert result.state == ReleaseState.NOT_PLANNED
@@ -466,7 +476,7 @@ repository:
         mock_github_client.list_branches.return_value = []
         mock_github_client.tag_exists.return_value = False
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert result.success
         assert result.state == ReleaseState.PLANNED
@@ -477,7 +487,7 @@ repository:
         """to_dict() returns proper structure for error results."""
         mock_github_client.get_file_content.return_value = None
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
         result_dict = result.to_dict()
 
         assert result_dict["release_tag"] is None
@@ -496,7 +506,7 @@ repository:
         mock_github_client.tag_exists.return_value = False
         mock_github_client.search_issues.return_value = []
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
         result_dict = result.to_dict()
 
         assert result_dict["release_tag"] == "r4.1"
@@ -595,8 +605,8 @@ class TestFindReleaseIssue:
         assert result is None
 
 
-class TestGetCurrentReleaseInfoWithIssue:
-    """Tests for get_current_release_info including release_issue_number."""
+class TestDeriveStateWithIssue:
+    """Tests for derive_state including release_issue_number."""
 
     def test_includes_issue_number_when_found(self, state_manager, mock_github_client):
         """Includes release issue number when issue exists."""
@@ -615,7 +625,7 @@ repository:
             }
         ]
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert result.success
         assert result.release_issue_number == 123
@@ -633,7 +643,7 @@ repository:
         mock_github_client.tag_exists.return_value = False
         mock_github_client.search_issues.return_value = []
 
-        result = state_manager.get_current_release_info()
+        result = state_manager.derive_state()
 
         assert result.success
         assert result.release_issue_number is None

--- a/shared-actions/derive-release-state/action.yml
+++ b/shared-actions/derive-release-state/action.yml
@@ -10,12 +10,6 @@ description: |
   - SNAPSHOT_ACTIVE/DRAFT_READY: from release-metadata.yaml on snapshot branch
   - PUBLISHED: from the git tag
 
-inputs:
-  release_tag:
-    description: "Release tag to check - DEPRECATED: leave empty to auto-derive from repository artifacts"
-    required: false
-    default: ""
-
 outputs:
   release_tag:
     description: "Release tag from authoritative source (release-plan.yaml or release-metadata.yaml)"
@@ -90,7 +84,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         GITHUB_SERVER_URL: ${{ github.server_url }}
-        RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
         REPO: ${{ github.repository }}
         SCRIPTS_PATH: ${{ github.action_path }}/../../release_automation/scripts
       run: |
@@ -112,14 +105,13 @@ runs:
         # Initialize clients
         repo = os.environ['REPO']
         token = os.environ.get('GITHUB_TOKEN')
-        release_tag_input = os.environ.get('RELEASE_TAG_INPUT', '').strip()
         server_url = os.environ.get('GITHUB_SERVER_URL', 'https://github.com')
 
         gh = GitHubClient(repo=repo, token=token)
         manager = ReleaseStateManager(github_client=gh)
 
-        # Get release info from repository artifacts (authoritative source)
-        release_info = manager.get_current_release_info()
+        # Derive state from repository artifacts (authoritative source)
+        release_info = manager.derive_state()
         output_file = os.environ['GITHUB_OUTPUT']
 
         # Handle configuration errors
@@ -172,11 +164,7 @@ runs:
         if snapshot and snapshot.src_commit_sha:
             src_commit_sha_short = snapshot.src_commit_sha[:7]
             
-        # Read meta_release from release-plan.yaml (raw cycle name, e.g., "Sync26")
-        meta_release = ""
-        plan = manager._read_release_plan()
-        if plan:
-            meta_release = plan.get("repository", {}).get("meta_release", "") or ""
+        meta_release = release_info.meta_release or ""
 
         # Write outputs to GITHUB_OUTPUT
         with open(output_file, 'a') as f:


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Internal cleanup of release automation on the validation-framework branch.

Consolidates `derive_state()` and `get_current_release_info()` into a single
`derive_state()` method that derives `release_tag` from repository artifacts
instead of requiring it as input. Also removes dead placeholder code for the
dropped snapshot history table feature.

**State derivation:**
- `derive_state()` no longer takes `release_tag` parameter — reads
  release-plan.yaml and release-metadata.yaml to determine it
- Returns `ReleaseInfoResult` instead of plain `ReleaseState` enum
- Uses strict config validation (config errors are failures, not states)
- Adds `meta_release` field to `ReleaseInfoResult`
- Removes `get_current_release_info()`, lenient `_read_release_plan()`, and
  deprecated `release_tag` input from `derive-release-state` action
- Fixes pre-existing bug where `release_type` referenced undefined variable
- Updates all callers and tests

**Snapshot history cleanup:**
- Removes `SnapshotHistoryEntry`, `append_to_history()`,
  `mark_snapshot_discarded()` — feature was dropped in favor of comment trail
- Removes 9 corresponding tests

#### Which issue(s) this PR fixes:

N/A — internal cleanup on validation-framework branch

#### Special notes for reviewers:

- 557 tests pass (565 original − 9 removed + 1 added)
- External behavior unchanged — only the Python interface and action input changed
- The `derive-release-state` action outputs remain identical

#### Changelog input

```release-note
N/A (internal refactoring, no user-facing changes)
```

#### Additional documentation

```docs
Updated technical-architecture.md to reflect new method name
```