### PR TITLE
Broken-spec regression coverage + scheduled runner workflow

### DIFF
--- a/.github/workflows/regression-runner.yml
+++ b/.github/workflows/regression-runner.yml
@@ -1,0 +1,91 @@
+# CAMARA Validation Framework — Regression Runner (canary)
+#
+# Auto-dispatches validation/scripts/regression_runner.py against
+# camaraproject/ReleaseTest on every push to validation-framework, so
+# that "broken stays broken" and "clean stays clean" are verified
+# automatically before v1-rc is moved for the rest of the org.
+#
+# The runner dispatches camara-validation.yml on each branch matching
+# regression/* on ReleaseTest, waits for it to complete, downloads the
+# diagnostics artifact, and diffs the findings against each branch's
+# committed .regression/regression-expected.yaml fixture.
+#
+# Cross-repo access is provided by a short-lived camara-validation
+# GitHub App installation token scoped to camaraproject/ReleaseTest.
+# The default GITHUB_TOKEN is only used for the initial checkout.
+#
+# See validation/docs/regression-testing.md for the full picture.
+
+name: Regression Runner
+
+on:
+  push:
+    branches: [validation-framework]
+    paths:
+      - 'validation/**'
+      - 'shared-actions/**'
+      - '.github/workflows/regression-runner.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: regression-runner-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  regression:
+    name: Regression canary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install runner dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pyyaml jsonschema
+
+      - name: Mint validation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VALIDATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VALIDATION_APP_PRIVATE_KEY }}
+          owner: camaraproject
+          repositories: ReleaseTest
+
+      - name: Run regression runner
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python3 validation/scripts/regression_runner.py \
+            --repo camaraproject/ReleaseTest \
+            --branch-filter 'regression/*' \
+            --summary-file regression-summary.md
+
+      - name: Publish summary
+        if: always()
+        run: |
+          if [ -f regression-summary.md ]; then
+            cat regression-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::regression-summary.md not produced (runner likely failed before writing)"
+          fi
+
+      - name: Upload summary artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-runner-summary
+          path: regression-summary.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/validation/docs/regression-testing.md
+++ b/validation/docs/regression-testing.md
@@ -242,13 +242,21 @@ field will reflect the current `validation-framework` HEAD.
 ### Adding a new regression branch
 
 1. Branch from `camaraproject/ReleaseTest@main` with a descriptive name
