### PR TITLE
fix: Spectral 64KB buffer truncation + app-id to client-id migration

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -422,10 +422,10 @@ jobs:
 
       - name: Generate App Token
         id: app-token
-        if: steps.decide.outputs.action == 'post_comment' && vars.RELEASE_APP_ID != ''
+        if: steps.decide.outputs.action == 'post_comment' && vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout tooling (for slash command)
@@ -798,10 +798,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout tooling
@@ -922,10 +922,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Discard Snapshot
@@ -1032,10 +1032,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Delete Draft Release
@@ -1160,10 +1160,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout tooling
@@ -1239,10 +1239,10 @@ jobs:
 
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Execute Publish Flow
@@ -1377,10 +1377,10 @@ jobs:
 
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Copy README release info from tag
@@ -1596,10 +1596,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Extract CHANGELOG release notes
@@ -1837,10 +1837,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout tooling
@@ -1946,10 +1946,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout tooling
@@ -2117,10 +2117,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout tooling

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -182,11 +182,11 @@ jobs:
         if: >-
           always() && steps.validation.outcome == 'success'
           && github.event_name == 'pull_request'
-          && vars.VALIDATION_APP_ID != ''
+          && vars.VALIDATION_APP_CLIENT_ID != ''
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.VALIDATION_APP_ID }}
+          client-id: ${{ vars.VALIDATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.VALIDATION_APP_PRIVATE_KEY }}
 
       # ── Step 9: Resolve write access ───────────────────────────

--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import List, Optional
@@ -292,10 +294,13 @@ def run_spectral(
 ) -> SpectralResult:
     """Invoke Spectral CLI and capture structured output.
 
-    Uses ``--format json`` for machine-readable output.  The default
-    ``--fail-severity error`` means exit 0 for warnings-only and exit 1
-    when errors are present — both are normal operation with valid JSON
-    on stdout.
+    Uses ``--format json`` for machine-readable output.  Output is written
+    to a temporary file via Spectral's ``--output`` flag to avoid Node.js
+    stdout pipe truncation on large result sets (>64 KB).
+
+    The default ``--fail-severity error`` means exit 0 for warnings-only
+    and exit 1 when errors are present — both are normal operation with
+    valid JSON in the output file.
 
     Args:
         ruleset_path: Path to the Spectral ruleset file.
@@ -307,48 +312,67 @@ def run_spectral(
     Returns:
         :class:`SpectralResult` with parsed findings and status.
     """
-    cmd = [
-        "spectral",
-        "lint",
-        "--format", "json",
-        "--quiet",
-        "--ruleset", str(ruleset_path),
-        *spec_patterns,
-    ]
-
+    # Create a temp file for Spectral JSON output.  Placed in cwd to stay
+    # on the same filesystem.  delete=False so we control cleanup.
+    fd, output_path = tempfile.mkstemp(suffix=".json", dir=str(cwd))
+    output_file = Path(output_path)
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=str(cwd),
-            timeout=300,
-        )
-    except FileNotFoundError:
+        # Close the fd immediately — Spectral will open the file by name.
+        os.close(fd)
+
+        cmd = [
+            "spectral",
+            "lint",
+            "--format", "json",
+            "--quiet",
+            "--output", str(output_file),
+            "--ruleset", str(ruleset_path),
+            *spec_patterns,
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(cwd),
+                timeout=300,
+            )
+        except FileNotFoundError:
+            return SpectralResult(
+                findings=[],
+                success=False,
+                error_message="Spectral CLI not found — is @stoplight/spectral-cli installed?",
+            )
+        except subprocess.TimeoutExpired:
+            return SpectralResult(
+                findings=[],
+                success=False,
+                error_message="Spectral timed out after 300 seconds",
+            )
+
+        # Exit 0 or 1: normal operation (findings may or may not exist).
+        if result.returncode in (0, 1):
+            if output_file.exists() and output_file.stat().st_size > 0:
+                json_text = output_file.read_text(encoding="utf-8")
+            else:
+                logger.warning(
+                    "Spectral output file is empty or missing (exit %d)",
+                    result.returncode,
+                )
+                json_text = ""
+            findings = parse_spectral_output(json_text, repo_root=str(cwd))
+            return SpectralResult(findings=findings, success=True)
+
+        # Exit 2+: Spectral runtime error.
+        stderr = result.stderr.strip() if result.stderr else "unknown error"
         return SpectralResult(
             findings=[],
             success=False,
-            error_message="Spectral CLI not found — is @stoplight/spectral-cli installed?",
+            error_message=f"Spectral exited with code {result.returncode}: {stderr}",
         )
