### PR TITLE
Add Regression Runner workflow stub on main

### DIFF
--- a/.github/workflows/regression-runner.yml
+++ b/.github/workflows/regression-runner.yml
@@ -1,0 +1,36 @@
+# CAMARA Validation Framework — Regression Runner (stub on main)
+#
+# This file exists on `main` only so the Regression Runner workflow
+# appears in the Actions UI and `workflow_dispatch` is wired up. The
+# functional workflow lives on the `validation-framework` branch. This
+# stub fails fast with a clear error if dispatched against `main`, so
+# accidental dispatches are visibly wrong instead of silently routed.
+#
+# To run the real regression canary, dispatch this workflow with
+# "Use workflow from: validation-framework" in the UI, or:
+#
+#   gh workflow run regression-runner.yml \
+#     --repo camaraproject/tooling --ref validation-framework
+#
+# When `validation-framework` merges into `main` at v1 GA, delete this
+# stub — the functional file will already be on `main`.
+
+name: Regression Runner
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stub:
+    name: Stub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse dispatch from main
+        run: |
+          echo "::error::This is the stub copy of the Regression Runner workflow on 'main'."
+          echo "::error::The functional workflow lives on the 'validation-framework' branch."
+          echo "::error::Re-dispatch with \"Use workflow from: validation-framework\" in the Actions UI, or pass --ref validation-framework to 'gh workflow run'."
+          exit 1


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Companion to camaraproject/tooling#172. Adds `.github/workflows/regression-runner.yml` as a dispatch-only stub on `main` so the Regression Runner workflow appears in the Actions UI — `workflow_dispatch` requires the file to exist on the default branch. The functional workflow lives on `validation-framework` (#172).

The stub has `workflow_dispatch` only and fails fast if dispatched against `main`, directing the user to re-dispatch with `--ref validation-framework`. Will be replaced by the real file when `validation-framework` merges into `main` at v1 GA.

#### Which issue(s) this PR fixes:

Tracks camaraproject/ReleaseManagement#483.

#### Special notes for reviewers:

No cross-repo auth, no secrets, no permission changes.

#### Changelog input

```
 release-note
Register Regression Runner workflow_dispatch surface on main (stub; functional workflow on validation-framework).
```

#### Additional documentation

```
docs

```