-   under the `regression/` namespace
-   (e.g. `regression/r4.1-broken-info-block`).
+   under the `regression/` namespace. Naming convention:
+   - **Baseline branches**: `regression/rX.Y-main-baseline`
+   - **Broken-spec branches**: `regression/rX.Y-broken-spec-<theme>`
+
+   The `rX.Y` prefix records the Commonalities minor release the branch
+   was captured against. See [The broken-spec branch plan](#the-broken-spec-branch-plan)
+   for the target theme set.
 2. Make whatever spec edits the branch is meant to test. For a baseline
-   branch, leave specs unmodified.
+   branch, leave specs unmodified. For a broken-spec branch, keep edits
+   surgical — one theme per branch — and avoid cascades into rules the
+   branch is not meant to test.
 3. Write a short `REGRESSION.md` at `.regression/REGRESSION.md`
-   explaining what this branch is for, what it expects, and the
-   caller-workflow context if it's not the canary default.
+   explaining what this branch is for, what it expects (edit-to-rule
+   mapping for broken-spec branches), and the caller-workflow context
+   if it's not the canary default.
 4. Push the branch.
 5. Run the runner in `--capture` mode to seed
    `.regression/regression-expected.yaml`.
@@ -274,6 +282,80 @@ tested_rules:
 Always list-valued for uniformity when a rule is covered by multiple
 branches. Treat the field as proof, not aspiration: bump it after the
 runner reports PASS against the new fixture, not before.
+
+## The broken-spec branch plan
+
+Broken-spec branches are organised by **theme**, not by individual rule.
+Each branch contains a small set of surgical edits to one or two spec
+files on `camaraproject/ReleaseTest` that together trigger a coherent
+group of rules. One branch = one workflow run — grouping by theme keeps
+the canary dispatch budget small while still pinning every rule that
+can reasonably be exercised from the spec side.
+
+### Target themes
+
+The r4.1 rule set partitions cleanly into seven themes (plus an optional
+eighth for test-file quality). The table records the current plan; each
+theme becomes one `regression/r4.1-broken-spec-<theme>` branch.
+
+| # | Branch | Theme / target files | Rules covered | Rebase risk on minor bump |
+|---|---|---|---|---|
+| 1 | `regression/r4.1-broken-spec-api-metadata` | `sample-service.yaml` — `info`, `servers`, `tags` block | S-018, S-019, S-020, S-021, S-022, S-023, S-024, S-201, S-210 | LOW |
+| 2 | `regression/r4.1-broken-spec-yaml-fundamentals` | `sample-service.yaml` YAML-level defects + `openapi:` version + schema type | Y-001…Y-013, S-005, S-016 | LOW |
+| 3 | `regression/r4.1-broken-spec-error-handling` | `sample-service.yaml` — error responses + error codes | S-025, S-026, S-027, S-221, S-307, S-318 | LOW |
+| 4 | `regression/r4.1-broken-spec-descriptions` | `sample-service.yaml` — descriptions on operations / parameters / properties / responses / array items | S-006, S-009, S-011, S-013, S-014, S-028, S-029, S-031, S-215, S-216, S-223 | MEDIUM |
+| 5 | `regression/r4.1-broken-spec-schema-constraints` | `sample-service.yaml` components (not common files — avoid baseline collision) | S-012, S-017, S-030, S-300, S-303, S-308, S-309, S-310, S-311, S-312 | MEDIUM |
+| 6 | `regression/r4.1-broken-spec-routing` | `sample-service.yaml` — paths, operationIds, HTTP methods, servers | S-002, S-003, S-007, S-008, S-010, S-204, S-214, S-217, S-218, S-220, S-222, S-224, S-225, S-226, S-227, S-301, S-306 | HIGH |
+| 7 | `regression/r4.1-broken-spec-subscriptions` | `sample-service-subscriptions.yaml` + `sample-implicit-events.yaml` — CloudEvent / Protocol / sink / notifications + Python subscription checks | S-032, S-033, S-034, S-035, P-014, P-015, P-016, P-020 | HIGH |
+| 8 (optional) | `regression/r4.1-broken-spec-test-files` | `code/Test_definitions/*.feature` — filename / version / gherkin defects | P-001, P-002, P-003, P-004, P-005, P-007, P-008, selected G-* | LOW |
+
+Rules **not** covered by any broken-spec branch:
+
+- **Owned by the baseline fixture**: P-006, S-211, S-313, S-314, S-316.
+  Broken-spec branches inherit these when captured, but do not own the
+  pinning — they would double-count.
+- **Un-triggerable via spec edits**: P-009, P-010, P-011, P-012, P-013,
+  P-019 (release-plan / PR-context / fixture-dependent).
+- **Deprecated, OAS-3.1-only, or low-signal**: S-001, S-004, S-015,
+  S-205, S-206, S-208, S-209, S-228, S-302, S-304, S-305, S-315, S-317,
+  S-319.
+- **Manual-only (not machine-checkable)**: the 25 `TG-*` rules from the
+  testing guidelines audit.
+
+### Inherited baseline findings
+
+Broken-spec branches are cut from `main`, so every captured fixture
+contains the full baseline finding set **plus** the new findings the
+broken edits trigger. A broken-spec branch fixture is a complete
+snapshot of its branch's output, not a delta. The runner's `exact`
+match mode evaluates both halves together.
+
+When designing a new broken-spec branch, pick edits whose new match keys
+(`(rule_id, path, level)`) do **not** collide with baseline keys — the
+baseline branch already pins those. If an edit would have collided, move
+it to a different file or pick a different rule.
+
+### Lifecycle across Commonalities versions
+
+The `rX.Y` prefix records the Commonalities minor release the branch
+was captured against. Two separate lifecycles apply:
+
+- **Minor bump** (e.g. r4.1 → r4.2): rebase each broken-spec branch onto
+  the updated ReleaseTest `main`, rename the prefix (`r4.1-broken-spec-*`
+  → `r4.2-broken-spec-*`), recapture the fixture, force-push. Delete the
+  old `r4.1-*` branch. Rationale: r4.2 is the current surface, and the
+  broken-spec predicate ("info.description missing", "license.name
+  wrong", etc.) is preserved by rebase for the LOW-risk themes. MEDIUM
+  and HIGH risk themes may need the edits re-applied manually after the
+  rebase — treat them as rewrites, not pure rebases.
+- **Major bump** (e.g. r4.3 → r5.1): **keep** the last `r4.x-broken-spec-*`
+  set as permanent regression coverage for the previous major, and
+  create a fresh `r5.1-broken-spec-*` set from `r5.1` main. Breaking
+  Commonalities changes can invalidate old predicates; the previous
+  major stays frozen so long as it's still supported.
+
+The same model applies to `regression/rX.Y-main-baseline` — rebase +
+rename on minor bumps, preserve across majors.
 
 ## Sharp edges and known limitations
 

--- a/validation/docs/regression-testing.md
+++ b/validation/docs/regression-testing.md
@@ -184,6 +184,26 @@ points at.
 
 ## Day-to-day usage
 
+### Automatic runs on `validation-framework`
+
+The regression runner fires automatically on every push to
+`validation-framework` that touches `validation/**`, `shared-actions/**`,
+or the workflow itself. The workflow lives at
+[.github/workflows/regression-runner.yml](../../.github/workflows/regression-runner.yml)
+on this same branch (so it only exists where it matters and does not
+run on `main`). Manual dispatch is available via the Actions UI for
+fix-then-verify cycles.
+
+Cross-repo access to ReleaseTest is provided by a short-lived
+`camara-validation` GitHub App installation token minted with
+`owner: camaraproject, repositories: ReleaseTest`. There is no
+persisted PAT.
+
+Results surface in three places: (1) the workflow's own pass/fail
+status in the Actions tab on `camaraproject/tooling`, (2) the markdown
+summary on the run's summary page, and (3) the `regression-runner-summary`
+artifact attached to each run (30-day retention).
+
 ### Verify all canary branches
 
 ```

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 5
+  total_tested: 14
   by_engine:
     spectral: 84
     gherkin: 25
@@ -294,6 +294,15 @@ pending_rules:
 
 tested_rules:
   P-006: [regression/r4.1-main-baseline]
+  S-018: [regression/r4.1-broken-spec-api-metadata]
+  S-019: [regression/r4.1-broken-spec-api-metadata]
+  S-020: [regression/r4.1-broken-spec-api-metadata]
+  S-021: [regression/r4.1-broken-spec-api-metadata]
+  S-022: [regression/r4.1-broken-spec-api-metadata]
+  S-023: [regression/r4.1-broken-spec-api-metadata]
+  S-024: [regression/r4.1-broken-spec-api-metadata]
+  S-201: [regression/r4.1-broken-spec-api-metadata]
+  S-210: [regression/r4.1-broken-spec-api-metadata]
   S-211: [regression/r4.1-main-baseline]
   S-313: [regression/r4.1-main-baseline]
   S-314: [regression/r4.1-main-baseline]


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Two related deliveries bundled under regression infrastructure:

1. **First broken-spec regression branch.** Pins nine rules via surgical metadata edits to `sample-service.yaml` on `camaraproject/ReleaseTest@regression/r4.1-broken-spec-api-metadata`: S-018, S-019 (errors), S-020, S-024, S-201, S-210 (warnings), S-021, S-022, S-023 (hints). `validation/rules/rule-inventory.yaml` `total_tested` 5 → 14. `validation/docs/regression-testing.md` gains a "broken-spec branch plan" section with the seven-theme roadmap and the minor-bump-rebase-and-rename / major-bump-preserve lifecycle.

2. **Scheduled regression runner workflow** (`.github/workflows/regression-runner.yml`). Auto-dispatches `validation/scripts/regression_runner.py` against `camaraproject/ReleaseTest` on every push to `validation-framework` that touches `validation/**` or `shared-actions/**`, plus `workflow_dispatch` for manual runs. Cross-repo access via a short-lived `camara-validation` GitHub App token scoped to `camaraproject/ReleaseTest`. Summary published to the step summary and uploaded as an artifact (30-day retention). Turns the canary from manual into automatic.

Verified locally before push: runner reports `PASS: 2/2 branches` (baseline + broken-spec); 832/832 validation unit tests pass.

#### Which issue(s) this PR fixes:

Tracks camaraproject/ReleaseManagement#483.

#### Special notes for reviewers:

- The workflow cannot be dispatched from a fork for testing: org secrets (`VALIDATION_APP_PRIVATE_KEY`) are not passed to workflows in repos outside the `camaraproject` org. First real exercise is the post-merge push to `validation-framework`.
- A follow-up PR to `main` will be needed to register the `workflow_dispatch` trigger surface in the Actions UI; pushes to `validation-framework` work without it.
- The `camara-validation` GitHub App's existing `actions: write` / `actions: read` permissions on `ReleaseTest` are sufficient; no app permission changes required.

#### Changelog input

```
 release-note
First broken-spec regression branch (api-metadata) pins nine rules; scheduled regression runner workflow auto-dispatches the canary on every push to validation-framework.
```

#### Additional documentation

```
docs
validation/docs/regression-testing.md — new "broken-spec branch plan" section + "automatic runs on validation-framework" subsection
```