### PR TITLE
Pin 15 rules via regression/r4.1-broken-spec-yaml-fundamentals

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 14
+  total_tested: 29
   by_engine:
     spectral: 84
     gherkin: 25
@@ -294,6 +294,8 @@ pending_rules:
 
 tested_rules:
   P-006: [regression/r4.1-main-baseline]
+  S-005: [regression/r4.1-broken-spec-yaml-fundamentals]
+  S-016: [regression/r4.1-broken-spec-yaml-fundamentals]
   S-018: [regression/r4.1-broken-spec-api-metadata]
   S-019: [regression/r4.1-broken-spec-api-metadata]
   S-020: [regression/r4.1-broken-spec-api-metadata]
@@ -307,6 +309,19 @@ tested_rules:
   S-313: [regression/r4.1-main-baseline]
   S-314: [regression/r4.1-main-baseline]
   S-316: [regression/r4.1-main-baseline]
+  Y-001: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-002: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-003: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-004: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-005: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-006: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-007: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-008: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-009: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-010: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-011: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-012: [regression/r4.1-broken-spec-yaml-fundamentals]
+  Y-013: [regression/r4.1-broken-spec-yaml-fundamentals]
 
 # ---------------------------------------------------------------------------
 # Manual rules — require human judgment


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Add Y-001..Y-013, S-005, S-016 to `tested_rules` in `rule-inventory.yaml` and update `total_tested` from 14 to 29.

Branch 2 of the 7-branch broken-spec regression roadmap. The corresponding broken-spec branch on `camaraproject/ReleaseTest` introduces 15 surgical YAML-level edits to `sample-service.yaml` targeting yamllint formatting rules (Y-001..Y-013), OpenAPI version (S-005), and schema type declaration (S-016).

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/camaraproject/ReleaseManagement/issues/483

#### Special notes for reviewers:

The broken-spec branch `regression/r4.1-broken-spec-yaml-fundamentals` on `camaraproject/ReleaseTest` is already pushed. Fixture capture pending first validation workflow run.

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

```
docs
 NONE
```