### PR TITLE
Pin 6 rules via regression/r4.1-broken-spec-error-handling

### DIFF
--- a/validation/output/formatting.py
+++ b/validation/output/formatting.py
@@ -6,7 +6,7 @@ commit status, diagnostics).
 
 Design doc references:
   - Section 9.2: finding grouping and priority ordering
-  - Section 9.3: per-API summary table
+  - Section 9.3: engine summary table
 """
 
 from __future__ import annotations

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -1,7 +1,7 @@
 """Workflow summary generation for ``$GITHUB_STEP_SUMMARY``.
 
-Produces a Markdown string with header, per-API summary table, findings
-tables grouped by severity level, engine status table, and footer.
+Produces a Markdown string with header, engine summary table, findings
+tables grouped by severity level, and footer.
 Implements 900 KB truncation with priority ordering (errors are never
 truncated).
 

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 29
+  total_tested: 35
   by_engine:
     spectral: 84
     gherkin: 25
@@ -303,12 +303,18 @@ tested_rules:
   S-022: [regression/r4.1-broken-spec-api-metadata]
   S-023: [regression/r4.1-broken-spec-api-metadata]
   S-024: [regression/r4.1-broken-spec-api-metadata]
+  S-025: [regression/r4.1-broken-spec-error-handling]
+  S-026: [regression/r4.1-broken-spec-error-handling]
+  S-027: [regression/r4.1-broken-spec-error-handling]
   S-201: [regression/r4.1-broken-spec-api-metadata]
   S-210: [regression/r4.1-broken-spec-api-metadata]
   S-211: [regression/r4.1-main-baseline]
+  S-221: [regression/r4.1-broken-spec-error-handling]
+  S-307: [regression/r4.1-broken-spec-error-handling]
   S-313: [regression/r4.1-main-baseline]
   S-314: [regression/r4.1-main-baseline]
   S-316: [regression/r4.1-main-baseline]
+  S-318: [regression/r4.1-broken-spec-error-handling]
   Y-001: [regression/r4.1-broken-spec-yaml-fundamentals]
   Y-002: [regression/r4.1-broken-spec-yaml-fundamentals]
   Y-003: [regression/r4.1-broken-spec-yaml-fundamentals]


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Add S-025, S-026, S-027, S-221, S-307, S-318 to `tested_rules` in
`rule-inventory.yaml` and update `total_tested` from 29 to 35.

Branch 3 of the 7-branch broken-spec regression roadmap. The
corresponding broken-spec branch on `camaraproject/ReleaseTest`
introduces 6 surgical edits to `sample-service.yaml` targeting error
code format validation, success response existence, and secured/validation
error response requirements.

Also fixes stale "per-API summary table" docstrings in
`workflow_summary.py` and `formatting.py` (implementation already
uses per-engine tables since session 31).

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/camaraproject/ReleaseManagement/issues/483

#### Special notes for reviewers:

Fixture: 35 findings (2 errors, 6 warnings, 27 hints). S-026 fires 3
times (direct edit + cascades from S-025 and S-027 edits). All baseline
findings unchanged.

#### Changelog input

 release-note
 NONE

#### Additional documentation

 docs
 NONE