### PR TITLE
Add post-filter suppress_schema_paths and apply to S-313 common-library hints

### DIFF
--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -180,6 +180,11 @@ def normalize_finding(raw: dict, repo_root: Optional[str] = None) -> dict:
     Critical field mapping:
     - ``raw["source"]`` -> ``finding["path"]`` (file path, NOT ``raw["path"]``
       which is the JSONPath within the document).
+    - ``raw["path"]`` (JSONPath array) -> ``finding["schema_path"]``
+      (dot-joined string).  Spectral emits this as the canonical path
+      within the source file, already source-mapped for $ref-followed
+      findings.  Consumed by the post-filter ``suppress_schema_paths``
+      mechanism.
     - ``raw["range"]["start"]["line"]`` is 0-indexed; add 1 for the framework.
     - ``raw["range"]["start"]["character"]`` is 0-indexed; add 1.
 
@@ -207,12 +212,20 @@ def normalize_finding(raw: dict, repo_root: Optional[str] = None) -> dict:
 
     level = "hint" if from_external else map_severity(raw.get("severity", 1))
 
+    raw_schema_path = raw.get("path")
+    schema_path: Optional[str]
+    if isinstance(raw_schema_path, list) and raw_schema_path:
+        schema_path = ".".join(str(segment) for segment in raw_schema_path)
+    else:
+        schema_path = None
+
     finding: dict = {
         "engine": ENGINE_NAME,
         "engine_rule": raw.get("code", "unknown"),
         "level": level,
         "message": raw.get("message", ""),
         "path": source,
+        "schema_path": schema_path,
         "line": line,
         "api_name": derive_api_name(source),
     }

--- a/validation/postfilter/engine.py
+++ b/validation/postfilter/engine.py
@@ -60,6 +60,27 @@ def _is_engine_error_finding(finding: dict) -> bool:
     return finding.get("engine_rule", "").endswith("-execution-error")
 
 
