### PR TITLE
Fix T1b feature-line regex and add Scope Issue template stub

### DIFF
--- a/release_automation/config/transformations.yaml
+++ b/release_automation/config/transformations.yaml
@@ -49,14 +49,16 @@ transformations:
     replacement: "/{url_version}"
 
   # T1b: Test definition API version in Feature line
-  # Replaces "vwip" with "v{api_version}" (e.g., "v1.1.0") in Feature declarations
-  # Handles variations: "CAMARA/Camara", "Operation/Operation:", comments before Feature
+  # Replaces "vwip" with "v{api_version}" (e.g., "v1.1.0") in Feature declarations.
+  # Matches both the comma-separated form ("Feature: <name>, vwip - …") and the
+  # space-only form ("Feature: <name> vwip - …"); the space before "vwip" is the
+  # single common anchor across CAMARA test-file conventions.
   - name: test_def_api_version
-    description: Replace vwip in test definition Feature line
+    description: Replace vwip in test definition Feature line (comma- or space-separated)
     type: regex
     file_pattern: "code/Test_definitions/*.feature"
-    pattern: "(Feature: [^,]+, )vwip"
-    replacement: "\\g<1>v{api_version}"
+    pattern: "(Feature: .*?) vwip\\b"
+    replacement: "\\g<1> v{api_version}"
 
   # T3: Commonalities reference in x-camara-commonalities
   - name: commonalities_ref

--- a/release_automation/templates/issue_bodies/release_issue.mustache
+++ b/release_automation/templates/issue_bodies/release_issue.mustache
@@ -1,9 +1,7 @@
 <!-- release-automation:workflow-owned -->
 <!-- release-automation:release-tag:{{release_tag}} -->
 
-### Release Highlights
-
-_Add release highlights here before creating snapshot._
+**Scope Issue:** _Link to the Scope Issue tracking your target release — fill in after issue creation._
 
 ### Preparing the release content
 

--- a/release_automation/tests/test_issue_manager.py
+++ b/release_automation/tests/test_issue_manager.py
@@ -357,8 +357,10 @@ class TestIssueManagerGenerateIssueBodyTemplate:
 
         # No redundant heading
         assert "## Release:" not in body
-        # Heading levels should be ###
-        assert "### Release Highlights" in body
+        # Scope Issue stub sits above the automation-managed markers
+        assert "**Scope Issue:**" in body
+        # Remaining section headings should stay at ###
+        assert "### Preparing the release content" in body
         assert "### Release Status" in body
 
 

--- a/release_automation/tests/test_mechanical_transformer.py
+++ b/release_automation/tests/test_mechanical_transformer.py
@@ -355,6 +355,88 @@ class TestRegexTransformation:
             os.unlink(temp_path)
 
 
