### PR TITLE
fix: move Scope Issue into release checklist as checkbox

### DIFF
--- a/release_automation/templates/issue_bodies/release_issue.mustache
+++ b/release_automation/templates/issue_bodies/release_issue.mustache
@@ -1,12 +1,11 @@
 <!-- release-automation:workflow-owned -->
 <!-- release-automation:release-tag:{{release_tag}} -->
 
-**Scope Issue:** _Link to the Scope Issue tracking your target release — fill in after issue creation._
-
 ### Preparing the release content
 
 Before issuing `/create-snapshot`, verify on `main`:
 
+- [ ] Scope Issue: _edit the issue description and link to the Scope Issue for the target release here_
 - [ ] `release-plan.yaml` content matches intent (check API names, versions, statuses, release type)
 - [ ] Commonalities and ICM dependency versions are current
 - [ ] CI checks are green (Spectral linting, PR validation)

--- a/release_automation/tests/test_issue_manager.py
+++ b/release_automation/tests/test_issue_manager.py
@@ -357,8 +357,8 @@ class TestIssueManagerGenerateIssueBodyTemplate:
 
         # No redundant heading
         assert "## Release:" not in body
-        # Scope Issue stub sits above the automation-managed markers
-        assert "**Scope Issue:**" in body
+        # Scope Issue is a checkbox item in the checklist
+        assert "- [ ] Scope Issue:" in body
         # Remaining section headings should stay at ###
         assert "### Preparing the release content" in body
         assert "### Release Status" in body


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Moves the Scope Issue link from a free-form bold line above the checklist into the checklist itself as the first checkbox item, so it cannot be overlooked.

Suggested by @tanjadegroot in https://github.com/camaraproject/ReleaseTest/issues/80#issuecomment-4259353952.

#### Which issue(s) this PR fixes:

Related: https://github.com/camaraproject/ReleaseManagement/issues/409

#### Special notes for reviewers:

None

#### Changelog input

```
 release-note
Move Scope Issue link into release checklist as checkbox item
```

#### Additional documentation

```
docs
N/A
```