### PR TITLE
fix: replace Scope Issue stub with optional scope placeholder

### DIFF
--- a/release_automation/templates/issue_bodies/release_issue.mustache
+++ b/release_automation/templates/issue_bodies/release_issue.mustache
@@ -1,7 +1,7 @@
 <!-- release-automation:workflow-owned -->
 <!-- release-automation:release-tag:{{release_tag}} -->
 
-**Scope Issue:** _Link to the Scope Issue tracking your target release — fill in after issue creation._
+_Optional: use this space to describe the (planned) content scope of this release — for example by linking a scope issue or milestone, or listing the issues/PRs to be resolved before the release._
 
 ### Preparing the release content
 

--- a/release_automation/tests/test_issue_manager.py
+++ b/release_automation/tests/test_issue_manager.py
@@ -357,8 +357,8 @@ class TestIssueManagerGenerateIssueBodyTemplate:
 
         # No redundant heading
         assert "## Release:" not in body
-        # Scope Issue stub sits above the automation-managed markers
-        assert "**Scope Issue:**" in body
+        # Optional scope placeholder sits above the automation-managed markers
+        assert "_Optional: use this space to describe" in body
         # Remaining section headings should stay at ###
         assert "### Preparing the release content" in body
         assert "### Release Status" in body


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Replaces the prescriptive "**Scope Issue:**" bold line in the Release Issue
template with a softer optional placeholder:

> _Optional: use this space to describe the (planned) content scope of this
> release — for example by linking a scope issue or milestone, or listing the
> issues/PRs to be resolved before the release._

Existing Release Issues are not affected — the placeholder sits above the
automation-managed section markers and is never rewritten.

#### Which issue(s) this PR fixes:

Fixes camaraproject/ReleaseManagement#409

#### Special notes for reviewers:

One template line changed, one test assertion updated. All 26 `test_issue_manager` tests pass.

#### Changelog input

```release-note
Release Issue template: replaced Scope Issue stub with optional scope placeholder
```

#### Additional documentation

This section can be blank.