+class TestFeatureLineReplacement:
+    """T1b: regression coverage for `test_def_api_version` across Feature-line shapes.
+
+    CAMARA test files use two conventions in the wild:
+    - `Feature: <name>, vwip - <op>` (comma-separated, majority)
+    - `Feature: <name> vwip - <op>` (space-only)
+
+    The earlier regex `(Feature: [^,]+, )vwip` silently missed the second form
+    and shipped unreplaced placeholders in snapshot branches (observed on
+    NetworkInsights r1.1). The new pattern `(Feature: .*?) vwip\\b` anchors on
+    the single space before `vwip` which is common to both forms.
+    """
+
+    T1B_RULE = TransformationRule(
+        name="test_def_api_version",
+        description="Replace vwip in test definition Feature line",
+        type=TransformationType.REGEX,
+        file_pattern="code/Test_definitions/*.feature",
+        pattern=r"(Feature: .*?) vwip\b",
+        replacement=r"\g<1> v{api_version}",
+    )
+
+    def _run(self, transformer, context, content):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_path = os.path.join(tmpdir, "quality-on-demand-createSession.feature")
+            with open(feature_path, "w") as f:
+                f.write(content)
+
+            result = transformer._apply_regex(feature_path, self.T1B_RULE, context)
+
+            with open(feature_path, "r") as f:
+                transformed = f.read()
+
+            return result, transformed, feature_path
+
+    def test_comma_separated_form(self, transformer, context):
+        """Majority form: `Feature: <name>, vwip - <op>`."""
+        result, content, feature_path = self._run(
+            transformer,
+            context,
+            "Feature: CAMARA Quality On Demand, vwip - Operation createSession\n",
+        )
+        assert result.success
+        assert feature_path in result.files_modified
+        assert content == (
+            "Feature: CAMARA Quality On Demand, v3.2.0-rc.2 - Operation createSession\n"
+        )
+
+    def test_space_only_form(self, transformer, context):
+        """Blocking bug: `Feature: <name> vwip - <op>` (no comma).
+
+        Observed on NetworkInsights r1.1: both .feature files used this form
+        and the earlier regex silently left `vwip` in place.
+        """
+        result, content, feature_path = self._run(
+            transformer,
+            context,
+            "Feature: CAMARA Quality On Demand vwip - Operation createSession\n",
+        )
+        assert result.success
+        assert feature_path in result.files_modified
+        assert content == (
+            "Feature: CAMARA Quality On Demand v3.2.0-rc.2 - Operation createSession\n"
+        )
+
+    def test_already_versioned_unchanged(self, transformer, context):
+        """A Feature line that already carries a real version must not match."""
+        original = "Feature: CAMARA Quality On Demand, v0.3.0 - Operation createSession\n"
+        result, content, feature_path = self._run(transformer, context, original)
+        assert result.success
+        assert feature_path not in result.files_modified
+        assert content == original
+
+    def test_no_vwip_unchanged(self, transformer, context):
+        """A Feature line with no `vwip` anywhere is a no-op."""
+        original = "Feature: CAMARA Quality On Demand - Operation createSession\n"
+        result, content, feature_path = self._run(transformer, context, original)
+        assert result.success
+        assert feature_path not in result.files_modified
+        assert content == original
+
+
 class TestYamlPathTransformation:
     """Tests for YAML path transformations."""
 


### PR DESCRIPTION
#### What type of PR is this?

bug + enhancement — T1b bug fix bundled with a small Release Issue template tweak

#### What this PR does / why we need it:

Two small, independent release-automation fixes that share a subsystem.

**T1b `test_def_api_version` regex fix (bug).** The current pattern
`(Feature: [^,]+, )vwip` in `release_automation/config/transformations.yaml`
requires the comma-separated form `Feature: <name>, vwip - …`. Test files
that use the space-only form `Feature: <name> vwip - …` silently miss the
replacement and ship unreplaced `vwip` placeholders in transformed snapshots.
Observed on NetworkInsights r1.1 (both `.feature` files affected). A survey
across current CAMARA API repositories confirms the space-only form is not
a one-off: ~13 repos use it. The new pattern `(Feature: .*?) vwip\b` anchors
on the single space shared by both conventions and leaves already-versioned
files (`Feature: X, v0.3.0 - op`) untouched.

**Release Issue template — Scope Issue stub (enhancement).** Per
[ReleaseManagement#409](https://github.com/camaraproject/ReleaseManagement/issues/409),
the Wiki release tracker has been dropped and the Scope Issue link needs a
new home. Adds a free-form `**Scope Issue:**` stub at the top of the
editable section in `release_issue.mustache`; maintainers fill in the URL
after issue creation. The Release Highlights block is removed in favour of
this targeted stub. No `release-plan.yaml` schema change, no new template
context variable.

#### Which issue(s) this PR fixes:

Refs camaraproject/ReleaseManagement#409 (Scope Issue link home)

#### Special notes for reviewers:

- Four new `TestFeatureLineReplacement` cases in `release_automation/tests/test_mechanical_transformer.py` cover: comma form, space form, already-versioned no-op, no-vwip no-op.
- `test_issue_manager.py::test_generate_template_without_meta_release` updated: the `### Release Highlights` assertion is replaced by a `**Scope Issue:**` / `### Preparing the release content` pair.
- 561/561 `release_automation/tests/` green locally.
- Audited as part of this change: the "bold the positive next action" convention is already applied consistently across `issue_manager.py` `generate_actions_section()` and every `bot_messages/*.md` template. `config_drift_warning.md` deliberately presents both options without bold because neither is clearly more positive mid-drift. No bolding code touched.

#### Changelog input

```
release-note
Fix T1b transformation to match space-only "Feature: <name> vwip" lines
in test files, and add a Scope Issue link stub to the Release Issue
template.
```

#### Additional documentation 

This section can be blank.

```
docs

```