-    except subprocess.TimeoutExpired:
-        return SpectralResult(
-            findings=[],
-            success=False,
-            error_message="Spectral timed out after 300 seconds",
-        )
-
-    # Exit 0 or 1: normal operation (findings may or may not exist).
-    if result.returncode in (0, 1):
-        findings = parse_spectral_output(result.stdout, repo_root=str(cwd))
-        return SpectralResult(findings=findings, success=True)
-
-    # Exit 2+: Spectral runtime error.
-    stderr = result.stderr.strip() if result.stderr else "unknown error"
-    return SpectralResult(
-        findings=[],
-        success=False,
-        error_message=f"Spectral exited with code {result.returncode}: {stderr}",
-    )
+    finally:
+        output_file.unlink(missing_ok=True)
 
 
 def _make_error_finding(message: str) -> dict:

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -401,12 +401,30 @@ class TestParseSpectralOutput:
 # ---------------------------------------------------------------------------
 
 
+def _spectral_side_effect(
+    json_content: str,
+    returncode: int = 0,
+    stderr: str = "",
+):
+    """Create a subprocess.run side_effect that writes JSON to the --output file.
+
+    Simulates Spectral's behaviour: it writes results to the file specified
+    by ``--output`` and exits with the given return code.
+    """
+    def side_effect(cmd, **kwargs):
+        output_idx = cmd.index("--output")
+        output_path = Path(cmd[output_idx + 1])
+        output_path.write_text(json_content, encoding="utf-8")
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=returncode, stdout="", stderr=stderr,
+        )
+    return side_effect
+
+
 class TestRunSpectral:
     @patch("validation.engines.spectral_adapter.subprocess.run")
     def test_exit_0_no_findings(self, mock_run, tmp_path):
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="[]", stderr="",
-        )
+        mock_run.side_effect = _spectral_side_effect("[]", returncode=0)
         result = run_spectral(
             tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path,
         )
