### PR TITLE
feat(validation): P-020 CloudEvent-via-ref check + P-006 severity

### DIFF
--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -14,6 +14,7 @@ from .readme_checks import check_readme_placeholder_removal
 from .release_plan_checks import check_orphan_api_definitions, check_release_plan_semantics
 from .release_review_checks import check_release_review_file_restriction
 from .subscription_checks import (
+    check_cloudevent_via_ref,
     check_event_type_format,
     check_sinkcredential_not_in_response,
     check_subscription_filename,
@@ -44,6 +45,7 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-subscription-filename", CheckScope.API, check_subscription_filename),
     CheckDescriptor("check-event-type-format", CheckScope.API, check_event_type_format),
     CheckDescriptor("check-sinkcredential-not-in-response", CheckScope.API, check_sinkcredential_not_in_response),
+    CheckDescriptor("check-cloudevent-via-ref", CheckScope.API, check_cloudevent_via_ref),
     CheckDescriptor("check-conflict-deprecated", CheckScope.API, check_conflict_deprecated),
     CheckDescriptor("check-contextcode-format", CheckScope.API, check_contextcode_format),
     # --- Repo-level checks (run once) ---

--- a/validation/engines/python_checks/subscription_checks.py
+++ b/validation/engines/python_checks/subscription_checks.py
@@ -220,3 +220,62 @@ def check_sinkcredential_not_in_response(
             )
 
     return findings
+
+
+# ---------------------------------------------------------------------------
+# P-020: check-cloudevent-via-ref
+# ---------------------------------------------------------------------------
+
+
+def check_cloudevent_via_ref(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Warn when CloudEvent is defined inline instead of via $ref.
+
+    Subscription APIs should consume the shared CloudEvent schema from
+    CAMARA_event_common.yaml via ``$ref`` (or ``allOf`` + ``$ref``) rather
+    than maintaining a local inline copy. Inline copies drift from the
+    Commonalities source and block bundling-based reuse.
+
+    Detection: the rule fires when ``components.schemas.CloudEvent`` is
+    present and has a top-level ``properties`` key. The ``$ref``-only
+    form and the ``allOf: [{$ref: ...}]`` migration form have no
+    top-level ``properties`` and are not flagged.
+    """
+    api = context.apis[0]
+
+    if api.api_pattern not in ("explicit-subscription", "implicit-subscription"):
+        return []
+
+    if api.spec_file.endswith("CAMARA_event_common.yaml"):
+        return []
+
+    spec = load_yaml_safe(repo_path / api.spec_file)
+    if spec is None:
+        return []
+
+    schemas = spec.get("components", {}).get("schemas", {})
+    if not isinstance(schemas, dict):
+        return []
+
+    cloudevent = schemas.get("CloudEvent")
+    if not isinstance(cloudevent, dict):
+        return []
+
+    if "properties" not in cloudevent:
+        return []
+
+    return [
+        make_finding(
+            engine_rule="check-cloudevent-via-ref",
+            level="warn",
+            message=(
+                f"CloudEvent is defined inline in {api.spec_file}. "
+                f"Consume the shared schema from CAMARA_event_common.yaml "
+                f"via $ref instead of maintaining a local copy."
+            ),
+            path=api.spec_file,
+            line=1,
+            api_name=api.api_name,
+        )
+    ]

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -41,6 +41,11 @@
     default: error
 
 # P-006: check-test-files-exist
+#
+# Severity is a function of API maturity and release type:
+#   - default (alpha, wip, any non-rc release): hint
+#   - initial (0.x) + rc/public release: warn
+#   - stable  (>=1.x) + rc/public release: error
 - id: P-006
   engine: python
   engine_rule: check-test-files-exist
@@ -50,7 +55,17 @@
       - condition:
           target_api_maturity: [stable]
           target_release_type: [pre-release-rc, public-release]
+        level: error
+      - condition:
+          target_api_maturity: [initial]
+          target_release_type: [pre-release-rc, public-release]
         level: warn
+  hint: >-
+    Test files are optional for alpha releases but expected before the
+    first release candidate. On stable (>=1.x) APIs they are required
+    at rc and public release; on initial (0.x) APIs they are strongly
+    recommended. See CAMARA Testing Guidelines for the expected file
+    layout.
 
 # P-007: check-test-file-version
 # Parses the Feature line of .feature files to extract the version
@@ -194,3 +209,23 @@
   engine_rule: check-orphan-api-definitions
   conditional_level:
     default: warn
+
+# P-020: check-cloudevent-via-ref
+# Subscription APIs should consume CloudEvent via $ref to
+# CAMARA_event_common.yaml rather than maintaining a local inline copy.
+# Detection: components.schemas.CloudEvent exists with top-level
+# `properties`. The $ref-only and `allOf: [{$ref: ...}]` forms have no
+# top-level `properties` and are not flagged.
+- id: P-020
+  engine: python
+  engine_rule: check-cloudevent-via-ref
+  applicability:
+    api_pattern: [explicit-subscription, implicit-subscription]
+  conditional_level:
+    default: warn
+  hint: >-
+    Replace the local CloudEvent schema with
+    `$ref: './CAMARA_event_common.yaml#/components/schemas/CloudEvent'`,
+    or an allOf combining the $ref with an API-specific ApiEventType
+    schema. See implicit-events API template in Commonalities
+    artifacts/api-templates/.

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -14,7 +14,7 @@ version: 1
 generated: 2026-04-07
 
 summary:
-  total_implemented: 141
+  total_implemented: 142
   total_gap: 0
   total_manual: 25
   total_pending: 0
@@ -22,7 +22,7 @@ summary:
   by_engine:
     spectral: 84
     gherkin: 25
-    python: 19
+    python: 20
     yamllint: 13
 
 # ---------------------------------------------------------------------------
@@ -198,6 +198,12 @@ gap_rules:
     target_engine: python
     status: implemented
     rule_id: P-019
+
+  - audit_id: NEW-004
+    description: "CloudEvent schema should be consumed via $ref to CAMARA_event_common.yaml, not maintained as a local inline copy"
+    target_engine: python
+    status: implemented
+    rule_id: P-020
 
 # ---------------------------------------------------------------------------
 # Fixes needed — implemented rules with incorrect behavior

--- a/validation/tests/test_python_checks_subscription.py
+++ b/validation/tests/test_python_checks_subscription.py
@@ -1,4 +1,4 @@
-"""Unit tests for subscription checks (P-014, P-015, P-016)."""
+"""Unit tests for subscription checks (P-014, P-015, P-016, P-020)."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import yaml
 
 from validation.context import ApiContext, ValidationContext
 from validation.engines.python_checks.subscription_checks import (
+    check_cloudevent_via_ref,
     check_event_type_format,
     check_sinkcredential_not_in_response,
     check_subscription_filename,
@@ -392,3 +393,104 @@ class TestCheckSinkCredentialNotInResponse:
         ctx = _make_context(api_name=api_name)
         findings = check_sinkcredential_not_in_response(tmp_path, ctx)
         assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# P-020: check-cloudevent-via-ref
+# ---------------------------------------------------------------------------
+
+
+def _spec_with_cloudevent(cloudevent_schema: dict) -> dict:
+    """Build a minimal subscription spec with a CloudEvent schema."""
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Test", "version": "wip"},
+        "paths": {"/subscriptions": {"post": {"responses": {"201": {}}}}},
+        "components": {"schemas": {"CloudEvent": cloudevent_schema}},
+    }
+
+
+class TestCheckCloudEventViaRef:
+    def test_inline_cloudevent_warns(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _spec_with_cloudevent({
+            "type": "object",
+            "required": ["id", "type"],
+            "properties": {
+                "id": {"type": "string"},
+                "type": {
+                    "type": "string",
+                    "enum": [f"org.camaraproject.{api_name}.v0.status-changed"],
+                },
+            },
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_cloudevent_via_ref(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert findings[0]["engine_rule"] == "check-cloudevent-via-ref"
+        assert "inline" in findings[0]["message"]
+        assert findings[0]["api_name"] == api_name
+
+    def test_ref_only_cloudevent_ok(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _spec_with_cloudevent({
+            "$ref": "./CAMARA_event_common.yaml#/components/schemas/CloudEvent",
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_cloudevent_via_ref(tmp_path, ctx) == []
+
+    def test_allof_with_ref_ok(self, tmp_path: Path):
+        """allOf + $ref migration form has no top-level properties — no finding."""
+        api_name = "device-status-subscriptions"
+        spec = _spec_with_cloudevent({
+            "allOf": [
+                {"$ref": "./CAMARA_event_common.yaml#/components/schemas/CloudEvent"},
+            ],
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_cloudevent_via_ref(tmp_path, ctx) == []
+
+    def test_no_cloudevent_schema_ok(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = {
+            "openapi": "3.0.3",
+            "info": {"title": "Test", "version": "wip"},
+            "paths": {"/subscriptions": {"post": {"responses": {"201": {}}}}},
+            "components": {"schemas": {"OtherSchema": {"type": "object"}}},
+        }
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_cloudevent_via_ref(tmp_path, ctx) == []
+
+    def test_implicit_subscription_inline_warns(self, tmp_path: Path):
+        api_name = "device-status"
+        spec = _spec_with_cloudevent({
+            "type": "object",
+            "properties": {
+                "type": {"type": "string", "enum": ["foo"]},
+            },
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name, api_pattern="implicit-subscription")
+        findings = check_cloudevent_via_ref(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+
+    def test_request_response_skip(self, tmp_path: Path):
+        """Request-response APIs do not define CloudEvent — skip even if inline."""
+        api_name = "device-status"
+        spec = _spec_with_cloudevent({
+            "type": "object",
+            "properties": {"type": {"type": "string"}},
+        })
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name, api_pattern="request-response")
+        assert check_cloudevent_via_ref(tmp_path, ctx) == []
+
+    def test_missing_spec_file(self, tmp_path: Path):
+        ctx = _make_context()
+        assert check_cloudevent_via_ref(tmp_path, ctx) == []

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 19
+        assert counts["python"] == 20
         assert counts["spectral"] == 84
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -306,8 +306,8 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 11, (
-            f"Expected 11 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 13, (
+            f"Expected 13 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Two pre-GA improvements to Python checks ahead of progressive rollout (advisory stage flip):

**P-020 `check-cloudevent-via-ref` (new rule)** — warns when a subscription API defines `components.schemas.CloudEvent` inline (top-level `properties` present) instead of consuming it via `$ref` to `CAMARA_event_common.yaml`. Detection ignores the `$ref`-only and `allOf: [{$ref: ...}]` migration forms (no top-level `properties`), so APIs that adopt either valid migration pattern are not flagged. Applicability: explicit- and implicit-subscription APIs.

This delivers a positive, explicit migration signal for inline-CloudEvent specs independent of whether maintainers also fix `type: object` declarations (which would otherwise silence the accidental `S-016` signal). Once `r4.2` is available, repos can migrate by replacing the local `CloudEvent` schema with a `$ref` (or `allOf` + `$ref`) to `CAMARA_event_common.yaml`.

**P-006 `check-test-files-exist` (severity bump + hint)** — strengthens the severity model so the lifecycle expectation is visible on every release type:

| target_api_maturity | target_release_type | level |
|---|---|---|
| stable (>=1.x) | pre-release-rc, public-release | **error** (was warn) |
| initial (0.x) | pre-release-rc, public-release | **warn** (was hint via default) |
| any | alpha, wip, non-rc | hint (unchanged) |

A static `hint:` field is added explaining the matrix so maintainers seeing the finding on alpha understand why it's still informational.

#### Which issue(s) this PR fixes:

No upstream issue — these items came from private dark-deployment analysis and the ReleaseTest r1.1 alpha snapshot review.

#### Special notes for reviewers:

- **Detection edge cases (P-020)**: the check fires only when `CloudEvent` has a top-level `properties` key. The `allOf: [{$ref: ...}]` migration pattern has no top-level `properties` and is not flagged. Test cases in `validation/tests/test_python_checks_subscription.py::TestCheckCloudEventViaRef` cover all five paths (inline warn / `$ref` ok / `allOf+$ref` ok / no CloudEvent / request-response skip).
- **Why metadata not check code for P-006**: severity is set in `python-rules.yaml` and applied by the post-filter (`level_resolver.py`). The check function still emits its own engine-level finding; the post-filter rewrites it based on the rule metadata. This matches the pattern already used by P-007 / P-008 / P-015.
- **Test counts updated**: `test_rule_metadata_integrity.py` counters bumped (`python: 19 → 20`, hints: `11 → 13`). `rule-inventory.yaml` adds P-020 as `NEW-004` and bumps the `python` count and `total_implemented`.
- **Tests**: 808/808 validation tests pass locally (`python3 -m pytest validation/tests/`). 7 new test cases for P-020.

#### Changelog input

```release-note
Add Python check P-020 (`check-cloudevent-via-ref`) warning when a
subscription API defines CloudEvent inline instead of via $ref to
CAMARA_event_common.yaml. Strengthen P-006 (`check-test-files-exist`)
severity model: stable APIs now error at rc/public, initial APIs warn
at rc/public, alpha and non-rc remain at hint. Add explanatory hint
text to P-006.
```

#### Additional documentation

This section can be blank.
