### PR TITLE
feat(validation): default stage advisory for progressive rollout

### DIFF
--- a/validation/config/validation-config.yaml
+++ b/validation/config/validation-config.yaml
@@ -5,7 +5,7 @@
 version: 1
 
 defaults:
-  stage: disabled
+  stage: advisory
 
 fork_owners:
   - hdamker


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Flip the central [`validation/config/validation-config.yaml`](validation/config/validation-config.yaml) `defaults.stage` from `disabled` to `advisory`.

**What changes for new repos**: instead of falling through to `disabled` (validation pipeline never runs at all, even on dispatch), they now fall through to `advisory` — `workflow_dispatch` runs work end-to-end, while `pull_request` events still short-circuit at the stage gate with no validation. This unblocks ad-hoc dispatch testing on newly onboarded repos without exposing PR authors to advisory findings yet.

**What does NOT change**:
- PR validation behaviour: `advisory` mode still skips on `pull_request` events ([config_gate.py:184-196](validation/config/config_gate.py)).
- Repos with explicit `stage:` overrides under `repositories:` (today: `ReleaseTest` at `enabled`).
- The `disabled → advisory → enabled` rollout sequence — this is the first step.

#### Which issue(s) this PR fixes:

No upstream issue.

#### Special notes for reviewers:

- The seven repos affected today (currently dark / falling through to the default) are the ones onboarded via the validation caller campaign: `QualityOnDemand`, `ClickToDial`, `ConsentInfo`, `IoTSIMFraudPrevention`, `MultiPointVPN`, `NetworkSliceBooking`, `SessionInsights`. After this change they can be exercised via `workflow_dispatch`; PR runs remain skipped.
- No tests need updating: the `disabled` literal in `validation/tests/test_config_gate.py` test fixtures is incidental example data, not a mirror of the production config. The `STAGE_ADVISORY` + `pull_request` skip behaviour is already covered by tests in [test_config_gate.py](validation/tests/test_config_gate.py).
- Per-repo opt-out remains available: add `<repo>: {stage: disabled}` under `repositories:`.

#### Changelog input

```release-note
Change central validation-config.yaml default stage from `disabled` to
`advisory`. Repos that currently fall through to the default can now be
exercised via workflow_dispatch; pull_request events remain skipped at
the stage gate. Existing per-repo overrides are unaffected.
```

#### Additional documentation

This section can be blank.
