### PR TITLE
fix(validation): P-015 implicit-subscription conditional + phantom filter broadening

### DIFF
--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -253,20 +253,18 @@ def parse_spectral_output(
     findings = []
     for item in data:
         try:
-            # The OWASP string-restricted rule uses a deep recursive JSONPath
-            # that can traverse Spectral's internally-resolved $ref copies,
-            # producing phantom findings with no source file and range 0:0.
-            # Drop these — they duplicate real findings on the actual source.
-            if (
-                item.get("code") == "owasp:api4:2023-string-restricted"
-                and not item.get("source")
-            ):
-                start = item.get("range", {}).get("start", {})
-                if start.get("line", 0) == 0 and start.get("character", 0) == 0:
-                    logger.debug(
-                        "Dropping phantom string-restricted finding (resolved $ref)"
-                    )
-                    continue
+            # Spectral's $ref resolution can produce phantom findings with
+            # no source file — the rule fires on internally-resolved copies
+            # rather than actual source files.  These duplicate real findings
+            # that have proper source paths.  Drop any finding without a
+            # source, regardless of line number.
+            if not item.get("source"):
+                logger.debug(
+                    "Dropping phantom finding without source file: %s line %s",
+                    item.get("code", "?"),
+                    item.get("range", {}).get("start", {}).get("line", "?"),
+                )
+                continue
             findings.append(normalize_finding(item, repo_root=repo_root))
         except (KeyError, TypeError) as exc:
             logger.warning("Skipping malformed Spectral finding: %s", exc)

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -131,6 +131,14 @@
 
 # P-015: check-event-type-format (DG-086)
 # Event types must follow org.camaraproject.<api-name>.<vN>.<event-name>.
+#
+# Level is conditional on api_pattern:
+#   - explicit-subscription: error (named EventType schema expected today)
+#   - implicit-subscription: warn (r4.1-era specs often inline the enum at
+#     CloudEvent.properties.type.enum, which the detector cannot see; the
+#     r4.2 migration path replaces inline CloudEvent with a $ref to
+#     CAMARA_event_common.yaml and a named ApiEventType schema, at which
+#     point this rule detects the event type correctly).
 - id: P-015
   engine: python
   engine_rule: check-event-type-format
@@ -138,6 +146,16 @@
     api_pattern: [explicit-subscription, implicit-subscription]
   conditional_level:
     default: error
+    overrides:
+      - condition:
+          api_pattern: [implicit-subscription]
+        level: warn
+  hint: >-
+    Define a named event type schema (e.g. ApiEventType) that constrains
+    the CloudEvent `type` value via allOf, rather than inlining the enum
+    directly in CloudEvent.properties.type.enum. See the implicit-events
+    API template in Commonalities artifacts/api-templates/ (tracked in
+    camaraproject/Commonalities#608).
 
 # P-016: check-sinkcredential-not-in-response (DG-092)
 # sinkCredential must not appear in subscription 2xx response schemas.

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -306,11 +306,32 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 10, (
-            f"Expected 10 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 11, (
+            f"Expected 11 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (
             f"Expected 0 message overrides (update test if adding overrides): "
             f"{with_overrides}"
         )
+
+    def test_p015_conditional_on_api_pattern(self, rule_index):
+        """P-015 stays error on explicit-subscription, warn on implicit.
+
+        Implicit-subscription APIs using the r4.1-era inline CloudEvent
+        pattern (enum at CloudEvent.properties.type.enum) cannot be
+        detected by the check, so the rule downgrades to warn until the
+        r4.2 migration to $ref + named ApiEventType schema is complete.
+        """
+        rule = rule_index[("python", "check-event-type-format")]
+        assert rule.id == "P-015"
+        assert rule.conditional_level is not None
+        assert rule.conditional_level.default == "error"
+        overrides = rule.conditional_level.overrides
+        assert len(overrides) == 1
+        assert overrides[0].condition == {
+            "api_pattern": ["implicit-subscription"],
+        }
+        assert overrides[0].level == "warn"
+        assert rule.hint is not None
+        assert "Commonalities#608" in rule.hint

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -351,8 +351,8 @@ class TestParseSpectralOutput:
         findings = parse_spectral_output(raw, repo_root="/runner/work")
         assert findings[0]["path"] == "code/API_definitions/quality-on-demand.yaml"
 
-    def test_string_restricted_phantom_dropped(self):
-        """Phantom string-restricted findings (no source, range 0:0) are dropped."""
+    def test_sourceless_phantom_dropped(self):
+        """Phantom findings without a source file are dropped regardless of rule."""
         phantom = {
             "code": "owasp:api4:2023-string-restricted",
             "message": "Schema of type string should specify a format.",
@@ -367,8 +367,23 @@ class TestParseSpectralOutput:
         assert len(findings) == 1
         assert findings[0]["engine_rule"] == "camara-parameter-casing-convention"
 
-    def test_other_rule_sourceless_not_dropped(self):
-        """Sourceless findings from other rules are kept (only string-restricted filtered)."""
+    def test_sourceless_nonzero_line_also_dropped(self):
+        """Sourceless findings with non-zero lines are still dropped (resolved $ref copies)."""
+        phantom = {
+            "code": "owasp:api4:2023-string-restricted",
+            "message": "Schema of type string should specify a format.",
+            "severity": 1,
+            "source": "",
+            "path": ["components", "schemas", "Foo", "properties", "bar"],
+            "range": {"start": {"line": 233, "character": 14},
+                      "end": {"line": 233, "character": 40}},
+        }
+        raw = json.dumps([phantom])
+        findings = parse_spectral_output(raw)
+        assert len(findings) == 0
+
+    def test_sourceless_other_rule_also_dropped(self):
+        """Sourceless findings from any rule are dropped — not just string-restricted."""
         other = {
             "code": "owasp:api4:2023-string-limit",
             "message": "Schema of type string must specify maxLength.",
@@ -380,7 +395,7 @@ class TestParseSpectralOutput:
         }
         raw = json.dumps([other])
         findings = parse_spectral_output(raw)
-        assert len(findings) == 1
+        assert len(findings) == 0
 
     def test_external_file_findings_downgraded_to_hint(self):
         """Findings from common schemas (followed via $ref) become hints."""


### PR DESCRIPTION
## What type of PR is this?

Bug fix + rule finetuning.

## What this PR does

Two commits on the `validation-framework` branch:

1. **P-015 postfilter conditional** — Downgrades P-015 from `error` to `warn` on implicit-subscription APIs (QoD-class callbacks pattern). These APIs don't define a named `EventType*` schema, so the detector correctly reports "no event type enum values found" — but during the r4.1→r4.2 transition this is expected, not a compliance failure. Adds a `hint` pointing to the Commonalities implicit-events template (#608/#612).

2. **Sourceless phantom filter broadening** — The existing phantom filter only dropped `owasp:api4:2023-string-restricted` findings with empty `source` at line 0:0. Spectral's `$ref` resolution also produces sourceless findings from other rules and at non-zero lines. Broadened to drop any finding without a `source` path — these always duplicate real findings on actual source files.

## Testing

- 792 tests pass (was 791 before; +1 new regression test for non-zero-line phantoms)
- Phantom finding confirmed on ReleaseTest PR #77 (3x S-313 with empty path at lines 233/321/359)

## Related issues

- P-015: [Commonalities#608](https://github.com/camaraproject/Commonalities/issues/608)
- Phantom filter: observed during ReleaseTest new r1.1 E2E testing