+def _is_suppressed_by_schema_path(finding: dict, rule: RuleMetadata) -> bool:
+    """Return ``True`` when a finding's ``schema_path`` matches an entry in
+    ``rule.suppress_schema_paths``.
+
+    A match is an exact path equality OR a prefix with a dot boundary, so
+    ``components.schemas.ErrorInfo`` does NOT false-match a sibling like
+    ``components.schemas.ErrorInfoExtended``.  Findings without a
+    ``schema_path`` field (e.g. from yamllint or gherkin) can never be
+    suppressed by this mechanism and fall through unchanged.
+    """
+    if not rule.suppress_schema_paths:
+        return False
+    schema_path = finding.get("schema_path")
+    if not isinstance(schema_path, str) or not schema_path:
+        return False
+    for entry in rule.suppress_schema_paths:
+        if schema_path == entry or schema_path.startswith(entry + "."):
+            return True
+    return False
+
+
 def _resolve_api_context(
     finding: dict,
     context: ValidationContext,
@@ -232,6 +253,11 @@ def run_post_filter(
         if rule is not None:
             # Step 3: Mapped rule
             api_ctx = _resolve_api_context(finding, context)
+
+            # Per-path suppression — drop findings on known-unactionable
+            # locations before any further processing.
+            if _is_suppressed_by_schema_path(finding, rule):
+                continue
 
             # Applicability check — remove if not applicable
             if not is_applicable(rule.applicability, context, api_ctx):

--- a/validation/postfilter/metadata_loader.py
+++ b/validation/postfilter/metadata_loader.py
@@ -76,6 +76,10 @@ class RuleMetadata:
         applicability: Condition dict — omitted fields are unconstrained.
         conditional_level: Severity specification, or ``None`` to preserve
             engine-reported severity (identity mapping).
+        suppress_schema_paths: Tuple of JSON paths within a source document
+            to suppress for this rule.  A finding is dropped entirely when
+            its ``schema_path`` equals an entry here or starts with an
+            entry followed by a dot.  Empty tuple means no suppression.
     """
 
     id: str
@@ -86,6 +90,7 @@ class RuleMetadata:
     hint: Optional[str]
     applicability: dict
     conditional_level: Optional[ConditionalLevel]
+    suppress_schema_paths: Tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +146,14 @@ def parse_rule_metadata(raw: dict) -> RuleMetadata:
     raw_cl = raw.get("conditional_level")
     conditional_level = _parse_conditional_level(raw_cl) if raw_cl is not None else None
 
+    # Optional suppress_schema_paths — empty tuple means no suppression
+    raw_suppress = raw.get("suppress_schema_paths") or []
+    if not isinstance(raw_suppress, list):
+        raise ValueError("suppress_schema_paths must be a list of strings")
+    suppress_schema_paths: Tuple[str, ...] = tuple(
+        entry for entry in raw_suppress if isinstance(entry, str) and entry
+    )
+
     return RuleMetadata(
         id=raw["id"],
         name=raw.get("name", raw["engine_rule"]),
@@ -150,6 +163,7 @@ def parse_rule_metadata(raw: dict) -> RuleMetadata:
         hint=raw.get("hint"),
         applicability=raw.get("applicability", {}),
         conditional_level=conditional_level,
+        suppress_schema_paths=suppress_schema_paths,
     )
 
 

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -348,6 +348,27 @@
   hint: "Acceptable if free-form field or implementation-dependent — no fix needed."
   conditional_level:
     default: hint
+  # Known-unactionable locations in the Commonalities common library.
+  # These string fields are already length-constrained via maxLength (S-312
+  # is satisfied); no sensible format/pattern/enum/const value exists for
+  # the free-text and identifier fields below.  The rule's own hint already
+  # flags this as "Acceptable ... no fix needed" — the allowlist removes
+  # the repeated noise. Entries are specific fields, not whole components,
+  # so any new unconstrained string added to a common schema still surfaces
+  # and can be evaluated on its own merits.
+  suppress_schema_paths:
+    # CAMARA_common.yaml
+    - components.schemas.ErrorInfo.properties.code
+    - components.schemas.ErrorInfo.properties.message
+    - components.schemas.NetworkAccessIdentifier
+    # CAMARA_event_common.yaml
+    - components.schemas.CloudEvent.properties.id
+    - components.schemas.CloudEvent.properties.type
+    - components.schemas.SubscriptionId
+    - components.schemas.HTTPSettings.properties.headers.additionalProperties
+    - components.schemas.SubscriptionStarted.properties.initiationDescription
+    - components.schemas.SubscriptionUpdated.properties.updateDescription
+    - components.schemas.SubscriptionEnded.properties.terminationDescription
 
 - id: S-314
   engine: spectral

--- a/validation/schemas/findings-schema.yaml
+++ b/validation/schemas/findings-schema.yaml
@@ -56,6 +56,15 @@ properties:
       File path relative to the repository root
       (e.g. "code/API_definitions/quality-on-demand.yaml").
 
+  schema_path:
+    type: ["string", "null"]
+    description: >
+      Dot-joined JSONPath of the offending node within the source document,
+      when the engine provides it (e.g.
+      "components.schemas.ErrorInfo.properties.code").  Optional — absent
+      for engines that only report file+line locations (yamllint, gherkin).
+      Used by post-filter suppress_schema_paths to drop specific findings.
+
   line:
     type: integer
     minimum: 1

--- a/validation/schemas/rule-metadata-schema.yaml
+++ b/validation/schemas/rule-metadata-schema.yaml
@@ -110,6 +110,23 @@ properties:
 
     additionalProperties: false
 
+  suppress_schema_paths:
+    type: array
+    description: >
+      Post-filter allowlist of JSON paths within a source document to
+      suppress for this rule.  A finding is dropped entirely when its
+      ``schema_path`` field equals an entry here or starts with the entry
+      followed by a dot (prefix-with-boundary match).  Intended for rules
+      that fire on known-unactionable locations — e.g. free-text fields in
+      Commonalities common schemas where no sensible ``pattern``/``format``
+      exists.  Entries should be specific field paths, not whole
+      components, so that any new unconstrained field surfaces instead of
+      being silently masked.  Optional — omit for rules that do not need
+      per-path suppression.
+    items:
+      type: string
+      minLength: 1
+
   conditional_level:
     type: object
     description: >

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -11,10 +11,12 @@ from validation.context import ApiContext, ValidationContext
 from validation.postfilter.engine import (
     PostFilterResult,
     _is_engine_error_finding,
+    _is_suppressed_by_schema_path,
     _resolve_api_context,
     compute_overall_result,
     run_post_filter,
 )
+from validation.postfilter.metadata_loader import RuleMetadata
 
 
 # ---------------------------------------------------------------------------
@@ -573,3 +575,174 @@ class TestRunPostFilter:
         f = result.findings[0]
         assert f["message"] == "Better description."
         assert f["hint"] == "Fix by doing X."
+
+
+# ---------------------------------------------------------------------------
+# TestSuppressSchemaPaths — per-path suppression (unit + integration)
+# ---------------------------------------------------------------------------
+
+
+def _rule_with_suppress(
+    *paths: str,
+    id: str = "S-313",
+    engine: str = "spectral",
+    engine_rule: str = "owasp:api4:2023-string-restricted",
+) -> RuleMetadata:
+    """Build a minimal RuleMetadata with suppress_schema_paths set."""
+    return RuleMetadata(
+        id=id,
+        name=engine_rule,
+        engine=engine,
+        engine_rule=engine_rule,
+        message_override=None,
+        hint=None,
+        applicability={},
+        conditional_level=None,
+        suppress_schema_paths=tuple(paths),
+    )
+
+
+class TestIsSuppressedBySchemaPath:
+    """Unit tests for the schema-path allowlist matcher."""
+
+    def test_no_allowlist_never_suppresses(self):
+        """A rule without suppress_schema_paths never suppresses anything."""
+        rule = _rule_with_suppress()  # empty allowlist
+        f = _make_finding()
+        f["schema_path"] = "components.schemas.ErrorInfo.properties.code"
+        assert _is_suppressed_by_schema_path(f, rule) is False
+
+    def test_exact_match_suppresses(self):
+        rule = _rule_with_suppress("components.schemas.ErrorInfo.properties.code")
+        f = _make_finding()
+        f["schema_path"] = "components.schemas.ErrorInfo.properties.code"
+        assert _is_suppressed_by_schema_path(f, rule) is True
+
+    def test_prefix_with_dot_boundary_suppresses(self):
+        """Subtree match: an entry for a container path also suppresses its descendants."""
+        rule = _rule_with_suppress("components.schemas.ErrorInfo")
+        f = _make_finding()
+        f["schema_path"] = "components.schemas.ErrorInfo.properties.code"
+        assert _is_suppressed_by_schema_path(f, rule) is True
+
+    def test_lookalike_prefix_does_not_suppress(self):
+        """`ErrorInfo` entry must NOT false-match `ErrorInfoExtended`."""
+        rule = _rule_with_suppress("components.schemas.ErrorInfo")
+        f = _make_finding()
+        f["schema_path"] = "components.schemas.ErrorInfoExtended.properties.code"
+        assert _is_suppressed_by_schema_path(f, rule) is False
+
+    def test_unrelated_path_does_not_suppress(self):
+        rule = _rule_with_suppress("components.schemas.ErrorInfo.properties.code")
+        f = _make_finding()
+        f["schema_path"] = "components.schemas.MySchema.properties.name"
+        assert _is_suppressed_by_schema_path(f, rule) is False
+
+    def test_missing_schema_path_falls_through(self):
+        """Findings without schema_path (e.g. yamllint) can never be suppressed."""
+        rule = _rule_with_suppress("components.schemas.ErrorInfo.properties.code")
+        f = _make_finding()  # no schema_path
+        assert _is_suppressed_by_schema_path(f, rule) is False
+
+    def test_empty_schema_path_falls_through(self):
+        rule = _rule_with_suppress("components.schemas.ErrorInfo.properties.code")
+        f = _make_finding()
+        f["schema_path"] = ""
+        assert _is_suppressed_by_schema_path(f, rule) is False
+
+    def test_first_matching_entry_wins(self):
+        """Multiple entries — only one needs to match."""
+        rule = _rule_with_suppress(
+            "components.schemas.Foo",
+            "components.schemas.ErrorInfo.properties.code",
+            "components.schemas.Bar",
+        )
+        f = _make_finding()
+        f["schema_path"] = "components.schemas.ErrorInfo.properties.code"
+        assert _is_suppressed_by_schema_path(f, rule) is True
+
+
+class TestRunPostFilterSuppression:
+    """Integration: suppressed findings are dropped entirely from the pipeline."""
+
+    def test_suppressed_finding_dropped(self, tmp_path: Path):
+        """A matching schema_path causes the finding to be dropped, not just downgraded."""
+        _write_rules(tmp_path, [{
+            "id": "S-313",
+            "engine": "spectral",
+            "engine_rule": "owasp:api4:2023-string-restricted",
+            "conditional_level": {"default": "hint"},
+            "suppress_schema_paths": [
+                "components.schemas.ErrorInfo.properties.code",
+                "components.schemas.ErrorInfo.properties.message",
+            ],
+        }])
+        ctx = _make_context()
+        finding = _make_finding(
+            engine_rule="owasp:api4:2023-string-restricted",
+            path="code/common/CAMARA_common.yaml",
+            level="hint",
+        )
+        finding["schema_path"] = "components.schemas.ErrorInfo.properties.code"
+        result = run_post_filter([finding], ctx, tmp_path)
+        assert result.findings == []
+        assert result.result == "pass"
+
+    def test_non_suppressed_finding_kept(self, tmp_path: Path):
+        """A non-matching schema_path passes through normally."""
+        _write_rules(tmp_path, [{
+            "id": "S-313",
+            "engine": "spectral",
+            "engine_rule": "owasp:api4:2023-string-restricted",
+            "conditional_level": {"default": "hint"},
+            "suppress_schema_paths": [
+                "components.schemas.ErrorInfo.properties.code",
+            ],
+        }])
+        ctx = _make_context()
+        finding = _make_finding(
+            engine_rule="owasp:api4:2023-string-restricted",
+            path="code/API_definitions/sample-service.yaml",
+            level="hint",
+        )
+        finding["schema_path"] = "components.schemas.MyApiSchema.properties.name"
+        result = run_post_filter([finding], ctx, tmp_path)
+        assert len(result.findings) == 1
+        assert result.findings[0]["rule_id"] == "S-313"
+
+    def test_mixed_findings(self, tmp_path: Path):
+        """A batch of findings — suppressed entries drop, others pass through."""
+        _write_rules(tmp_path, [{
+            "id": "S-313",
+            "engine": "spectral",
+            "engine_rule": "owasp:api4:2023-string-restricted",
+            "conditional_level": {"default": "hint"},
+            "suppress_schema_paths": [
+                "components.schemas.ErrorInfo.properties.code",
+                "components.schemas.ErrorInfo.properties.message",
+                "components.schemas.NetworkAccessIdentifier",
+            ],
+        }])
+        ctx = _make_context()
+        findings = []
+        for schema_path in (
+            "components.schemas.ErrorInfo.properties.code",
+            "components.schemas.ErrorInfo.properties.message",
+            "components.schemas.NetworkAccessIdentifier",
+            "components.schemas.MyApiSchema.properties.name",
+            "components.schemas.MyOtherSchema.properties.id",
+        ):
+            f = _make_finding(
+                engine_rule="owasp:api4:2023-string-restricted",
+                level="hint",
+            )
+            f["schema_path"] = schema_path
+            findings.append(f)
+
+        result = run_post_filter(findings, ctx, tmp_path)
+        # 3 common-library entries suppressed, 2 API-specific kept
+        kept_paths = [f["schema_path"] for f in result.findings]
+        assert kept_paths == [
+            "components.schemas.MyApiSchema.properties.name",
+            "components.schemas.MyOtherSchema.properties.id",
+        ]

--- a/validation/tests/test_postfilter_metadata.py
+++ b/validation/tests/test_postfilter_metadata.py
@@ -98,6 +98,47 @@ class TestParseRuleMetadata:
         rule = parse_rule_metadata(raw)
         assert rule.message_override is None
         assert rule.hint is None
+        assert rule.suppress_schema_paths == ()
+
+    def test_suppress_schema_paths_parsed(self):
+        """suppress_schema_paths is an optional list that becomes a tuple."""
+        raw = _minimal_rule_dict(
+            suppress_schema_paths=[
+                "components.schemas.ErrorInfo.properties.code",
+                "components.schemas.NetworkAccessIdentifier",
+            ]
+        )
+        rule = parse_rule_metadata(raw)
+        assert rule.suppress_schema_paths == (
+            "components.schemas.ErrorInfo.properties.code",
+            "components.schemas.NetworkAccessIdentifier",
+        )
+
+    def test_suppress_schema_paths_empty_list(self):
+        raw = _minimal_rule_dict(suppress_schema_paths=[])
+        rule = parse_rule_metadata(raw)
+        assert rule.suppress_schema_paths == ()
+
+    def test_suppress_schema_paths_invalid_type_raises(self):
+        raw = _minimal_rule_dict(suppress_schema_paths="not-a-list")
+        with pytest.raises(ValueError, match="suppress_schema_paths"):
+            parse_rule_metadata(raw)
+
+    def test_suppress_schema_paths_drops_non_string_entries(self):
+        """Non-string entries are silently dropped (defensive)."""
+        raw = _minimal_rule_dict(
+            suppress_schema_paths=[
+                "components.schemas.Valid",
+                123,  # not a string
+                "",   # empty
+                "components.schemas.AlsoValid",
+            ]
+        )
+        rule = parse_rule_metadata(raw)
+        assert rule.suppress_schema_paths == (
+            "components.schemas.Valid",
+            "components.schemas.AlsoValid",
+        )
 
     def test_explicit_message_override(self):
         raw = _minimal_rule_dict(message_override="Better message.")

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -248,6 +248,38 @@ class TestNormalizeFinding:
         assert "rule_id" not in finding
         assert "hint" not in finding
 
+    def test_schema_path_dot_joined(self):
+        """Spectral's JSONPath array is dot-joined into finding['schema_path']."""
+        finding = normalize_finding(SAMPLE_SPECTRAL_FINDING)
+        # raw path is ["paths", "/qualityOnDemand", "post"]
+        assert finding["schema_path"] == "paths./qualityOnDemand.post"
+
+    def test_schema_path_mixed_string_and_int_segments(self):
+        """JSONPath segments can include array indices — cast to str."""
+        raw = {
+            **SAMPLE_SPECTRAL_FINDING,
+            "path": ["components", "schemas", "Foo", "allOf", 0, "properties", "bar"],
+        }
+        finding = normalize_finding(raw)
+        assert finding["schema_path"] == "components.schemas.Foo.allOf.0.properties.bar"
+
+    def test_schema_path_none_when_empty(self):
+        """An empty JSONPath list yields schema_path=None."""
+        raw = {**SAMPLE_SPECTRAL_FINDING, "path": []}
+        finding = normalize_finding(raw)
+        assert finding["schema_path"] is None
+
+    def test_schema_path_none_when_missing(self):
+        raw = {
+            "code": "some-rule",
+            "message": "msg",
+            "severity": 1,
+            "source": "code/API_definitions/api.yaml",
+            "range": {"start": {"line": 0, "character": 0}},
+        }
+        finding = normalize_finding(raw)
+        assert finding["schema_path"] is None
+
     def test_absolute_path_normalised_with_repo_root(self):
         raw = {
             **SAMPLE_SPECTRAL_FINDING,


### PR DESCRIPTION
#### What type of PR is this?

enhancement

#### What this PR does / why we need it:

Adds a new reusable post-filter hook `suppress_schema_paths` on rule metadata and wires it up for S-313. Any rule that accumulates known-unactionable hints can opt in by listing specific JSON paths; matching findings are dropped before applicability/severity processing. The Spectral ruleset is not modified — `owasp:api4:2023-string-restricted` stays enabled at `warn` severity, Spectral continues to produce the full finding set, and the post-filter is the only thing that hides the known-unactionable entries. This keeps `resolved: true` behaviour intact, so string fields in API-local modules under `code/modules/` reachable only via `$ref` continue to be checked.

**Changes:**

- `validation/schemas/findings-schema.yaml` — new optional field `schema_path` (dot-joined JSONPath of the offending node within the source document).
- `validation/engines/spectral_adapter.py` — `normalize_finding` extracts Spectral's `raw["path"]` (JSONPath array), dot-joins it, and stores it as `finding["schema_path"]`. Spectral's internal source mapping already reports canonical paths within the source file (e.g. `components.schemas.ErrorInfo.properties.code` on a finding attributed to `code/common/CAMARA_common.yaml`), so no further normalisation is needed.
- `validation/schemas/rule-metadata-schema.yaml` — new optional field `suppress_schema_paths` (list of strings).
- `validation/postfilter/metadata_loader.py` — `RuleMetadata` dataclass gains `suppress_schema_paths: Tuple[str, ...]` (defaults to empty). Parser reads the new field and defensively drops non-string entries.
- `validation/postfilter/engine.py` — new helper `_is_suppressed_by_schema_path(finding, rule)` with exact-or-prefix-with-dot-boundary semantics. Called from `run_post_filter` immediately after metadata lookup; matching findings are dropped entirely so they never reach applicability evaluation, severity resolution, or the output.
- `validation/rules/spectral-rules.yaml` — S-313 gets `suppress_schema_paths` populated with the ten field paths currently firing on `CAMARA_common.yaml` and `CAMARA_event_common.yaml`. Rule ID, engine binding, default severity, and hint are unchanged.

**Why entries are specific fields, not whole components:**

The allowlist names exact field paths so any new unconstrained string added to a common schema still surfaces as a hint. A codeowner or Commonalities maintainer can then decide whether the new field is also intentionally unconstrained (and should join the allowlist) or whether it should actually be constrained upstream in Commonalities.

**Match semantics:**

Exact equality (`components.schemas.ErrorInfo.properties.code`) OR prefix with dot boundary. The boundary check prevents look-alike neighbours like `components.schemas.ErrorInfoExtended.properties.code` from being false-matched by an `ErrorInfo` entry.

#### Which issue(s) this PR fixes:

Fixes camaraproject/tooling#175

#### Special notes for reviewers:

- 19 new tests across three files (+346 lines, test coverage only — no existing tests were touched):
  - `test_spectral_adapter.py` — 4 tests for `schema_path` extraction (dot-joined string, mixed string/int segments, missing path → None, empty path → None)
  - `test_postfilter_metadata.py` — 4 tests for `suppress_schema_paths` parsing (list → tuple, empty list, invalid type raises, non-string entries dropped)
  - `test_postfilter_engine.py` — 9 unit tests for `_is_suppressed_by_schema_path` (exact match, prefix-with-boundary, look-alike does NOT match, missing/empty schema_path falls through, first-match-wins) + 3 integration tests via `run_post_filter` (suppressed dropped, non-suppressed kept, mixed batch)
- 851/851 `validation/tests/` pass locally.
- End-to-end smoke-tested against the current `camaraproject/ReleaseTest@regression/r4.1-main-baseline`: 14 S-313 raw findings → 10 common-library entries suppressed → 4 API-specific entries kept. The four kept correspond to `components.schemas.{CreateResource,Resource}.properties.name` in `sample-service.yaml` and `sample-implicit-events.yaml`.
- **After merge**: regression fixtures on `camaraproject/ReleaseTest` need a recapture before the next canary run will go green. Expected deltas: `regression/r4.1-main-baseline` hints 27 → 17, `regression/r4.1-broken-spec-api-metadata` hints 30 → 20 (errors and warnings unchanged at 2 and 4). Fixture branches on ReleaseTest are updated via `validation/scripts/regression_runner.py --capture <branch>` dispatched against the new `validation-framework` HEAD.

#### Changelog input

```
release-note
Post-filter gains `suppress_schema_paths`, a reusable per-rule JSON-path allowlist. S-313 uses it to silence ten known-unactionable hints on Commonalities common-library fields.
```

#### Additional documentation 

This section can be blank.

```
docs

```