### PR TITLE
fix(validation): revert overly broad phantom finding filter

### DIFF
--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -253,18 +253,20 @@ def parse_spectral_output(
     findings = []
     for item in data:
         try:
-            # Spectral's $ref resolution can produce phantom findings with
-            # no source file — the rule fires on internally-resolved copies
-            # rather than actual source files.  These duplicate real findings
-            # that have proper source paths.  Drop any finding without a
-            # source, regardless of line number.
-            if not item.get("source"):
-                logger.debug(
-                    "Dropping phantom finding without source file: %s line %s",
-                    item.get("code", "?"),
-                    item.get("range", {}).get("start", {}).get("line", "?"),
-                )
-                continue
+            # The OWASP string-restricted rule uses a deep recursive JSONPath
+            # that can traverse Spectral's internally-resolved $ref copies,
+            # producing phantom findings with no source file and range 0:0.
+            # Drop these — they duplicate real findings on the actual source.
+            if (
+                item.get("code") == "owasp:api4:2023-string-restricted"
+                and not item.get("source")
+            ):
+                start = item.get("range", {}).get("start", {})
+                if start.get("line", 0) == 0 and start.get("character", 0) == 0:
+                    logger.debug(
+                        "Dropping phantom string-restricted finding (resolved $ref)"
+                    )
+                    continue
             findings.append(normalize_finding(item, repo_root=repo_root))
         except (KeyError, TypeError) as exc:
             logger.warning("Skipping malformed Spectral finding: %s", exc)

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -351,8 +351,8 @@ class TestParseSpectralOutput:
         findings = parse_spectral_output(raw, repo_root="/runner/work")
         assert findings[0]["path"] == "code/API_definitions/quality-on-demand.yaml"
 
-    def test_sourceless_phantom_dropped(self):
-        """Phantom findings without a source file are dropped regardless of rule."""
+    def test_string_restricted_phantom_dropped(self):
+        """Phantom string-restricted findings (no source, range 0:0) are dropped."""
         phantom = {
             "code": "owasp:api4:2023-string-restricted",
             "message": "Schema of type string should specify a format.",
@@ -367,23 +367,8 @@ class TestParseSpectralOutput:
         assert len(findings) == 1
         assert findings[0]["engine_rule"] == "camara-parameter-casing-convention"
 
-    def test_sourceless_nonzero_line_also_dropped(self):
-        """Sourceless findings with non-zero lines are still dropped (resolved $ref copies)."""
-        phantom = {
-            "code": "owasp:api4:2023-string-restricted",
-            "message": "Schema of type string should specify a format.",
-            "severity": 1,
-            "source": "",
-            "path": ["components", "schemas", "Foo", "properties", "bar"],
-            "range": {"start": {"line": 233, "character": 14},
-                      "end": {"line": 233, "character": 40}},
-        }
-        raw = json.dumps([phantom])
-        findings = parse_spectral_output(raw)
-        assert len(findings) == 0
-
-    def test_sourceless_other_rule_also_dropped(self):
-        """Sourceless findings from any rule are dropped — not just string-restricted."""
+    def test_other_rule_sourceless_not_dropped(self):
+        """Sourceless findings from other rules are kept (only string-restricted filtered)."""
         other = {
             "code": "owasp:api4:2023-string-limit",
             "message": "Schema of type string must specify maxLength.",
@@ -395,7 +380,7 @@ class TestParseSpectralOutput:
         }
         raw = json.dumps([other])
         findings = parse_spectral_output(raw)
-        assert len(findings) == 0
+        assert len(findings) == 1
 
     def test_external_file_findings_downgraded_to_hint(self):
         """Findings from common schemas (followed via $ref) become hints."""


### PR DESCRIPTION
## What type of PR is this?

Bug fix (revert).

## What this PR does

Reverts commit `65a0fec` ("drop all sourceless Spectral phantom findings") from PR #159. That change broadened the phantom filter to drop ALL Spectral findings with an empty `source` field. This incorrectly suppressed legitimate findings, including S-314/S-316 (`additionalProperties` OWASP rules) that fire on schemas resolved through `$ref`.

The original narrow filter (only `owasp:api4:2023-string-restricted` at line 0:0) is restored. A proper investigation of Spectral's `source` field behavior with `$ref` resolution is needed before refining this filter — tracked as a pre-GA improvement.

The P-015 postfilter conditional from the same PR (#159, commit `88b877f`) is **not** affected by this revert.

## Testing

791 tests pass (matches pre-broadening count).