### PR TITLE
Add validation framework regression runner and baseline pilot

### DIFF
--- a/validation/docs/regression-testing.md
+++ b/validation/docs/regression-testing.md
@@ -1,0 +1,311 @@
+# Regression Testing for the Validation Framework
+
+A safety net for evolving the validation framework with confidence.
+
+## Why it exists
+
+The Validation Framework will be the gate that decides whether a CAMARA API
+release proceeds. As new rules land and existing ones evolve, two failure
+modes have to stay out of the framework:
+
+1. A rule starts firing where it shouldn't. Codeowners drown in noise and
+   lose trust in the tool.
+2. A rule stops firing where it should. Codeowners ship a defect and nobody
+   noticed.
+
+Unit tests catch implementation bugs in individual checks. They don't catch
+the cumulative behaviour of the whole framework against real API specs.
+Regression testing closes that gap.
+
+## What it does
+
+Think of a canary in a coal mine.
+
+A curated set of CAMARA-style API specs lives on regression branches in
+`camaraproject/ReleaseTest`. Two flavours, both useful:
+
+- **Known-good baselines** — clean specs paired with the (small) set of
+  advisory findings the framework legitimately produces against them.
+  These verify that "clean stays clean": no new false positives creep in
+  as rules evolve.
+- **Known-bad targeted branches** — specs containing intentional defects
+  paired with the specific findings those defects must trigger. These
+  verify that "broken stays broken": rules don't silently stop catching
+  the things they were written to catch.
+
+What's frozen on each branch is not the quality of the spec but the
+**expected verdict** the framework should deliver about it. Each branch
+ships with a `regression-expected.yaml` fixture that lists exactly which
+findings the framework should produce.
+
+A runner script dispatches the validation framework against each regression
+branch, downloads the findings, and diffs them against the committed
+expectation. PASS means the framework's behaviour is unchanged from the
+last fixture capture. FAIL means something changed — and the diff shows
+exactly which rules now report differently and against which files.
+
+## Why ReleaseTest is special
+
+Most CAMARA repositories use the **stable** version of the framework — a
+tag called `v1-rc`. That tag only moves when the framework team
+deliberately rolls out a new version to all repositories.
+
+`camaraproject/ReleaseTest` is different on purpose. Its caller workflow
+targets `validation.yml@validation-framework` — that is, the **HEAD of the
+development branch**, not the stable tag. Every push to the
+`validation-framework` branch is exercised against ReleaseTest's regression
+fixtures **before** `v1-rc` is moved for the rest of the org. If a change
+accidentally breaks something, the canary catches it minutes after the
+push, in isolation, before any production API repository sees the change.
+
+## What we achieve
+
+- **Confidence to evolve rules.** Rule developers can refactor or add
+  checks without fearing they'll silently break something elsewhere — the
+  canary tells them within minutes if they did.
+- **A safety net before each framework release.** Before the `v1-rc` tag
+  is moved to a new commit, the canary is green. If it isn't, the release
+  doesn't go out.
+- **Living evidence of which rules are tested.** The framework has 142
+  rules. The rule inventory records which of them are pinned by a
+  regression branch. Adding more themed branches grows that number and
+  gives a measurable picture of test coverage.
+- **An authoritative answer when codeowners ask "did anything change?"**
+  Either the canary is unchanged (no behaviour change) or it's changed
+  and we can point at exactly which rules now report differently.
+
+## What it is *not*
+
+- Not a test of the **APIs themselves**. It doesn't tell us whether
+  QualityOnDemand or Device Location are correct. It tests whether the
+  validation framework judges them correctly.
+- Not user-facing. Codeowners never see this. It's a developer tool for
+  the framework team, like a smoke alarm that only the firefighters check.
+- Not a replacement for the manual review work that goes into release
+  PRs. It complements that — humans review release content; the canary
+  makes sure the tools they rely on haven't drifted.
+
+## How it works concretely
+
+### Components
+
+```
+camaraproject/tooling                       camaraproject/ReleaseTest
+─────────────────────                       ────────────────────────
+validation/                                 main
+├── docs/                                   ├── code/API_definitions/...
+│   └── regression-testing.md   ◄── this    │
+├── schemas/                                regression/r4.1-main-baseline
+│   └── regression-expected-schema.yaml     ├── code/API_definitions/...   (frozen)
+├── scripts/                                └── .regression/
+│   ├── regression_runner.py                    ├── REGRESSION.md          (purpose)
+│   └── README.md (CLI reference)               └── regression-expected.yaml (fixture)
+└── rules/
+    └── rule-inventory.yaml (tested_rules)  regression/<other-themes>...
+```
+
+### The fixture format
+
+Each regression branch has a `.regression/regression-expected.yaml` file
+that conforms to
+[validation/schemas/regression-expected-schema.yaml](../schemas/regression-expected-schema.yaml).
+It records:
+
+- `branch` — the regression branch name (informational)
+- `description` — what this branch tests
+- `captured_at`, `captured_from_run`, `tooling_ref` — provenance: when the
+  fixture was generated, which run produced it, and the validation
+  framework SHA in effect at the time
+- `summary` — expected aggregate counts (errors / warnings / hints), used
+  as a fast sanity check
+- `match_mode` — `exact` (default) rejects unexpected findings; `subset`
+  allows extras
+- `findings[]` — the expected list, where each entry is a unique
+  `(rule_id, path, level)` tuple with an optional `count` (default 1)
+
+### The match key — what counts as "the same finding"
+
+Two findings are considered the same if they share the same
+`(rule_id, path, level)` tuple. For findings that don't have a framework
+`rule_id` (raw engine rules without metadata), the runner falls back to
+`(engine/engine_rule, path, level)`.
+
+Three things are deliberately **excluded** from the match key:
+
+- **Line numbers.** Source maps shift as bundled output evolves; pinning
+  on a line number turns every cosmetic source change into a "regression".
+- **Messages.** Phrasing improves over time without changing the substance
+  of the check.
+- **Counts above the expected minimum.** A `count: N` entry means "at least
+  N", not "exactly N". A spec fix that removes one of three duplicate hints
+  is a desired change, not a regression. (This rule applies even in
+  `exact` match mode; `exact` only restricts what extra `(rule, path,
+  level)` keys are allowed, not how many times each one fires.)
+
+### The runner
+
+[validation/scripts/regression_runner.py](../scripts/regression_runner.py)
+is a single-file Python CLI that talks to GitHub via the `gh` CLI. Two
+modes:
+
+**Verify mode** (default): for each matching regression branch, the runner
+
+1. Fetches `regression-expected.yaml` from the branch via the GitHub
+   contents API
+2. Dispatches the validation workflow on the branch via
+   `gh workflow run camara-validation.yml --ref <branch>`
+3. Polls for the new run to appear (using a UTC timestamp marker plus the
+   branch tip SHA to disambiguate from concurrent runs) and waits for it
+   to complete
+4. Downloads the `validation-diagnostics` artifact, reads
+   `findings.json`, `summary.json`, and `context.json`
+5. Diffs actual findings against the expected fixture and reports
+6. Exits 0 (all PASS), 1 (one or more FAIL), or 2 (infrastructure
+   failure)
+
+**Capture mode** (`--capture <branch> --out <path>`): the runner runs
+steps 2–4 above, then groups the actual findings into a
+`regression-expected.yaml` document, and writes it to the requested
+output path. The reviewer then commits that file to the branch at
+`.regression/regression-expected.yaml`.
+
+The same dispatch / download / diff code path serves both modes — there
+is one set of bugs, not two.
+
+### How `tooling_ref` is recorded
+
+Every validation run writes its resolved tooling SHA into `context.json`
+in the diagnostics artifact (the orchestrator already does this for the
+workflow summary). The runner reads it directly from there, so the value
+in the fixture is the SHA the run actually used, regardless of which ref
+the caller targets. On ReleaseTest that's the `validation-framework` HEAD
+at run time; on dark / production repos it would be whatever `v1-rc`
+points at.
+
+## Day-to-day usage
+
+### Verify all canary branches
+
+```
+python3 validation/scripts/regression_runner.py \
+    --repo camaraproject/ReleaseTest \
+    --branch-filter 'regression/*'
+```
+
+Expected output for a clean run:
+
+```
+## Regression Runner — N/N branches PASS
+
+| Branch | Result | Matched | Missing | Unexpected | Summary |
+|---|---|---:|---:|---:|---|
+| `regression/r4.1-main-baseline` | PASS | 27 | 0 | 0 | - |
+PASS: 1/1 branches
+```
+
+Exit code 0. CLI flags and exit-code reference live in
+[validation/scripts/README.md](../scripts/README.md).
+
+### When a regression fires
+
+The runner exits 1 and prints a per-branch diff. Three classes of failure:
+
+- **Missing**: a finding in the fixture didn't appear in the actual run.
+  Either the rule was deleted, or its conditions changed and it no longer
+  fires on that file. If intentional → recapture. If not → fix the
+  framework before merging the change to `validation-framework`.
+- **Unexpected**: a finding appeared that wasn't in the fixture. Either a
+  new rule was added (or activated) and is now firing, or a rule's
+  conditions changed and it now fires where it didn't before. Same
+  triage: intended → recapture; unintended → fix.
+- **Summary mismatch**: the aggregate counts in `summary.json` don't
+  match the fixture's `summary` block. This usually shows up alongside
+  one of the other failures and confirms the cause.
+
+### Recapturing a fixture
+
+When a change is intentional, refresh the fixture:
+
+```
+python3 validation/scripts/regression_runner.py \
+    --repo camaraproject/ReleaseTest \
+    --capture regression/r4.1-main-baseline \
+    --out /tmp/expected.yaml \
+    --capture-description "baseline - ReleaseTest main, unmodified"
+```
+
+Review `/tmp/expected.yaml` against the previous version, commit it to
+the branch at `.regression/regression-expected.yaml`, and re-run the
+runner without `--capture` to confirm PASS. The fixture's `tooling_ref`
+field will reflect the current `validation-framework` HEAD.
+
+### Adding a new regression branch
+
+1. Branch from `camaraproject/ReleaseTest@main` with a descriptive name
+   under the `regression/` namespace
+   (e.g. `regression/r4.1-broken-info-block`).
+2. Make whatever spec edits the branch is meant to test. For a baseline
+   branch, leave specs unmodified.
+3. Write a short `REGRESSION.md` at `.regression/REGRESSION.md`
+   explaining what this branch is for, what it expects, and the
+   caller-workflow context if it's not the canary default.
+4. Push the branch.
+5. Run the runner in `--capture` mode to seed
+   `.regression/regression-expected.yaml`.
+6. Review, commit, push, and verify with the runner in default mode.
+7. Update [validation/rules/rule-inventory.yaml](../rules/rule-inventory.yaml):
+   add the new branch to the `tested_rules` entries for whichever rules
+   it pins, and bump `summary.total_tested` to the new unique-rule count.
+
+### Updating `tested_rules`
+
+The `tested_rules` mapping in `rule-inventory.yaml` records which rules
+are pinned by which regression branches:
+
+```yaml
+tested_rules:
+  P-006: [regression/r4.1-main-baseline]
+  S-211: [regression/r4.1-main-baseline]
+  S-313: [regression/r4.1-main-baseline]
+  S-314: [regression/r4.1-main-baseline]
+  S-316: [regression/r4.1-main-baseline]
+```
+
+Always list-valued for uniformity when a rule is covered by multiple
+branches. Treat the field as proof, not aspiration: bump it after the
+runner reports PASS against the new fixture, not before.
+
+## Sharp edges and known limitations
+
+- **Tooling-ref pinning is set by the caller workflow.** A local
+  `gh workflow run` cannot override which tooling SHA runs server-side.
+  ReleaseTest pins to `validation-framework` HEAD by design (canary).
+  Production API repos pin to `@v1-rc`. There is currently no way to
+  test an un-published developer SHA against the runner — that's a
+  separate piece of design work.
+- **Dispatch → run-id race.** `gh workflow run` does not return a run
+  ID. The runner records a UTC timestamp before dispatch and polls
+  `gh run list` for a `workflow_dispatch` run with a matching branch
+  tip SHA and a `createdAt` after the marker. Reliable in practice but
+  worth knowing if you need to debug a dispatch that "vanished".
+- **Findings ordering is not stable.** The post-filter emits findings in
+  whatever order the engines produced them. The diff is set-based on
+  the match key, so ordering is irrelevant — but if you eyeball
+  `findings.json` and `regression-expected.yaml` side by side, expect
+  them not to line up linearly.
+- **Capture-then-verify must be deterministic.** If the runner captures
+  a fixture and then immediately fails verification on a re-run against
+  the same SHA, the framework's output is non-deterministic on that
+  branch. That's a framework bug, not a runner bug — stop and
+  investigate before adding the branch.
+
+## Related references
+
+- [validation/scripts/README.md](../scripts/README.md) — runner CLI
+  reference, exit codes, troubleshooting
+- [validation/schemas/regression-expected-schema.yaml](../schemas/regression-expected-schema.yaml)
+  — JSON Schema for the fixture format
+- [validation/rules/rule-inventory.yaml](../rules/rule-inventory.yaml)
+  — rule registry with `tested_rules` coverage
+- Upstream tracking issue: [camaraproject/ReleaseManagement#483](https://github.com/camaraproject/ReleaseManagement/issues/483)
+- Umbrella validation framework issue: [camaraproject/ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448)

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 0
+  total_tested: 5
   by_engine:
     spectral: 84
     gherkin: 25
@@ -285,12 +285,19 @@ pending_rules:
 # Source: private-dev-docs/validation-framework/reviews/testing-guidelines-audit.md
 
 # ---------------------------------------------------------------------------
-# Tested rules — verified via regression branches (Phase 1b)
+# Tested rules — verified via regression branches (WS07 Phase 3)
 # ---------------------------------------------------------------------------
-# Updated as regression branches verify rules.
-# Format: rule_id: regression_branch (or list of branches)
+# Updated as regression branches verify rules. Each rule lists the branches
+# where its expected behaviour is pinned by a regression-expected.yaml
+# fixture. Populated by scripts/regression_runner.py runs (capture mode).
+# Format: rule_id: [branch, ...]
 
-tested_rules: {}
+tested_rules:
+  P-006: [regression/r4.1-main-baseline]
+  S-211: [regression/r4.1-main-baseline]
+  S-313: [regression/r4.1-main-baseline]
+  S-314: [regression/r4.1-main-baseline]
+  S-316: [regression/r4.1-main-baseline]
 
 # ---------------------------------------------------------------------------
 # Manual rules — require human judgment

--- a/validation/schemas/regression-expected-schema.yaml
+++ b/validation/schemas/regression-expected-schema.yaml
@@ -1,0 +1,127 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: CAMARA Validation Regression Expected Findings
+description: |
+  Schema for regression-expected.yaml fixtures committed to regression/* branches
+  of test repositories. Each fixture declares the expected validation findings for
+  a specific themed branch; the regression runner dispatches the validation
+  framework against the branch, downloads the findings, and diffs them against
+  this file.
+
+  Match semantics are set-based on (rule_id, path, level) tuples, with per-key
+  "at least N" count thresholds. Line numbers and finding messages are NOT part
+  of the match key - they drift as specs evolve.
+
+type: object
+additionalProperties: false
+required:
+  - schema_version
+  - branch
+  - findings
+
+properties:
+  schema_version:
+    type: integer
+    enum: [1]
+    description: Schema version for forward compatibility.
+
+  branch:
+    type: string
+    description: >
+      The regression branch this fixture pins. Informational; the runner
+      resolves the branch from its filter arguments, not from this field.
+
+  description:
+    type: string
+    description: Human-readable summary of what this branch tests.
+
+  captured_at:
+    type: string
+    format: date-time
+    description: ISO-8601 timestamp when the fixture was last captured.
+
+  captured_from_run:
+    type: string
+    description: URL of the workflow run that produced this fixture.
+
+  tooling_ref:
+    type: string
+    description: >
+      40-character SHA of the tooling commit that produced the expected findings.
+      For dispatches from API repositories, this is the SHA that v1-rc pointed
+      at during capture. If v1-rc moves, the fixture must be recaptured.
+    pattern: "^[0-9a-f]{40}$"
+
+  match_mode:
+    type: string
+    enum: [exact, subset]
+    default: exact
+    description: >
+      exact  - any actual finding whose match key is not in `findings` causes
+               FAIL. Count surpluses also cause FAIL.
+      subset - extra actual findings are allowed; only missing expected findings
+               cause FAIL. Use as an escape hatch for flaky rules.
+
+  summary:
+    type: object
+    additionalProperties: false
+    description: >
+      Expected aggregate counts across all findings. Compared against
+      summary.json.counts before per-finding diffing. A mismatch here causes
+      FAIL even if no per-finding mismatch exists.
+    properties:
+      errors:
+        type: integer
+        minimum: 0
+      warnings:
+        type: integer
+        minimum: 0
+      hints:
+        type: integer
+        minimum: 0
+
+  findings:
+    type: array
+    description: >
+      Expected findings. Each entry identifies a unique (rule_id, path, level)
+      tuple (or (engine/engine_rule, path, level) fallback). Duplicate match
+      keys within a file are rejected - collapse them into a single entry with
+      `count`.
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - path
+        - level
+      properties:
+        rule_id:
+          type: string
+          pattern: "^[A-Z]-[0-9]{3}$"
+          description: Framework rule ID (e.g. S-042, P-015).
+        engine:
+          type: string
+          enum: [spectral, yamllint, gherkin, python]
+          description: >
+            Validation engine that produced the finding. Required only when
+            rule_id is absent.
+        engine_rule:
+          type: string
+          description: >
+            Native rule identifier within the engine. Required only when
+            rule_id is absent.
+        path:
+          type: string
+          description: Repository-relative file path (exact match, no globs).
+        level:
+          type: string
+          enum: [error, warn, hint]
+        count:
+          type: integer
+          minimum: 1
+          default: 1
+          description: >
+            Minimum number of matching findings required. "At least N" semantics
+            in both exact and subset modes. A spec fix that removes one of three
+            duplicate hints is not a regression.
+      oneOf:
+        - required: [rule_id]
+        - required: [engine, engine_rule]

--- a/validation/scripts/README.md
+++ b/validation/scripts/README.md
@@ -19,16 +19,23 @@ Dispatches the validation framework against `regression/*` branches of a test
 repository, downloads findings, and diffs them against the committed
 `.regression/regression-expected.yaml` fixture on each branch.
 
+For motivation, the canary model, the fixture format, and day-to-day
+workflows (capture, verify, recapture, adding new branches), see the manual:
+**[../docs/regression-testing.md](../docs/regression-testing.md)**.
+
+This file is the CLI reference only.
+
 ### Prerequisites
 
 - Python 3.11+ with `pyyaml` and `jsonschema`
 - `gh` CLI installed and authenticated (`gh auth status` must be green)
-- The test repo must have the Validation Framework caller workflow installed
-  (`.github/workflows/camara-validation.yml`)
-- Each `regression/*` branch must contain `.regression/regression-expected.yaml`
-  conforming to `validation/schemas/regression-expected-schema.yaml`
+- The test repo must have the validation framework caller workflow installed
+  at `.github/workflows/camara-validation.yml`
+- For verify mode: each `regression/*` branch must contain
+  `.regression/regression-expected.yaml` conforming to
+  [../schemas/regression-expected-schema.yaml](../schemas/regression-expected-schema.yaml)
 
-### Run
+### Verify mode
 
 ```
 python3 validation/scripts/regression_runner.py \
@@ -36,76 +43,34 @@ python3 validation/scripts/regression_runner.py \
     [--branch-filter 'regression/r4.1-*'] \
     [--workflow-file camara-validation.yml] \
     [--poll-interval 15] [--poll-timeout 1800] \
-    [--summary-file regression-summary.md]
+    [--summary-file regression-summary.md] \
+    [-v|--verbose]
 ```
 
-Exit codes:
+Default `--branch-filter` is `regression/*`. Default `--workflow-file` is
+`camara-validation.yml`.
 
-| Code | Meaning |
-|---|---|
-| 0 | all branches PASS |
-| 1 | one or more branches FAIL (diff mismatch) |
-| 2 | infrastructure failure (gh error, timeout, missing artifact, schema invalid) |
-
-### Capture a new fixture
+### Capture mode
 
 ```
 python3 validation/scripts/regression_runner.py \
     --repo camaraproject/ReleaseTest \
     --capture regression/r4.1-main-baseline \
     --out /tmp/expected.yaml \
-    [--capture-description "baseline"]
+    [--capture-description "baseline - ReleaseTest main, unmodified"]
 ```
 
-Review the generated file, commit it to the branch at
-`.regression/regression-expected.yaml`, then re-run the runner without
-`--capture` to verify PASS.
+Writes a fresh `regression-expected.yaml` to `--out`. Review, commit to the
+branch at `.regression/regression-expected.yaml`, and re-run in verify mode
+to confirm PASS. See the manual for the full add-a-new-branch flow.
 
-### Fixture match semantics
+### Exit codes
 
-- Match key is `(rule_id, path, level)` — or `(engine/engine_rule, path, level)`
-  when the framework has no `rule_id` for the rule.
-- Line numbers and messages are **not** part of the match key.
-- `count` means "at least N" in both `exact` and `subset` modes.
-- `match_mode: exact` (default) fails on unexpected extra findings;
-  `match_mode: subset` allows extras and only fails on missing expected findings.
-- The optional top-level `summary` block is checked against
-  `summary.json.counts` before per-finding diffing; any mismatch there is a
-  separate failure axis.
-
-### Tooling ref the run actually used
-
-Each test repo's caller workflow hardcodes the tooling ref it consumes, and
-does not forward `workflow_dispatch` inputs. A local `gh workflow run` can't
-override which tooling SHA runs server-side; OIDC inside the reusable
-inherits `job_workflow_ref` from the caller's hardcoded reference.
-
-Two cases in the wild:
-
-- **Dark / production API repos** — caller targets
-  `camaraproject/tooling/.github/workflows/validation.yml@v1-rc`. Each run
-  pins to whatever commit `v1-rc` currently points at; the SHA only changes
-  when the tag is moved (a deliberate, repo-wide release event).
-- **`camaraproject/ReleaseTest` (canary)** — caller targets
-  `...@validation-framework`. Each run pins to the current HEAD of the
-  `validation-framework` branch. Every push to that branch can change what
-  the runner sees here, *before* `v1-rc` is moved for the rest of the org.
-  This is the intentional canary surface for changes under development.
-
-The runner records the **actually used** SHA into the captured fixture by
-reading `tooling_ref` from `context.json` in the diagnostics artifact. That
-field comes from the orchestrator's own resolved context, so it's correct
-regardless of which ref the caller targeted.
-
-Implications for fixture maintenance:
-
-- For ReleaseTest fixtures: any merge to `validation-framework` that changes
-  findings against the same specs will produce a FAIL on the next runner
-  invocation. That's the canary working as designed. Triage the diff:
-  - Intended rule/engine change → recapture the fixture (`--capture`),
-    review the new findings, commit.
-  - Unintended regression → fix the code on `validation-framework`, re-run.
-- For dark-repo fixtures (none today): only stale after `v1-rc` moves.
+| Code | Meaning |
+|---|---|
+| 0 | All branches PASS (or capture succeeded) |
+| 1 | One or more branches FAIL (diff mismatch) |
+| 2 | Infrastructure failure (gh error, timeout, missing artifact, schema invalid) |
 
 ### Troubleshooting
 
@@ -117,5 +82,6 @@ Implications for fixture maintenance:
   probably failed before the output step. Check the run URL printed in
   the log.
 - **Capture-then-verify fails on immediate re-run** — the validation output
-  is non-deterministic for this branch. Treat as a framework bug, not a
-  runner bug; stop and investigate.
+  is non-deterministic for this branch. That's a framework bug, not a
+  runner bug; stop and investigate. See the "Sharp edges" section of the
+  manual.

--- a/validation/scripts/README.md
+++ b/validation/scripts/README.md
@@ -73,16 +73,39 @@ Review the generated file, commit it to the branch at
   `summary.json.counts` before per-finding diffing; any mismatch there is a
   separate failure axis.
 
-### Tooling ref pinning (known constraint)
+### Tooling ref the run actually used
 
-The caller workflow hardcodes `uses: camaraproject/tooling/.github/workflows/validation.yml@v1-rc`
-and does not forward `workflow_dispatch` inputs to the reusable. OIDC
-resolution inside the reusable therefore locks to whatever commit `v1-rc`
-currently points at — a local `gh workflow run` cannot override this.
+Each test repo's caller workflow hardcodes the tooling ref it consumes, and
+does not forward `workflow_dispatch` inputs. A local `gh workflow run` can't
+override which tooling SHA runs server-side; OIDC inside the reusable
+inherits `job_workflow_ref` from the caller's hardcoded reference.
 
-Fixtures are implicitly pinned to that ref. Record the current `v1-rc` SHA in
-each branch's `REGRESSION.md` (`gh api repos/camaraproject/tooling/git/refs/tags/v1-rc --jq '.object.sha'`).
-If `v1-rc` moves, recapture the fixtures.
+Two cases in the wild:
+
+- **Dark / production API repos** — caller targets
+  `camaraproject/tooling/.github/workflows/validation.yml@v1-rc`. Each run
+  pins to whatever commit `v1-rc` currently points at; the SHA only changes
+  when the tag is moved (a deliberate, repo-wide release event).
+- **`camaraproject/ReleaseTest` (canary)** — caller targets
+  `...@validation-framework`. Each run pins to the current HEAD of the
+  `validation-framework` branch. Every push to that branch can change what
+  the runner sees here, *before* `v1-rc` is moved for the rest of the org.
+  This is the intentional canary surface for changes under development.
+
+The runner records the **actually used** SHA into the captured fixture by
+reading `tooling_ref` from `context.json` in the diagnostics artifact. That
+field comes from the orchestrator's own resolved context, so it's correct
+regardless of which ref the caller targeted.
+
+Implications for fixture maintenance:
+
+- For ReleaseTest fixtures: any merge to `validation-framework` that changes
+  findings against the same specs will produce a FAIL on the next runner
+  invocation. That's the canary working as designed. Triage the diff:
+  - Intended rule/engine change → recapture the fixture (`--capture`),
+    review the new findings, commit.
+  - Unintended regression → fix the code on `validation-framework`, re-run.
+- For dark-repo fixtures (none today): only stale after `v1-rc` moves.
 
 ### Troubleshooting
 

--- a/validation/scripts/README.md
+++ b/validation/scripts/README.md
@@ -1,0 +1,98 @@
+# Validation Framework — Scripts
+
+CLI entry points for the validation framework. Callable both from reusable
+workflow steps and from a developer workstation.
+
+## `validate-release-plan.py`
+
+Validates `release-plan.yaml` files against the JSON schema and semantic rules.
+Called by `pr_validation` via `shared-actions/validate-release-plan`. Do not
+modify its CLI or exit codes without updating that action.
+
+```
+python3 validate-release-plan.py <release-plan-file> [--check-files]
+```
+
+## `regression_runner.py`
+
+Dispatches the validation framework against `regression/*` branches of a test
+repository, downloads findings, and diffs them against the committed
+`.regression/regression-expected.yaml` fixture on each branch.
+
+### Prerequisites
+
+- Python 3.11+ with `pyyaml` and `jsonschema`
+- `gh` CLI installed and authenticated (`gh auth status` must be green)
+- The test repo must have the Validation Framework caller workflow installed
+  (`.github/workflows/camara-validation.yml`)
+- Each `regression/*` branch must contain `.regression/regression-expected.yaml`
+  conforming to `validation/schemas/regression-expected-schema.yaml`
+
+### Run
+
+```
+python3 validation/scripts/regression_runner.py \
+    --repo camaraproject/ReleaseTest \
+    [--branch-filter 'regression/r4.1-*'] \
+    [--workflow-file camara-validation.yml] \
+    [--poll-interval 15] [--poll-timeout 1800] \
+    [--summary-file regression-summary.md]
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | all branches PASS |
+| 1 | one or more branches FAIL (diff mismatch) |
+| 2 | infrastructure failure (gh error, timeout, missing artifact, schema invalid) |
+
+### Capture a new fixture
+
+```
+python3 validation/scripts/regression_runner.py \
+    --repo camaraproject/ReleaseTest \
+    --capture regression/r4.1-main-baseline \
+    --out /tmp/expected.yaml \
+    [--capture-description "baseline"]
+```
+
+Review the generated file, commit it to the branch at
+`.regression/regression-expected.yaml`, then re-run the runner without
+`--capture` to verify PASS.
+
+### Fixture match semantics
+
+- Match key is `(rule_id, path, level)` — or `(engine/engine_rule, path, level)`
+  when the framework has no `rule_id` for the rule.
+- Line numbers and messages are **not** part of the match key.
+- `count` means "at least N" in both `exact` and `subset` modes.
+- `match_mode: exact` (default) fails on unexpected extra findings;
+  `match_mode: subset` allows extras and only fails on missing expected findings.
+- The optional top-level `summary` block is checked against
+  `summary.json.counts` before per-finding diffing; any mismatch there is a
+  separate failure axis.
+
+### Tooling ref pinning (known constraint)
+
+The caller workflow hardcodes `uses: camaraproject/tooling/.github/workflows/validation.yml@v1-rc`
+and does not forward `workflow_dispatch` inputs to the reusable. OIDC
+resolution inside the reusable therefore locks to whatever commit `v1-rc`
+currently points at — a local `gh workflow run` cannot override this.
+
+Fixtures are implicitly pinned to that ref. Record the current `v1-rc` SHA in
+each branch's `REGRESSION.md` (`gh api repos/camaraproject/tooling/git/refs/tags/v1-rc --jq '.object.sha'`).
+If `v1-rc` moves, recapture the fixtures.
+
+### Troubleshooting
+
+- **`gh CLI not found`** — install from <https://cli.github.com/> and run
+  `gh auth login`.
+- **`timed out waiting for dispatched run to appear`** — GitHub Actions
+  backlog; retry after a minute, or raise `--poll-timeout`.
+- **`findings.json not found in downloaded artifact`** — the workflow run
+  probably failed before the output step. Check the run URL printed in
+  the log.
+- **Capture-then-verify fails on immediate re-run** — the validation output
+  is non-deterministic for this branch. Treat as a framework bug, not a
+  runner bug; stop and investigate.

--- a/validation/scripts/regression_runner.py
+++ b/validation/scripts/regression_runner.py
@@ -466,39 +466,6 @@ def fetch_expected(repo: str, branch: str) -> dict[str, Any]:
     return load_expected(text)
 
 
-def _resolve_tooling_ref(repo: str, tag: str) -> str:
-    """Dereference *tag* on *repo* to the underlying commit SHA.
-
-    Handles both lightweight tags (object.type == "commit") and annotated
-    tags (object.type == "tag", requiring one more dereference through
-    git/tags/{sha}).
-    """
-    ref = gh(
-        [
-            "api", f"repos/{repo}/git/refs/tags/{tag}",
-            "--jq", "[.object.type, .object.sha] | @tsv",
-        ]
-    ).strip()
-    if not ref or "\t" not in ref:
-        raise InfrastructureError(f"{repo}@{tag}: unexpected refs response: {ref!r}")
-    obj_type, obj_sha = ref.split("\t", 1)
-    if obj_type == "commit":
-        return obj_sha
-    if obj_type == "tag":
-        commit_sha = gh(
-            [
-                "api", f"repos/{repo}/git/tags/{obj_sha}",
-                "--jq", ".object.sha",
-            ]
-        ).strip()
-        if not re.match(r"^[0-9a-f]{40}$", commit_sha):
-            raise InfrastructureError(
-                f"{repo}@{tag}: dereferenced commit sha invalid: {commit_sha!r}"
-            )
-        return commit_sha
-    raise InfrastructureError(f"{repo}@{tag}: unsupported object type {obj_type!r}")
-
-
 def branch_tip_sha(repo: str, branch: str) -> str:
     """Return the current tip SHA of *branch* on *repo*."""
     data = gh(
@@ -615,11 +582,13 @@ def download_findings(
     run_id: str,
     workdir: Path,
     artifact_name: str = "validation-diagnostics",
-) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """Download the validation-diagnostics artifact and load findings + summary.
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None]:
+    """Download the validation-diagnostics artifact and load findings, summary, context.
 
-    Returns (findings_list, summary_dict_or_None). Raises InfrastructureError
-    if the artifact is missing or findings.json is not parseable.
+    Returns (findings_list, summary_dict_or_None, context_dict_or_None).
+    Raises InfrastructureError if the artifact is missing or findings.json is
+    not parseable. Summary and context are best-effort: if they fail to load,
+    the corresponding return value is None.
     """
     workdir.mkdir(parents=True, exist_ok=True)
     gh(
@@ -652,14 +621,19 @@ def download_findings(
             f"findings.json root is not a list (got {type(findings).__name__})"
         )
 
-    summary_path = findings_path.parent / "summary.json"
-    summary: dict[str, Any] | None = None
-    if summary_path.exists():
+    def _load_optional(name: str) -> dict[str, Any] | None:
+        path = findings_path.parent / name
+        if not path.exists():
+            return None
         try:
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            data = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
-            summary = None
-    return findings, summary
+            return None
+        return data if isinstance(data, dict) else None
+
+    summary = _load_optional("summary.json")
+    context = _load_optional("context.json")
+    return findings, summary, context
 
 
 # ---------------------------------------------------------------------------
@@ -692,7 +666,7 @@ def run_branch(
     with tempfile.TemporaryDirectory(prefix="vf-regression-") as td:
         workdir = Path(td)
         logger.info("[%s] downloading diagnostics into %s", branch, workdir)
-        actual, summary = download_findings(repo, run_id, workdir)
+        actual, summary, _context = download_findings(repo, run_id, workdir)
 
     report = diff_findings(expected, actual, actual_summary=summary)
     report.branch = branch
@@ -721,15 +695,18 @@ def capture_branch(
 
     with tempfile.TemporaryDirectory(prefix="vf-capture-") as td:
         workdir = Path(td)
-        actual, _summary = download_findings(repo, run_id, workdir)
+        actual, _summary, context = download_findings(repo, run_id, workdir)
 
-    # Resolve the tooling_ref the run used. Best-effort: dereference the
-    # current v1-rc tag to the underlying commit SHA. v1-rc is annotated, so
-    # the ref returns a tag object that must be dereferenced once more.
-    tooling_ref: str | None
-    try:
-        tooling_ref = _resolve_tooling_ref("camaraproject/tooling", "v1-rc")
-    except InfrastructureError:
+    # The actually-used tooling SHA comes from the validation context
+    # written by the orchestrator. This is the canonical answer and works
+    # regardless of which ref the caller targets (@v1-rc on dark repos,
+    # @validation-framework HEAD on the ReleaseTest canary, etc.).
+    tooling_ref: str | None = (context or {}).get("tooling_ref") or None
+    if tooling_ref and not re.match(r"^[0-9a-f]{40}$", tooling_ref):
+        logger.warning(
+            "context.json tooling_ref is not a 40-char SHA: %r — omitting from fixture",
+            tooling_ref,
+        )
         tooling_ref = None
 
     run_url = f"https://github.com/{repo}/actions/runs/{run_id}"

--- a/validation/scripts/regression_runner.py
+++ b/validation/scripts/regression_runner.py
@@ -1,0 +1,883 @@
+#!/usr/bin/env python3
+"""
+CAMARA Validation Framework — Regression Runner
+
+Dispatches the Validation Framework against regression/* branches of a test
+repository, downloads findings, and diffs them against a committed
+regression-expected.yaml fixture on each branch.
+
+Usage:
+    python3 regression_runner.py --repo camaraproject/ReleaseTest \\
+        [--branch-filter 'regression/r4.1-*'] \\
+        [--workflow-file camara-validation.yml] \\
+        [--poll-interval 15] [--poll-timeout 1800]
+
+    # Capture an expected-findings fixture from a fresh run:
+    python3 regression_runner.py --repo camaraproject/ReleaseTest \\
+        --capture regression/r4.1-main-baseline --out /tmp/expected.yaml
+
+Exit codes:
+    0  all branches PASS (or capture succeeded)
+    1  one or more branches FAIL (diff mismatch)
+    2  infrastructure failure (gh error, timeout, missing artifact, invalid schema)
+
+Design reference: private-dev-docs/validation-framework/session-logs/
+  (initial session — WS07 Phase 3 regression infrastructure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fnmatch
+import json
+import logging
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import yaml
+except ImportError:
+    print("Error: pyyaml package is required. Install with: pip install pyyaml")
+    sys.exit(2)
+
+try:
+    import jsonschema
+    from jsonschema import Draft7Validator
+except ImportError:
+    print("Error: jsonschema package is required. Install with: pip install jsonschema")
+    sys.exit(2)
+
+
+logger = logging.getLogger("regression_runner")
+
+
+# ---------------------------------------------------------------------------
+# Types and errors
+# ---------------------------------------------------------------------------
+
+
+class InfrastructureError(RuntimeError):
+    """Raised for gh errors, missing artifacts, schema failures, or timeouts.
+
+    Distinct from a failed diff (which is a regression, not infrastructure).
+    Infrastructure errors map to exit code 2; diff failures map to exit 1.
+    """
+
+
+# Match key = (rule_key, path, level). rule_key is the framework rule_id
+# when present, otherwise f"{engine}/{engine_rule}". Level is the
+# post-filter level string ("error", "warn", "hint").
+MatchKey = tuple[str, str, str]
+
+
+@dataclass
+class DiffReport:
+    branch: str
+    match_mode: str
+    matched: int
+    missing: list[dict[str, Any]] = field(default_factory=list)
+    unexpected: list[dict[str, Any]] = field(default_factory=list)
+    summary_mismatch: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return (
+            not self.missing
+            and not self.unexpected
+            and self.summary_mismatch is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _schema_path() -> Path:
+    return _repo_root() / "validation" / "schemas" / "regression-expected-schema.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — loader, normalize, diff, capture
+# ---------------------------------------------------------------------------
+
+
+def load_expected(source: str | Path) -> dict[str, Any]:
+    """Load and schema-validate a regression-expected.yaml fixture.
+
+    Accepts a Path (file on disk) or a raw YAML string. Raises
+    InfrastructureError on schema violations so that the runner maps to
+    exit code 2 rather than treating a malformed fixture as a regression.
+    """
+    if isinstance(source, Path):
+        text = source.read_text(encoding="utf-8")
+        origin = str(source)
+    else:
+        text = source
+        origin = "<inline>"
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise InfrastructureError(f"{origin}: YAML parse error: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise InfrastructureError(f"{origin}: expected a YAML mapping at the root")
+
+    schema_path = _schema_path()
+    if not schema_path.exists():
+        raise InfrastructureError(f"Schema file not found: {schema_path}")
+    schema = yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if errors:
+        lines = [f"{origin}: schema validation failed:"]
+        for err in errors:
+            path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+            lines.append(f"  at {path}: {err.message}")
+        raise InfrastructureError("\n".join(lines))
+
+    # Reject duplicate match keys within the fixture — they must be
+    # collapsed into one entry with `count`.
+    seen: dict[MatchKey, int] = {}
+    for idx, item in enumerate(data.get("findings", [])):
+        key = _expected_key(item)
+        if key in seen:
+            raise InfrastructureError(
+                f"{origin}: duplicate finding entry at index {idx} "
+                f"(match key already at index {seen[key]}). "
+                f"Collapse into one entry with count."
+            )
+        seen[key] = idx
+
+    return data
+
+
+def _expected_key(entry: dict[str, Any]) -> MatchKey:
+    """Compute the match key for an expected-finding entry."""
+    if "rule_id" in entry:
+        rule_key = entry["rule_id"]
+    else:
+        rule_key = f"{entry['engine']}/{entry['engine_rule']}"
+    return (rule_key, entry["path"], entry["level"])
+
+
+def normalize_finding(finding: dict[str, Any]) -> MatchKey:
+    """Compute the match key for an actual finding dict from findings.json.
+
+    Deliberately ignores `line`, `column`, `message`, `api_name`, `hint`,
+    and any engine-specific extras. Uses `rule_id` when present, falling
+    back to `engine/engine_rule` otherwise.
+    """
+    rule_id = finding.get("rule_id")
+    if rule_id:
+        rule_key = rule_id
+    else:
+        engine = finding.get("engine", "?")
+        engine_rule = finding.get("engine_rule", "?")
+        rule_key = f"{engine}/{engine_rule}"
+    return (rule_key, finding.get("path", ""), finding.get("level", ""))
+
+
+def _index_expected(findings: list[dict[str, Any]]) -> dict[MatchKey, int]:
+    counts: dict[MatchKey, int] = {}
+    for entry in findings:
+        counts[_expected_key(entry)] = entry.get("count", 1)
+    return counts
+
+
+def _index_actual(findings: list[dict[str, Any]]) -> dict[MatchKey, int]:
+    counts: dict[MatchKey, int] = {}
+    for finding in findings:
+        key = normalize_finding(finding)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _check_summary(
+    expected: dict[str, Any] | None,
+    actual_summary: dict[str, Any] | None,
+) -> str | None:
+    if expected is None:
+        return None
+    if actual_summary is None:
+        return "expected `summary` block but no summary.json was found"
+    counts = actual_summary.get("counts", {})
+    mismatches: list[str] = []
+    for key in ("errors", "warnings", "hints"):
+        if key not in expected:
+            continue
+        want = expected[key]
+        have = counts.get(key, 0)
+        if want != have:
+            mismatches.append(f"{key}: expected={want} actual={have}")
+    if mismatches:
+        return "; ".join(mismatches)
+    return None
+
+
+def diff_findings(
+    expected: dict[str, Any],
+    actual: list[dict[str, Any]],
+    actual_summary: dict[str, Any] | None = None,
+) -> DiffReport:
+    """Diff actual findings against an expected fixture.
+
+    Match key is (rule_id_or_engine_rule, path, level). `count` is minimum
+    required — surpluses are only a failure in `exact` match_mode. Line
+    numbers and messages are deliberately ignored.
+    """
+    mode = expected.get("match_mode", "exact")
+    expected_counts = _index_expected(expected.get("findings", []))
+    actual_counts = _index_actual(actual)
+
+    missing: list[dict[str, Any]] = []
+    unexpected: list[dict[str, Any]] = []
+    matched = 0
+
+    for key, need in expected_counts.items():
+        have = actual_counts.get(key, 0)
+        matched += min(need, have)
+        if have < need:
+            missing.append(
+                {
+                    "rule": key[0],
+                    "path": key[1],
+                    "level": key[2],
+                    "expected": need,
+                    "actual": have,
+                }
+            )
+
+    if mode == "exact":
+        for key, have in actual_counts.items():
+            need = expected_counts.get(key, 0)
+            if have > need:
+                unexpected.append(
+                    {
+                        "rule": key[0],
+                        "path": key[1],
+                        "level": key[2],
+                        "expected": need,
+                        "actual": have,
+                    }
+                )
+
+    summary_mismatch = _check_summary(expected.get("summary"), actual_summary)
+
+    return DiffReport(
+        branch=expected.get("branch", "<unknown>"),
+        match_mode=mode,
+        matched=matched,
+        missing=missing,
+        unexpected=unexpected,
+        summary_mismatch=summary_mismatch,
+    )
+
+
+def capture_to_yaml(
+    actual: list[dict[str, Any]],
+    *,
+    branch: str,
+    run_url: str | None,
+    tooling_ref: str | None,
+    description: str | None = None,
+) -> str:
+    """Group actual findings into a regression-expected.yaml document.
+
+    Collapses duplicate match keys into a single entry with `count`. Emits
+    deterministic ordering (sorted by rule_key, path, level) so that
+    repeated captures produce identical output for clean diffs.
+    """
+    counts: dict[MatchKey, int] = {}
+    for finding in actual:
+        key = normalize_finding(finding)
+        counts[key] = counts.get(key, 0) + 1
+
+    # Aggregate counts (matches summary.json["counts"] shape used by the
+    # VF output pipeline).
+    errors = sum(1 for f in actual if f.get("level") == "error")
+    warnings = sum(1 for f in actual if f.get("level") == "warn")
+    hints = sum(1 for f in actual if f.get("level") == "hint")
+
+    findings_entries: list[dict[str, Any]] = []
+    for (rule_key, path, level), count in sorted(counts.items()):
+        entry: dict[str, Any] = {}
+        if re.match(r"^[A-Z]-[0-9]{3}$", rule_key):
+            entry["rule_id"] = rule_key
+        else:
+            engine, _, engine_rule = rule_key.partition("/")
+            entry["engine"] = engine
+            entry["engine_rule"] = engine_rule
+        entry["path"] = path
+        entry["level"] = level
+        if count > 1:
+            entry["count"] = count
+        findings_entries.append(entry)
+
+    doc: dict[str, Any] = {
+        "schema_version": 1,
+        "branch": branch,
+    }
+    if description:
+        doc["description"] = description
+    doc["captured_at"] = (
+        datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    if run_url:
+        doc["captured_from_run"] = run_url
+    if tooling_ref:
+        doc["tooling_ref"] = tooling_ref
+    doc["summary"] = {
+        "errors": errors,
+        "warnings": warnings,
+        "hints": hints,
+    }
+    doc["match_mode"] = "exact"
+    doc["findings"] = findings_entries
+
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(reports: dict[str, DiffReport]) -> str:
+    """Render a per-branch PASS/FAIL summary as markdown."""
+    total = len(reports)
+    passed = sum(1 for r in reports.values() if r.passed)
+    lines: list[str] = []
+    lines.append(f"## Regression Runner — {passed}/{total} branches PASS")
+    lines.append("")
+    lines.append("| Branch | Result | Matched | Missing | Unexpected | Summary |")
+    lines.append("|---|---|---:|---:|---:|---|")
+    for branch, report in sorted(reports.items()):
+        status = "PASS" if report.passed else "FAIL"
+        summary_note = report.summary_mismatch or "-"
+        lines.append(
+            f"| `{branch}` | {status} | {report.matched} | "
+            f"{len(report.missing)} | {len(report.unexpected)} | {summary_note} |"
+        )
+    for branch, report in sorted(reports.items()):
+        if report.passed:
+            continue
+        lines.append("")
+        lines.append(f"### `{branch}` — diff detail")
+        if report.summary_mismatch:
+            lines.append(f"- **summary mismatch**: {report.summary_mismatch}")
+        for entry in report.missing:
+            lines.append(
+                f"- **missing** `{entry['rule']}` at `{entry['path']}` "
+                f"({entry['level']}): expected {entry['expected']}, actual {entry['actual']}"
+            )
+        for entry in report.unexpected:
+            lines.append(
+                f"- **unexpected** `{entry['rule']}` at `{entry['path']}` "
+                f"({entry['level']}): expected {entry['expected']}, actual {entry['actual']}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# GitHub I/O (via gh CLI subprocess)
+# ---------------------------------------------------------------------------
+
+
+def gh(args: list[str], *, parse_json: bool = False) -> Any:
+    """Run `gh <args>` and return stdout (optionally JSON-parsed).
+
+    Raises InfrastructureError on non-zero exit. Stderr is captured and
+    included in the exception message for diagnosis.
+    """
+    cmd = ["gh", *args]
+    logger.debug("gh call: %s", " ".join(cmd))
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True
+        )
+    except FileNotFoundError as exc:
+        raise InfrastructureError(
+            "gh CLI not found — install https://cli.github.com and run `gh auth login`"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise InfrastructureError(
+            f"gh {' '.join(args)}: exit {exc.returncode}\n"
+            f"stderr: {exc.stderr.strip()}"
+        ) from exc
+    if parse_json:
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise InfrastructureError(
+                f"gh {' '.join(args)}: could not parse stdout as JSON: {exc}"
+            ) from exc
+    return result.stdout
+
+
+def list_regression_branches(repo: str, pattern: str) -> list[str]:
+    """Return branch names on *repo* matching *pattern* (fnmatch glob)."""
+    branches = gh(
+        ["api", f"repos/{repo}/branches", "--paginate", "--jq", ".[].name"]
+    )
+    names = [line.strip() for line in branches.splitlines() if line.strip()]
+    return sorted(name for name in names if fnmatch.fnmatch(name, pattern))
+
+
+def fetch_expected(repo: str, branch: str) -> dict[str, Any]:
+    """Fetch and validate `.regression/regression-expected.yaml` from *branch*."""
+    path = ".regression/regression-expected.yaml"
+    try:
+        payload = gh(
+            [
+                "api",
+                f"repos/{repo}/contents/{path}",
+                "-H", "Accept: application/vnd.github+json",
+                "--jq", ".content",
+                "-X", "GET",
+                "-f", f"ref={branch}",
+            ]
+        )
+    except InfrastructureError as exc:
+        raise InfrastructureError(
+            f"{repo}@{branch}: could not fetch {path} — {exc}"
+        ) from exc
+    content_b64 = payload.strip().replace("\n", "")
+    try:
+        text = base64.b64decode(content_b64).decode("utf-8")
+    except Exception as exc:  # noqa: BLE001 — any decode error is infra
+        raise InfrastructureError(
+            f"{repo}@{branch}: could not base64-decode {path}: {exc}"
+        ) from exc
+    return load_expected(text)
+
+
+def _resolve_tooling_ref(repo: str, tag: str) -> str:
+    """Dereference *tag* on *repo* to the underlying commit SHA.
+
+    Handles both lightweight tags (object.type == "commit") and annotated
+    tags (object.type == "tag", requiring one more dereference through
+    git/tags/{sha}).
+    """
+    ref = gh(
+        [
+            "api", f"repos/{repo}/git/refs/tags/{tag}",
+            "--jq", "[.object.type, .object.sha] | @tsv",
+        ]
+    ).strip()
+    if not ref or "\t" not in ref:
+        raise InfrastructureError(f"{repo}@{tag}: unexpected refs response: {ref!r}")
+    obj_type, obj_sha = ref.split("\t", 1)
+    if obj_type == "commit":
+        return obj_sha
+    if obj_type == "tag":
+        commit_sha = gh(
+            [
+                "api", f"repos/{repo}/git/tags/{obj_sha}",
+                "--jq", ".object.sha",
+            ]
+        ).strip()
+        if not re.match(r"^[0-9a-f]{40}$", commit_sha):
+            raise InfrastructureError(
+                f"{repo}@{tag}: dereferenced commit sha invalid: {commit_sha!r}"
+            )
+        return commit_sha
+    raise InfrastructureError(f"{repo}@{tag}: unsupported object type {obj_type!r}")
+
+
+def branch_tip_sha(repo: str, branch: str) -> str:
+    """Return the current tip SHA of *branch* on *repo*."""
+    data = gh(
+        ["api", f"repos/{repo}/branches/{branch}", "--jq", ".commit.sha"]
+    )
+    sha = data.strip()
+    if not re.match(r"^[0-9a-f]{40}$", sha):
+        raise InfrastructureError(
+            f"{repo}@{branch}: unexpected branch tip response: {sha!r}"
+        )
+    return sha
+
+
+def _iso_to_dt(stamp: str) -> datetime:
+    return datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+
+
+def dispatch_validation(
+    repo: str,
+    branch: str,
+    *,
+    workflow_file: str,
+    startup_attempts: int = 15,
+    startup_interval: float = 2.0,
+) -> str:
+    """Dispatch *workflow_file* on *branch* of *repo* and return the run ID.
+
+    GitHub's `workflow run` endpoint does not return the created run ID, so
+    we record a UTC marker, call dispatch, then poll `gh run list` for a new
+    workflow_dispatch run whose `createdAt` is >= marker and whose `headSha`
+    matches the branch tip. Raises InfrastructureError on timeout.
+    """
+    sha = branch_tip_sha(repo, branch)
+    marker = datetime.now(timezone.utc).replace(microsecond=0)
+    gh(
+        [
+            "workflow", "run", workflow_file,
+            "--repo", repo,
+            "--ref", branch,
+        ]
+    )
+    logger.info("dispatched %s on %s@%s; polling for run id", workflow_file, repo, branch)
+
+    for _ in range(startup_attempts):
+        time.sleep(startup_interval)
+        runs = gh(
+            [
+                "run", "list",
+                "--repo", repo,
+                "--workflow", workflow_file,
+                "--branch", branch,
+                "--event", "workflow_dispatch",
+                "--json", "databaseId,createdAt,headSha,status,conclusion",
+                "--limit", "10",
+            ],
+            parse_json=True,
+        )
+        for run in runs:
+            try:
+                created = _iso_to_dt(run["createdAt"])
+            except (KeyError, ValueError):
+                continue
+            if created >= marker and run.get("headSha") == sha:
+                run_id = str(run["databaseId"])
+                logger.info("found dispatched run id=%s", run_id)
+                return run_id
+
+    raise InfrastructureError(
+        f"{repo}@{branch}: timed out waiting for dispatched run to appear "
+        f"(polled {startup_attempts} times)"
+    )
+
+
+def poll_run(
+    repo: str,
+    run_id: str,
+    *,
+    interval: int,
+    timeout: int,
+) -> str:
+    """Wait until *run_id* completes; return its conclusion string.
+
+    Raises InfrastructureError on timeout. A conclusion of "success" is the
+    only value that guarantees artifacts are ready; other conclusions still
+    produce a result and are returned for the caller to decide.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        data = gh(
+            [
+                "run", "view", run_id,
+                "--repo", repo,
+                "--json", "status,conclusion",
+            ],
+            parse_json=True,
+        )
+        status = data.get("status")
+        conclusion = data.get("conclusion") or ""
+        logger.debug("run %s status=%s conclusion=%s", run_id, status, conclusion)
+        if status == "completed":
+            return conclusion
+        if time.monotonic() >= deadline:
+            raise InfrastructureError(
+                f"run {run_id} did not complete within {timeout}s "
+                f"(last status={status})"
+            )
+        time.sleep(interval)
+
+
+def download_findings(
+    repo: str,
+    run_id: str,
+    workdir: Path,
+    artifact_name: str = "validation-diagnostics",
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Download the validation-diagnostics artifact and load findings + summary.
+
+    Returns (findings_list, summary_dict_or_None). Raises InfrastructureError
+    if the artifact is missing or findings.json is not parseable.
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+    gh(
+        [
+            "run", "download", run_id,
+            "--repo", repo,
+            "--name", artifact_name,
+            "--dir", str(workdir),
+        ]
+    )
+    findings_path = workdir / "findings.json"
+    if not findings_path.exists():
+        # gh run download strips the artifact name from the path if --name is
+        # passed; but some versions preserve it. Check both.
+        nested = workdir / artifact_name / "findings.json"
+        if nested.exists():
+            findings_path = nested
+    if not findings_path.exists():
+        raise InfrastructureError(
+            f"findings.json not found in downloaded artifact at {workdir}"
+        )
+    try:
+        findings = json.loads(findings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise InfrastructureError(
+            f"findings.json is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(findings, list):
+        raise InfrastructureError(
+            f"findings.json root is not a list (got {type(findings).__name__})"
+        )
+
+    summary_path = findings_path.parent / "summary.json"
+    summary: dict[str, Any] | None = None
+    if summary_path.exists():
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            summary = None
+    return findings, summary
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_branch(
+    repo: str,
+    branch: str,
+    *,
+    workflow_file: str,
+    poll_interval: int,
+    poll_timeout: int,
+) -> DiffReport:
+    """Full per-branch check: fetch expected, dispatch, poll, download, diff."""
+    logger.info("[%s] fetching expected fixture", branch)
+    expected = fetch_expected(repo, branch)
+
+    logger.info("[%s] dispatching validation workflow", branch)
+    run_id = dispatch_validation(repo, branch, workflow_file=workflow_file)
+
+    logger.info("[%s] polling run %s", branch, run_id)
+    conclusion = poll_run(repo, run_id, interval=poll_interval, timeout=poll_timeout)
+    if conclusion not in {"success", "failure", "neutral"}:
+        raise InfrastructureError(
+            f"[{branch}] unexpected run conclusion: {conclusion}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="vf-regression-") as td:
+        workdir = Path(td)
+        logger.info("[%s] downloading diagnostics into %s", branch, workdir)
+        actual, summary = download_findings(repo, run_id, workdir)
+
+    report = diff_findings(expected, actual, actual_summary=summary)
+    report.branch = branch
+    return report
+
+
+def capture_branch(
+    repo: str,
+    branch: str,
+    *,
+    out_path: Path,
+    workflow_file: str,
+    poll_interval: int,
+    poll_timeout: int,
+    description: str | None,
+) -> Path:
+    """Dispatch the VF, download findings, and write a fresh expected fixture.
+
+    Writes to *out_path*; the caller commits it to the branch after review.
+    """
+    logger.info("[%s] CAPTURE: dispatching workflow", branch)
+    run_id = dispatch_validation(repo, branch, workflow_file=workflow_file)
+    logger.info("[%s] CAPTURE: polling run %s", branch, run_id)
+    conclusion = poll_run(repo, run_id, interval=poll_interval, timeout=poll_timeout)
+    logger.info("[%s] CAPTURE: run completed (%s)", branch, conclusion)
+
+    with tempfile.TemporaryDirectory(prefix="vf-capture-") as td:
+        workdir = Path(td)
+        actual, _summary = download_findings(repo, run_id, workdir)
+
+    # Resolve the tooling_ref the run used. Best-effort: dereference the
+    # current v1-rc tag to the underlying commit SHA. v1-rc is annotated, so
+    # the ref returns a tag object that must be dereferenced once more.
+    tooling_ref: str | None
+    try:
+        tooling_ref = _resolve_tooling_ref("camaraproject/tooling", "v1-rc")
+    except InfrastructureError:
+        tooling_ref = None
+
+    run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+
+    text = capture_to_yaml(
+        actual,
+        branch=branch,
+        run_url=run_url,
+        tooling_ref=tooling_ref,
+        description=description,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(text, encoding="utf-8")
+    logger.info("[%s] CAPTURE: wrote %d findings to %s", branch, len(actual), out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="regression_runner.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="owner/repo of the test repository (e.g. camaraproject/ReleaseTest)",
+    )
+    parser.add_argument(
+        "--branch-filter",
+        default="regression/*",
+        help="fnmatch glob over branch names (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--workflow-file",
+        default="camara-validation.yml",
+        help="caller workflow filename in the test repo (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=15,
+        help="seconds between run status polls (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--poll-timeout",
+        type=int,
+        default=1800,
+        help="max seconds to wait for a run to complete (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        help="write a markdown summary report to this path",
+    )
+    parser.add_argument(
+        "--capture",
+        metavar="BRANCH",
+        help="CAPTURE MODE: dispatch against BRANCH and write a fresh "
+             "regression-expected.yaml to --out (skips diff/reporting)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="output path for --capture mode",
+    )
+    parser.add_argument(
+        "--capture-description",
+        help="description field for captured fixture (optional)",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="verbose logging",
+    )
+    return parser
+
+
+def _setup_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-5s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_argparser().parse_args(argv)
+    _setup_logging(args.verbose)
+
+    try:
+        if args.capture:
+            if not args.out:
+                print("error: --capture requires --out", file=sys.stderr)
+                return 2
+            capture_branch(
+                args.repo,
+                args.capture,
+                out_path=args.out,
+                workflow_file=args.workflow_file,
+                poll_interval=args.poll_interval,
+                poll_timeout=args.poll_timeout,
+                description=args.capture_description,
+            )
+            print(f"CAPTURE OK: wrote {args.out}")
+            return 0
+
+        branches = list_regression_branches(args.repo, args.branch_filter)
+        if not branches:
+            print(
+                f"No branches on {args.repo} match filter "
+                f"{args.branch_filter!r}",
+                file=sys.stderr,
+            )
+            return 2
+        logger.info("matched %d branch(es): %s", len(branches), ", ".join(branches))
+
+        reports: dict[str, DiffReport] = {}
+        for branch in branches:
+            report = run_branch(
+                args.repo,
+                branch,
+                workflow_file=args.workflow_file,
+                poll_interval=args.poll_interval,
+                poll_timeout=args.poll_timeout,
+            )
+            reports[branch] = report
+
+    except InfrastructureError as exc:
+        print(f"INFRA: {exc}", file=sys.stderr)
+        return 2
+
+    markdown = render_markdown(reports)
+    print(markdown)
+    if args.summary_file:
+        args.summary_file.write_text(markdown, encoding="utf-8")
+
+    passed = all(r.passed for r in reports.values())
+    total = len(reports)
+    passing = sum(1 for r in reports.values() if r.passed)
+    print(f"{'PASS' if passed else 'FAIL'}: {passing}/{total} branches", file=sys.stderr)
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/tests/test_regression_runner.py
+++ b/validation/tests/test_regression_runner.py
@@ -1,0 +1,448 @@
+"""Unit tests for validation.scripts.regression_runner.
+
+Covers pure-logic functions only: loader + schema validation, match-key
+normalization, diff semantics (exact/subset, counts, summary mismatch),
+capture→load round-trip, and markdown rendering. GitHub I/O helpers are
+verified manually during integration.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# validation/scripts/ is not a package — load the module directly.
+_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _ROOT / "validation" / "scripts" / "regression_runner.py"
+_spec = importlib.util.spec_from_file_location("regression_runner", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+regression_runner = importlib.util.module_from_spec(_spec)
+sys.modules["regression_runner"] = regression_runner
+_spec.loader.exec_module(regression_runner)
+
+
+InfrastructureError = regression_runner.InfrastructureError
+DiffReport = regression_runner.DiffReport
+load_expected = regression_runner.load_expected
+normalize_finding = regression_runner.normalize_finding
+diff_findings = regression_runner.diff_findings
+capture_to_yaml = regression_runner.capture_to_yaml
+render_markdown = regression_runner.render_markdown
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_finding(
+    *,
+    rule_id: str | None = "S-042",
+    engine: str = "spectral",
+    engine_rule: str = "operation-tag-defined",
+    path: str = "code/API_definitions/sample-service.yaml",
+    line: int = 12,
+    level: str = "hint",
+    message: str = "Operation tag is not defined",
+) -> dict:
+    finding: dict = {
+        "engine": engine,
+        "engine_rule": engine_rule,
+        "level": level,
+        "message": message,
+        "path": path,
+        "line": line,
+    }
+    if rule_id is not None:
+        finding["rule_id"] = rule_id
+    return finding
+
+
+def _valid_fixture() -> dict:
+    return {
+        "schema_version": 1,
+        "branch": "regression/r4.1-main-baseline",
+        "description": "baseline",
+        "summary": {"errors": 0, "warnings": 0, "hints": 2},
+        "match_mode": "exact",
+        "findings": [
+            {
+                "rule_id": "S-042",
+                "path": "code/API_definitions/sample-service.yaml",
+                "level": "hint",
+                "count": 2,
+            },
+            {
+                "engine": "spectral",
+                "engine_rule": "oas3-api-servers",
+                "path": "code/API_definitions/sample-service.yaml",
+                "level": "hint",
+            },
+        ],
+    }
+
+
+def _dump(doc: dict) -> str:
+    return yaml.safe_dump(doc, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# load_expected
+# ---------------------------------------------------------------------------
+
+
+class TestLoadExpected:
+    def test_happy_path(self) -> None:
+        data = load_expected(_dump(_valid_fixture()))
+        assert data["branch"] == "regression/r4.1-main-baseline"
+        assert len(data["findings"]) == 2
+
+    def test_missing_schema_version(self) -> None:
+        fixture = _valid_fixture()
+        del fixture["schema_version"]
+        with pytest.raises(InfrastructureError, match="schema_version"):
+            load_expected(_dump(fixture))
+
+    def test_invalid_rule_id_pattern(self) -> None:
+        fixture = _valid_fixture()
+        fixture["findings"][0]["rule_id"] = "foo-123"
+        with pytest.raises(InfrastructureError, match="foo-123"):
+            load_expected(_dump(fixture))
+
+    def test_neither_rule_id_nor_engine_rule(self) -> None:
+        fixture = _valid_fixture()
+        fixture["findings"] = [
+            {
+                "path": "some.yaml",
+                "level": "error",
+            }
+        ]
+        with pytest.raises(InfrastructureError):
+            load_expected(_dump(fixture))
+
+    def test_duplicate_match_key_rejected(self) -> None:
+        fixture = _valid_fixture()
+        fixture["findings"] = [
+            {
+                "rule_id": "S-042",
+                "path": "x.yaml",
+                "level": "hint",
+            },
+            {
+                "rule_id": "S-042",
+                "path": "x.yaml",
+                "level": "hint",
+                "count": 2,
+            },
+        ]
+        with pytest.raises(InfrastructureError, match="duplicate"):
+            load_expected(_dump(fixture))
+
+    def test_invalid_yaml_root(self) -> None:
+        with pytest.raises(InfrastructureError, match="YAML mapping"):
+            load_expected("- not-a-mapping\n")
+
+    def test_invalid_match_mode(self) -> None:
+        fixture = _valid_fixture()
+        fixture["match_mode"] = "wibble"
+        with pytest.raises(InfrastructureError):
+            load_expected(_dump(fixture))
+
+
+# ---------------------------------------------------------------------------
+# normalize_finding
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFinding:
+    def test_strips_line_column_message(self) -> None:
+        a = _make_finding(line=10, message="x")
+        b = _make_finding(line=200, message="completely different message")
+        assert normalize_finding(a) == normalize_finding(b)
+
+    def test_uses_rule_id_when_present(self) -> None:
+        f = _make_finding(rule_id="P-007")
+        key = normalize_finding(f)
+        assert key[0] == "P-007"
+
+    def test_engine_rule_fallback_when_rule_id_absent(self) -> None:
+        f = _make_finding(rule_id=None, engine="python", engine_rule="my-check")
+        key = normalize_finding(f)
+        assert key[0] == "python/my-check"
+
+
+# ---------------------------------------------------------------------------
+# diff_findings
+# ---------------------------------------------------------------------------
+
+
+class TestDiffFindings:
+    def test_zero_vs_zero(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/empty",
+            "match_mode": "exact",
+            "findings": [],
+        }))
+        report = diff_findings(expected, [])
+        assert report.passed
+        assert report.matched == 0
+
+    def test_baseline_clean_match(self) -> None:
+        fixture = _valid_fixture()
+        # Three actual hints total: S-042 ×2 + oas3-api-servers ×1
+        fixture["summary"] = {"errors": 0, "warnings": 0, "hints": 3}
+        expected = load_expected(_dump(fixture))
+        actual = [
+            _make_finding(rule_id="S-042", line=10),
+            _make_finding(rule_id="S-042", line=20),
+            _make_finding(
+                rule_id=None, engine="spectral", engine_rule="oas3-api-servers"
+            ),
+        ]
+        report = diff_findings(
+            expected,
+            actual,
+            actual_summary={
+                "counts": {
+                    "errors": 0, "warnings": 0, "hints": 3,
+                    "total": 3, "blocking": 0,
+                }
+            },
+        )
+        assert report.passed
+        assert report.matched == 3
+        assert not report.missing
+        assert not report.unexpected
+        assert report.summary_mismatch is None
+
+    def test_missing_finding(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "exact",
+            "findings": [
+                {"rule_id": "S-042", "path": "a.yaml", "level": "hint"},
+            ],
+        }))
+        report = diff_findings(expected, [])
+        assert not report.passed
+        assert len(report.missing) == 1
+        assert report.missing[0]["rule"] == "S-042"
+        assert report.missing[0]["expected"] == 1
+        assert report.missing[0]["actual"] == 0
+
+    def test_unexpected_extra_exact_mode(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "exact",
+            "findings": [],
+        }))
+        actual = [_make_finding(rule_id="S-042")]
+        report = diff_findings(expected, actual)
+        assert not report.passed
+        assert len(report.unexpected) == 1
+        assert report.unexpected[0]["rule"] == "S-042"
+
+    def test_unexpected_extra_subset_mode(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "subset",
+            "findings": [],
+        }))
+        actual = [_make_finding(rule_id="S-042")]
+        report = diff_findings(expected, actual)
+        assert report.passed
+        assert not report.unexpected
+
+    def test_count_shortfall(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "exact",
+            "findings": [
+                {"rule_id": "S-042", "path": "a.yaml", "level": "hint", "count": 3},
+            ],
+        }))
+        actual = [
+            _make_finding(rule_id="S-042", path="a.yaml"),
+            _make_finding(rule_id="S-042", path="a.yaml"),
+        ]
+        report = diff_findings(expected, actual)
+        assert not report.passed
+        assert len(report.missing) == 1
+        assert report.missing[0]["expected"] == 3
+        assert report.missing[0]["actual"] == 2
+
+    def test_count_surplus_exact_mode(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "exact",
+            "findings": [
+                {"rule_id": "S-042", "path": "a.yaml", "level": "hint", "count": 2},
+            ],
+        }))
+        actual = [
+            _make_finding(rule_id="S-042", path="a.yaml"),
+            _make_finding(rule_id="S-042", path="a.yaml"),
+            _make_finding(rule_id="S-042", path="a.yaml"),
+        ]
+        report = diff_findings(expected, actual)
+        assert not report.passed
+        assert len(report.unexpected) == 1
+        assert report.unexpected[0]["expected"] == 2
+        assert report.unexpected[0]["actual"] == 3
+
+    def test_count_surplus_subset_mode(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "subset",
+            "findings": [
+                {"rule_id": "S-042", "path": "a.yaml", "level": "hint", "count": 2},
+            ],
+        }))
+        actual = [
+            _make_finding(rule_id="S-042", path="a.yaml"),
+            _make_finding(rule_id="S-042", path="a.yaml"),
+            _make_finding(rule_id="S-042", path="a.yaml"),
+        ]
+        report = diff_findings(expected, actual)
+        assert report.passed
+        assert report.matched == 2  # min(expected=2, actual=3)
+
+    def test_summary_mismatch_on_counts(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "exact",
+            "summary": {"errors": 0, "warnings": 0, "hints": 0},
+            "findings": [],
+        }))
+        report = diff_findings(expected, [], actual_summary={
+            "counts": {"errors": 1, "warnings": 0, "hints": 0, "total": 1, "blocking": 1}
+        })
+        assert not report.passed
+        assert report.summary_mismatch is not None
+        assert "errors" in report.summary_mismatch
+
+    def test_scrambled_order_still_matches(self) -> None:
+        expected = load_expected(_dump({
+            "schema_version": 1,
+            "branch": "regression/x",
+            "match_mode": "exact",
+            "findings": [
+                {"rule_id": "S-042", "path": "a.yaml", "level": "hint"},
+                {"rule_id": "P-007", "path": "b.yaml", "level": "warn"},
+            ],
+        }))
+        actual = [
+            _make_finding(rule_id="P-007", path="b.yaml", level="warn"),
+            _make_finding(rule_id="S-042", path="a.yaml", level="hint"),
+        ]
+        report = diff_findings(expected, actual)
+        assert report.passed
+
+
+# ---------------------------------------------------------------------------
+# capture_to_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureToYaml:
+    def test_roundtrip(self) -> None:
+        actual = [
+            _make_finding(rule_id="S-042", path="a.yaml", level="hint"),
+            _make_finding(rule_id="S-042", path="a.yaml", level="hint"),
+            _make_finding(rule_id=None, engine="python",
+                          engine_rule="check-x", path="b.yaml", level="warn"),
+        ]
+        text = capture_to_yaml(
+            actual,
+            branch="regression/r4.1-main-baseline",
+            run_url="https://github.com/camaraproject/ReleaseTest/actions/runs/1",
+            tooling_ref="b4c1c3e0000000000000000000000000000000b4",
+            description="baseline",
+        )
+        # Round-trips through the loader + schema
+        data = load_expected(text)
+        assert data["branch"] == "regression/r4.1-main-baseline"
+        assert data["summary"]["warnings"] == 1
+        assert data["summary"]["hints"] == 2
+        # Duplicates collapsed into count
+        rule_042 = next(f for f in data["findings"] if f.get("rule_id") == "S-042")
+        assert rule_042["count"] == 2
+        # Engine-rule entry uses engine+engine_rule fields, not rule_id
+        python_entry = next(
+            f for f in data["findings"]
+            if f.get("engine") == "python"
+        )
+        assert python_entry["engine_rule"] == "check-x"
+        assert "rule_id" not in python_entry
+
+    def test_deterministic_output(self) -> None:
+        actual = [
+            _make_finding(rule_id="S-099", path="z.yaml", level="hint"),
+            _make_finding(rule_id="S-001", path="a.yaml", level="hint"),
+        ]
+        text1 = capture_to_yaml(
+            actual, branch="regression/x", run_url=None, tooling_ref=None,
+        )
+        text2 = capture_to_yaml(
+            list(reversed(actual)), branch="regression/x", run_url=None, tooling_ref=None,
+        )
+        # captured_at differs by timestamp but findings ordering should match
+        doc1 = yaml.safe_load(text1)
+        doc2 = yaml.safe_load(text2)
+        assert doc1["findings"] == doc2["findings"]
+        # Sorted by rule_key
+        assert doc1["findings"][0]["rule_id"] == "S-001"
+        assert doc1["findings"][1]["rule_id"] == "S-099"
+
+
+# ---------------------------------------------------------------------------
+# render_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMarkdown:
+    def test_mixed_pass_fail(self) -> None:
+        pass_report = DiffReport(
+            branch="regression/clean", match_mode="exact", matched=5,
+        )
+        fail_report = DiffReport(
+            branch="regression/broken",
+            match_mode="exact",
+            matched=1,
+            missing=[{"rule": "S-042", "path": "a.yaml", "level": "hint",
+                      "expected": 2, "actual": 1}],
+            unexpected=[{"rule": "S-099", "path": "z.yaml", "level": "warn",
+                         "expected": 0, "actual": 1}],
+        )
+        text = render_markdown({
+            "regression/clean": pass_report,
+            "regression/broken": fail_report,
+        })
+        assert "1/2 branches PASS" in text
+        assert "`regression/clean` | PASS" in text
+        assert "`regression/broken` | FAIL" in text
+        assert "missing" in text
+        assert "unexpected" in text
+        assert "S-042" in text
+        assert "S-099" in text
+
+    def test_all_pass_no_detail_section(self) -> None:
+        report = DiffReport(
+            branch="regression/clean", match_mode="exact", matched=27,
+        )
+        text = render_markdown({"regression/clean": report})
+        assert "1/1 branches PASS" in text
+        assert "PASS" in text
+        assert "diff detail" not in text


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds a regression testing layer for the Validation Framework: a fixture schema, a runner script with capture and verify modes, 24 unit tests, the first pilot regression branch on `camaraproject/ReleaseTest`, and a manual under `validation/docs/`.

Tracked in [camaraproject/ReleaseManagement#483](https://github.com/camaraproject/ReleaseManagement/issues/483) (sibling to #448). See [validation/docs/regression-testing.md](https://github.com/camaraproject/tooling/blob/validation-framework/validation/docs/regression-testing.md) for motivation, the canary model, the fixture format, and day-to-day workflows. Per-commit detail in the three commits on this branch.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

- Pilot branch `regression/r4.1-main-baseline` is live on `camaraproject/ReleaseTest` (caller pinned to `@validation-framework` HEAD, by design as canary).
- End-to-end verified: capture [run 24386656531](https://github.com/camaraproject/ReleaseTest/actions/runs/24386656531) → fixture committed → verify run PASS 27/27 → four perturbation scenarios all detected.
- 832/832 existing validation tests still pass; 24 new tests added. No new Python dependencies. No reusable workflow / caller template / `diagnostics.py` changes.

#### Changelog input

```
release-note
Add regression testing infrastructure for the validation framework: fixture
schema, runner script (capture and verify modes), first baseline branch on
camaraproject/ReleaseTest, manual under validation/docs/.
```

#### Additional documentation

```
docs
validation/docs/regression-testing.md - regression testing manual
validation/scripts/README.md - runner CLI reference
```