### PR TITLE
fix(derive-state): read release plan for PLANNED state output context

### DIFF
--- a/shared-actions/derive-release-state/action.yml
+++ b/shared-actions/derive-release-state/action.yml
@@ -193,11 +193,12 @@ runs:
                 f.write(f"commonalities_release={snapshot.commonalities_release}\n")
                 f.write(f"identity_consent_management_release={snapshot.identity_consent_management_release}\n")
             else:
-                # No snapshot — use plan data (already read above) for PLANNED state context
+                # No snapshot — read plan data for PLANNED state context
                 plan_apis = []
                 plan_commonalities = ""
                 plan_icm = ""
                 plan_rtype = release_info.release_type or ""
+                plan, _ = manager._read_release_plan_with_validation()
                 if plan:
                     for api in plan.get("apis", []):
                         plan_apis.append({


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes a `NameError: name 'plan' is not defined` crash in the `derive-release-state` action for repos in PLANNED state (no snapshot).

After the state derivation consolidation in #156, the inline script in `action.yml` still referenced a `plan` variable that was previously populated by the now-removed `_read_release_plan()` call. This caused the action to crash when outputting API and dependency data for the PLANNED state path.

Fix: re-read the plan via `_read_release_plan_with_validation()` in the no-snapshot branch.

#### Which issue(s) this PR fixes:

Bug found in canary test in ReleaseTest: [run 24303751703](https://github.com/camaraproject/ReleaseTest/actions/runs/24303751703/job/70961515962)

#### Special notes for reviewers:

- One-line fix (+ comment update)
- 557 tests pass
- Verified no other references to removed functions remain in the codebase

#### Changelog input

```release-note
N/A (internal fix)
```

#### Additional documentation

```docs
N/A
```