@@ -416,11 +434,8 @@ class TestRunSpectral:
 
     @patch("validation.engines.spectral_adapter.subprocess.run")
     def test_exit_1_with_findings(self, mock_run, tmp_path):
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[],
-            returncode=1,
-            stdout=json.dumps([SAMPLE_SPECTRAL_FINDING]),
-            stderr="",
+        mock_run.side_effect = _spectral_side_effect(
+            json.dumps([SAMPLE_SPECTRAL_FINDING]), returncode=1,
         )
         result = run_spectral(
             tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path,
@@ -431,8 +446,8 @@ class TestRunSpectral:
 
     @patch("validation.engines.spectral_adapter.subprocess.run")
     def test_exit_2_runtime_error(self, mock_run, tmp_path):
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=2, stdout="", stderr="Error: invalid ruleset",
+        mock_run.side_effect = _spectral_side_effect(
+            "", returncode=2, stderr="Error: invalid ruleset",
         )
         result = run_spectral(
             tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path,
@@ -465,9 +480,8 @@ class TestRunSpectral:
             **SAMPLE_SPECTRAL_FINDING,
             "source": f"{tmp_path}/code/API_definitions/quality-on-demand.yaml",
         }
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=1,
-            stdout=json.dumps([abs_finding]), stderr="",
+        mock_run.side_effect = _spectral_side_effect(
+            json.dumps([abs_finding]), returncode=1,
         )
         result = run_spectral(
             tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path,
@@ -476,19 +490,65 @@ class TestRunSpectral:
         assert result.findings[0]["path"] == "code/API_definitions/quality-on-demand.yaml"
 
     @patch("validation.engines.spectral_adapter.subprocess.run")
-    def test_command_includes_ruleset_and_patterns(self, mock_run, tmp_path):
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="[]", stderr="",
-        )
+    def test_command_includes_output_flag_and_patterns(self, mock_run, tmp_path):
+        mock_run.side_effect = _spectral_side_effect("[]", returncode=0)
         ruleset = tmp_path / ".spectral-r4.yaml"
         run_spectral(ruleset, ["code/API_definitions/*.yaml"], cwd=tmp_path)
         call_args = mock_run.call_args
         cmd = call_args[0][0]
         assert "--ruleset" in cmd
         assert "--quiet" in cmd
+        assert "--output" in cmd
         assert str(ruleset) in cmd
         assert "code/API_definitions/*.yaml" in cmd
         assert call_args[1]["cwd"] == str(tmp_path)
+
+    @patch("validation.engines.spectral_adapter.subprocess.run")
+    def test_temp_file_cleaned_up_on_success(self, mock_run, tmp_path):
+        """Temp output file is removed after successful invocation."""
+        mock_run.side_effect = _spectral_side_effect("[]", returncode=0)
+        run_spectral(tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path)
+        # No leftover .json files in the working directory.
+        remaining = list(tmp_path.glob("*.json"))
+        assert remaining == []
+
+    @patch("validation.engines.spectral_adapter.subprocess.run")
+    def test_temp_file_cleaned_up_on_error(self, mock_run, tmp_path):
+        """Temp output file is removed even when Spectral fails."""
+        mock_run.side_effect = _spectral_side_effect(
+            "", returncode=2, stderr="boom",
+        )
+        run_spectral(tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path)
+        remaining = list(tmp_path.glob("*.json"))
+        assert remaining == []
+
+    @patch("validation.engines.spectral_adapter.subprocess.run")
+    def test_temp_file_cleaned_up_on_timeout(self, mock_run, tmp_path):
+        """Temp output file is removed when Spectral times out."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="spectral", timeout=300)
+        run_spectral(tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path)
+        remaining = list(tmp_path.glob("*.json"))
+        assert remaining == []
+
+    @patch("validation.engines.spectral_adapter.subprocess.run")
+    def test_large_output_over_64kb(self, mock_run, tmp_path):
+        """Output larger than 64 KB is correctly read from file (the original bug)."""
+        # Generate >64 KB of JSON findings.
+        findings_data = []
+        for i in range(200):
+            findings_data.append({
+                **SAMPLE_SPECTRAL_FINDING,
+                "message": f"Finding {i}: {'x' * 300}",
+            })
+        large_json = json.dumps(findings_data)
+        assert len(large_json) > 65536, "Test data must exceed 64 KB"
+
+        mock_run.side_effect = _spectral_side_effect(large_json, returncode=1)
+        result = run_spectral(
+            tmp_path / ".spectral.yaml", ["*.yaml"], cwd=tmp_path,
+        )
+        assert result.success is True
+        assert len(result.findings) == 200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Two independent fixes for the validation framework:

1. **Spectral adapter 64KB stdout buffer truncation** — Spectral (Node.js) silently truncates piped stdout at 64KB, causing the adapter to report 0 findings on repos with enough API surface. Fix: use Spectral's `--output` flag to write JSON to a temp file instead of piping stdout, bypassing the issue entirely. Includes new tests for temp file cleanup and >64KB output.

2. **app-id to client-id migration** — `create-github-app-token@v3` deprecated the `app-id` input. Migrated all 12 call sites to `client-id` with new org variables (`RELEASE_APP_CLIENT_ID`, `VALIDATION_APP_CLIENT_ID`) since Client ID is a different value from App ID. New org variables already set. Old variables (`RELEASE_APP_ID`, `VALIDATION_APP_ID`) can be removed after merge.

#### Which issue(s) this PR fixes:

No upstream issue — discovered during v1-rc dark deployment testing.

#### Special notes for reviewers:

- The Spectral buffer truncation was a **blocker** for further v1-rc use — Spectral findings were silently lost on larger repos (observed on ReleaseTest and QualityOnDemand forks).
- The `private-key` secrets (`RELEASE_APP_PRIVATE_KEY`, `VALIDATION_APP_PRIVATE_KEY`) are unchanged.
- Full test suite: 790/790 pass.

#### Changelog input

```
 release-note
fix: use file output for Spectral CLI to avoid 64KB stdout truncation
fix: migrate create-github-app-token from deprecated app-id to client-id
```

#### Additional documentation

This section can be blank.

```
docs

```