### PR TITLE
chore: enable Dependabot on validation-framework branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,23 @@
 
 version: 2
 updates:
-  # GitHub Actions - check weekly for updates
+  # GitHub Actions on main - check weekly for updates
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions on validation-framework - until it merges into main
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "validation-framework"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Adds a second `dependabot.yml` entry with
`target-branch: validation-framework` so Dependabot also raises
dependency update PRs against the `validation-framework` branch
during the RC period, preventing it from falling behind `main`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

Remove the second entry once `validation-framework` merges into
`main` — two entries with the same `package-ecosystem` targeting
the same effective branch would duplicate PRs.

#### Changelog input

```
 release-note

```

#### Additional documentation

This section can be blank.

```
docs

```