### PR TITLE
Add P-021 check-common-cache-sync and tooling_lib shared package

### DIFF
--- a/tooling_lib/__init__.py
+++ b/tooling_lib/__init__.py
@@ -1,0 +1,9 @@
+"""Shared Python library for camaraproject/tooling.
+
+Hosts code reused across ``validation/`` (VF) and
+``release_automation/`` (RA).  Both packages import from here via
+``from tooling_lib.<module> import ...``.
+
+Modules:
+    cache_sync  -- Common-file cache sync status checking (DEC-030/031).
+"""

--- a/tooling_lib/cache_sync.py
+++ b/tooling_lib/cache_sync.py
@@ -1,0 +1,204 @@
+"""Common-file cache sync status checking.
+
+Verifies that ``code/common/`` files match the expected content declared
+in ``.sync-manifest.yaml``.  The manifest is written by the
+camara-release-automation sync-common handler and records the source
+repository, release tag, and git blob SHA-1 for each synced file.
+
+This module is intentionally VF- and RA-independent: it uses only the
+Python standard library plus ``pyyaml``.  Both the validation framework
+(P-021 check) and release automation (derive-state ``out_of_sync``
+signal) import from here.
+
+See DEC-030 (manifest-based validation) and DEC-031 (tooling_lib).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+__all__ = [
+    "SyncStatus",
+    "SourceStatus",
+    "check_sync_status",
+    "git_blob_sha",
+    "MANIFEST_FILENAME",
+]
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILENAME = ".sync-manifest.yaml"
+"""Name of the sync manifest inside ``code/common/``."""
+
+COMMON_DIR = "code/common"
+"""Repo-relative path to the common-file cache directory."""
+
+
+# ---------------------------------------------------------------------------
+# Git blob SHA-1
+# ---------------------------------------------------------------------------
+
+
+def git_blob_sha(content: bytes) -> str:
+    """Compute the git blob SHA-1 for *content*.
+
+    Produces the same 40-character hex digest as ``git hash-object`` and
+    the GitHub Contents API ``.sha`` field::
+
+        sha1("blob {length}\\0" + content)
+    """
+    header = f"blob {len(content)}\0".encode("ascii")
+    return hashlib.sha1(header + content).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SourceStatus:
+    """Sync status for a single source repository entry in the manifest."""
+
+    repository: str
+    tag_mismatch: Optional[Tuple[str, str]] = None  # (expected, actual)
+    missing_files: List[str] = field(default_factory=list)
+    modified_files: List[str] = field(default_factory=list)
+
+    @property
+    def in_sync(self) -> bool:
+        return (
+            self.tag_mismatch is None
+            and not self.missing_files
+            and not self.modified_files
+        )
+
+
+@dataclass
+class SyncStatus:
+    """Overall sync status for ``code/common/``."""
+
+    no_common_dir: bool = False
+    no_manifest: bool = False
+    sources: List[SourceStatus] = field(default_factory=list)
+
+    @property
+    def in_sync(self) -> bool:
+        if self.no_common_dir or self.no_manifest:
+            return False
+        return all(s.in_sync for s in self.sources)
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading
+# ---------------------------------------------------------------------------
+
+
+def _load_manifest(manifest_path: Path) -> Optional[dict]:
+    """Load and basic-validate the sync manifest.
+
+    Returns ``None`` if the file does not exist, is not valid YAML, or
+    does not contain the expected top-level structure.
+    """
+    if not manifest_path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Failed to parse %s", manifest_path)
+        return None
+    if not isinstance(data, dict) or "sources" not in data:
+        logger.warning("Manifest %s missing 'sources' key", manifest_path)
+        return None
+    if not isinstance(data["sources"], list):
+        logger.warning("Manifest %s 'sources' is not a list", manifest_path)
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Core check
+# ---------------------------------------------------------------------------
+
+
+def check_sync_status(
+    repo_path: Path,
+    expected_releases: Dict[str, str],
+) -> SyncStatus:
+    """Check whether ``code/common/`` files match the sync manifest.
+
+    Parameters
+    ----------
+    repo_path:
+        Root of the API repository checkout.
+    expected_releases:
+        Map of source repository name to expected release tag, e.g.
+        ``{"Commonalities": "r4.2"}``.  Built by the caller from
+        ``release-plan.yaml`` dependencies.
+
+    Returns
+    -------
+    SyncStatus
+        Structured result.  Callers convert this to their own output
+        format (VF findings or RA error strings).
+    """
+    common_dir = repo_path / COMMON_DIR
+
+    if not common_dir.is_dir():
+        return SyncStatus(no_common_dir=True)
+
+    manifest_path = common_dir / MANIFEST_FILENAME
+    manifest = _load_manifest(manifest_path)
+    if manifest is None:
+        return SyncStatus(no_manifest=True)
+
+    # Index manifest sources by repository name for O(1) lookup.
+    manifest_sources: Dict[str, dict] = {}
+    for entry in manifest["sources"]:
+        if isinstance(entry, dict) and "repository" in entry:
+            manifest_sources[entry["repository"]] = entry
+
+    # Check each expected dependency against the manifest.
+    source_statuses: List[SourceStatus] = []
+    for repo_name, expected_tag in sorted(expected_releases.items()):
+        entry = manifest_sources.get(repo_name)
+        if entry is None:
+            # Source expected but not in manifest — treat as missing manifest
+            # for this specific source.  Produces a tag_mismatch with
+            # actual=None signalling "not present".
+            source_statuses.append(
+                SourceStatus(
+                    repository=repo_name,
+                    tag_mismatch=(expected_tag, "<not in manifest>"),
+                )
+            )
+            continue
+
+        status = SourceStatus(repository=repo_name)
+
+        # --- Tag match ---
+        actual_tag = entry.get("release", "")
+        if actual_tag != expected_tag:
+            status.tag_mismatch = (expected_tag, actual_tag)
+
+        # --- File integrity ---
+        files = entry.get("files", {})
+        if isinstance(files, dict):
+            for filename, expected_sha in sorted(files.items()):
+                file_path = common_dir / filename
+                if not file_path.is_file():
+                    status.missing_files.append(filename)
+                    continue
+                actual_sha = git_blob_sha(file_path.read_bytes())
+                if actual_sha != expected_sha:
+                    status.modified_files.append(filename)
+
+        source_statuses.append(status)
+
+    return SyncStatus(sources=source_statuses)

--- a/tooling_lib/tests/test_cache_sync.py
+++ b/tooling_lib/tests/test_cache_sync.py
@@ -1,0 +1,359 @@
+"""Unit tests for tooling_lib.cache_sync."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+from tooling_lib.cache_sync import (
+    COMMON_DIR,
+    MANIFEST_FILENAME,
+    SourceStatus,
+    SyncStatus,
+    check_sync_status,
+    git_blob_sha,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _blob_sha(content: bytes) -> str:
+    """Reference implementation for expected SHA values in tests."""
+    header = f"blob {len(content)}\0".encode("ascii")
+    return hashlib.sha1(header + content).hexdigest()
+
+
+def _write_manifest(
+    tmp_path: Path,
+    sources: list,
+) -> None:
+    """Write a .sync-manifest.yaml into code/common/."""
+    common_dir = tmp_path / COMMON_DIR
+    common_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {"sources": sources}
+    (common_dir / MANIFEST_FILENAME).write_text(
+        yaml.dump(manifest, default_flow_style=False), encoding="utf-8"
+    )
+
+
+def _write_common_file(tmp_path: Path, filename: str, content: str) -> str:
+    """Write a file into code/common/ and return its git blob SHA."""
+    common_dir = tmp_path / COMMON_DIR
+    common_dir.mkdir(parents=True, exist_ok=True)
+    data = content.encode("utf-8")
+    (common_dir / filename).write_text(content, encoding="utf-8")
+    return _blob_sha(data)
+
+
+def _make_source(
+    repo: str = "Commonalities",
+    release: str = "r4.2",
+    files: Dict[str, str] | None = None,
+) -> dict:
+    """Build a manifest source entry."""
+    return {
+        "repository": repo,
+        "release": release,
+        "files": files or {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# git_blob_sha
+# ---------------------------------------------------------------------------
+
+
+class TestGitBlobSha:
+
+    def test_known_content(self):
+        content = b"hello world"
+        expected = hashlib.sha1(b"blob 11\0hello world").hexdigest()
+        assert git_blob_sha(content) == expected
+
+    def test_empty_content(self):
+        expected = hashlib.sha1(b"blob 0\0").hexdigest()
+        assert git_blob_sha(b"") == expected
+
+    def test_binary_content(self):
+        content = bytes(range(256))
+        header = f"blob {len(content)}\0".encode("ascii")
+        expected = hashlib.sha1(header + content).hexdigest()
+        assert git_blob_sha(content) == expected
+
+
+# ---------------------------------------------------------------------------
+# check_sync_status — structural checks
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStatusStructural:
+
+    def test_no_common_dir(self, tmp_path: Path):
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.no_common_dir is True
+        assert status.in_sync is False
+
+    def test_no_manifest(self, tmp_path: Path):
+        (tmp_path / COMMON_DIR).mkdir(parents=True)
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.no_manifest is True
+        assert status.in_sync is False
+
+    def test_invalid_yaml_manifest(self, tmp_path: Path):
+        common_dir = tmp_path / COMMON_DIR
+        common_dir.mkdir(parents=True)
+        (common_dir / MANIFEST_FILENAME).write_text(
+            ": invalid: yaml: [", encoding="utf-8"
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.no_manifest is True
+
+    def test_manifest_missing_sources_key(self, tmp_path: Path):
+        common_dir = tmp_path / COMMON_DIR
+        common_dir.mkdir(parents=True)
+        (common_dir / MANIFEST_FILENAME).write_text(
+            yaml.dump({"version": 1}), encoding="utf-8"
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.no_manifest is True
+
+    def test_manifest_sources_not_a_list(self, tmp_path: Path):
+        common_dir = tmp_path / COMMON_DIR
+        common_dir.mkdir(parents=True)
+        (common_dir / MANIFEST_FILENAME).write_text(
+            yaml.dump({"sources": "not-a-list"}), encoding="utf-8"
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.no_manifest is True
+
+
+# ---------------------------------------------------------------------------
+# check_sync_status — tag matching
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStatusTagMatch:
+
+    def test_tag_matches(self, tmp_path: Path):
+        sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "content")
+        _write_manifest(
+            tmp_path,
+            [_make_source(files={"CAMARA_common.yaml": sha})],
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is True
+        assert len(status.sources) == 1
+        assert status.sources[0].tag_mismatch is None
+
+    def test_tag_mismatch(self, tmp_path: Path):
+        sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "content")
+        _write_manifest(
+            tmp_path,
+            [_make_source(release="r4.1", files={"CAMARA_common.yaml": sha})],
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is False
+        assert status.sources[0].tag_mismatch == ("r4.2", "r4.1")
+
+    def test_source_not_in_manifest(self, tmp_path: Path):
+        _write_manifest(tmp_path, [_make_source(repo="OtherRepo")])
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is False
+        assert len(status.sources) == 1
+        assert status.sources[0].tag_mismatch == ("r4.2", "<not in manifest>")
+
+
+# ---------------------------------------------------------------------------
+# check_sync_status — file integrity
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStatusFileIntegrity:
+
+    def test_file_matches(self, tmp_path: Path):
+        sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "data")
+        _write_manifest(
+            tmp_path,
+            [_make_source(files={"CAMARA_common.yaml": sha})],
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is True
+        assert status.sources[0].missing_files == []
+        assert status.sources[0].modified_files == []
+
+    def test_file_missing(self, tmp_path: Path):
+        (tmp_path / COMMON_DIR).mkdir(parents=True, exist_ok=True)
+        _write_manifest(
+            tmp_path,
+            [_make_source(files={"CAMARA_common.yaml": "a" * 40})],
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is False
+        assert status.sources[0].missing_files == ["CAMARA_common.yaml"]
+
+    def test_file_modified(self, tmp_path: Path):
+        original_sha = _blob_sha(b"original content")
+        _write_common_file(tmp_path, "CAMARA_common.yaml", "modified content")
+        _write_manifest(
+            tmp_path,
+            [_make_source(files={"CAMARA_common.yaml": original_sha})],
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is False
+        assert status.sources[0].modified_files == ["CAMARA_common.yaml"]
+
+    def test_multiple_files_mixed(self, tmp_path: Path):
+        sha_ok = _write_common_file(tmp_path, "CAMARA_common.yaml", "ok")
+        sha_wrong = _blob_sha(b"expected")
+        _write_common_file(tmp_path, "CAMARA_event_common.yaml", "actual")
+        _write_manifest(
+            tmp_path,
+            [
+                _make_source(
+                    files={
+                        "CAMARA_common.yaml": sha_ok,
+                        "CAMARA_event_common.yaml": sha_wrong,
+                        "CAMARA_missing.yaml": "b" * 40,
+                    }
+                )
+            ],
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is False
+        src = status.sources[0]
+        assert src.missing_files == ["CAMARA_missing.yaml"]
+        assert src.modified_files == ["CAMARA_event_common.yaml"]
+
+    def test_empty_files_dict(self, tmp_path: Path):
+        _write_manifest(tmp_path, [_make_source(files={})])
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        # Tag matches, no files to check → in sync.
+        assert status.in_sync is True
+
+
+# ---------------------------------------------------------------------------
+# check_sync_status — multi-source / extra files
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStatusMultiSource:
+
+    def test_extra_local_files_ignored(self, tmp_path: Path):
+        sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "content")
+        _write_common_file(tmp_path, "local_extra.yaml", "extra stuff")
+        _write_manifest(
+            tmp_path,
+            [_make_source(files={"CAMARA_common.yaml": sha})],
+        )
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is True
+
+    def test_multiple_sources(self, tmp_path: Path):
+        sha1 = _write_common_file(tmp_path, "CAMARA_common.yaml", "c1")
+        sha2 = _write_common_file(tmp_path, "QoS_common.yaml", "q1")
+        _write_manifest(
+            tmp_path,
+            [
+                _make_source(
+                    repo="Commonalities",
+                    release="r4.2",
+                    files={"CAMARA_common.yaml": sha1},
+                ),
+                _make_source(
+                    repo="QoSProfiles",
+                    release="r1.1",
+                    files={"QoS_common.yaml": sha2},
+                ),
+            ],
+        )
+        status = check_sync_status(
+            tmp_path,
+            {"Commonalities": "r4.2", "QoSProfiles": "r1.1"},
+        )
+        assert status.in_sync is True
+        assert len(status.sources) == 2
+
+    def test_manifest_source_not_in_expected_skipped(self, tmp_path: Path):
+        sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "c1")
+        _write_manifest(
+            tmp_path,
+            [
+                _make_source(
+                    repo="Commonalities",
+                    release="r4.2",
+                    files={"CAMARA_common.yaml": sha},
+                ),
+                _make_source(
+                    repo="UnexpectedRepo",
+                    release="r1.1",
+                    files={"other.yaml": "c" * 40},
+                ),
+            ],
+        )
+        # Only checking Commonalities — UnexpectedRepo is skipped.
+        status = check_sync_status(tmp_path, {"Commonalities": "r4.2"})
+        assert status.in_sync is True
+        assert len(status.sources) == 1
+        assert status.sources[0].repository == "Commonalities"
+
+
+# ---------------------------------------------------------------------------
+# SourceStatus.in_sync property
+# ---------------------------------------------------------------------------
+
+
+class TestSourceStatusProperty:
+
+    def test_in_sync_when_clean(self):
+        s = SourceStatus(repository="X")
+        assert s.in_sync is True
+
+    def test_not_in_sync_tag_mismatch(self):
+        s = SourceStatus(repository="X", tag_mismatch=("r4.2", "r4.1"))
+        assert s.in_sync is False
+
+    def test_not_in_sync_missing_files(self):
+        s = SourceStatus(repository="X", missing_files=["a.yaml"])
+        assert s.in_sync is False
+
+    def test_not_in_sync_modified_files(self):
+        s = SourceStatus(repository="X", modified_files=["a.yaml"])
+        assert s.in_sync is False
+
+
+# ---------------------------------------------------------------------------
+# SyncStatus.in_sync property
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStatusProperty:
+
+    def test_in_sync_all_sources_ok(self):
+        s = SyncStatus(sources=[SourceStatus(repository="X")])
+        assert s.in_sync is True
+
+    def test_not_in_sync_no_common_dir(self):
+        s = SyncStatus(no_common_dir=True)
+        assert s.in_sync is False
+
+    def test_not_in_sync_no_manifest(self):
+        s = SyncStatus(no_manifest=True)
+        assert s.in_sync is False
+
+    def test_not_in_sync_source_problem(self):
+        s = SyncStatus(
+            sources=[
+                SourceStatus(repository="X", tag_mismatch=("a", "b")),
+            ]
+        )
+        assert s.in_sync is False
+
+    def test_empty_sources_is_in_sync(self):
+        s = SyncStatus(sources=[])
+        assert s.in_sync is True

--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -11,6 +11,7 @@ from .error_code_checks import check_conflict_deprecated, check_contextcode_form
 from .filename_checks import check_filename_kebab_case, check_filename_matches_api_name
 from .metadata_checks import check_commonalities_version
 from .readme_checks import check_readme_placeholder_removal
+from .common_cache_checks import check_common_cache_sync
 from .release_plan_checks import check_orphan_api_definitions, check_release_plan_semantics
 from .release_review_checks import check_release_review_file_restriction
 from .subscription_checks import (
@@ -55,6 +56,7 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-readme-placeholder-removal", CheckScope.REPO, check_readme_placeholder_removal),
     CheckDescriptor("check-release-review-file-restriction", CheckScope.REPO, check_release_review_file_restriction),
     CheckDescriptor("check-orphan-api-definitions", CheckScope.REPO, check_orphan_api_definitions),
+    CheckDescriptor("check-common-cache-sync", CheckScope.REPO, check_common_cache_sync),
 ]
 
 __all__ = ["CHECKS", "CheckDescriptor", "CheckScope"]

--- a/validation/engines/python_checks/common_cache_checks.py
+++ b/validation/engines/python_checks/common_cache_checks.py
@@ -1,0 +1,130 @@
+"""Common-file cache sync check (P-021).
+
+Wrapper around :func:`tooling_lib.cache_sync.check_sync_status` that
+converts the structured :class:`~tooling_lib.cache_sync.SyncStatus`
+into VF findings.
+
+DEC-027 (RA-integrated sync), DEC-030 (manifest-based validation).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from tooling_lib.cache_sync import COMMON_DIR, SyncStatus, check_sync_status
+from validation.context import ValidationContext
+
+from ._types import make_finding
+
+_ENGINE_RULE = "check-common-cache-sync"
+
+
+def check_common_cache_sync(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Verify ``code/common/`` files match the sync manifest.
+
+    Repo-level check — runs once, not per-API.
+
+    Builds the expected-releases dict from *context* and delegates to
+    :func:`~tooling_lib.cache_sync.check_sync_status`.  Returns an
+    empty list when no expected releases can be determined (e.g. no
+    ``release-plan.yaml``).
+    """
+    expected = _build_expected_releases(context)
+    if not expected:
+        return []
+
+    status = check_sync_status(repo_path, expected)
+    return _status_to_findings(status)
+
+
+# ------------------------------------------------------------------
+# Internals
+# ------------------------------------------------------------------
+
+
+def _build_expected_releases(context: ValidationContext) -> dict:
+    """Derive expected source-repo releases from the validation context."""
+    expected: dict = {}
+    if context.commonalities_release:
+        expected["Commonalities"] = context.commonalities_release
+    return expected
+
+
+def _status_to_findings(status: SyncStatus) -> List[dict]:
+    """Convert a *SyncStatus* into a list of VF findings."""
+    findings: List[dict] = []
+
+    if status.no_common_dir:
+        findings.append(
+            make_finding(
+                engine_rule=_ENGINE_RULE,
+                level="warn",
+                message=(
+                    f"{COMMON_DIR}/ directory is missing — required for "
+                    f"repos declaring a commonalities_release dependency"
+                ),
+                path=COMMON_DIR,
+            )
+        )
+        return findings
+
+    if status.no_manifest:
+        findings.append(
+            make_finding(
+                engine_rule=_ENGINE_RULE,
+                level="warn",
+                message=(
+                    f"Sync manifest ({COMMON_DIR}/.sync-manifest.yaml) is "
+                    f"missing — common files must be managed by the sync "
+                    f"mechanism"
+                ),
+                path=f"{COMMON_DIR}/.sync-manifest.yaml",
+            )
+        )
+        return findings
+
+    for src in status.sources:
+        if src.tag_mismatch:
+            expected, actual = src.tag_mismatch
+            findings.append(
+                make_finding(
+                    engine_rule=_ENGINE_RULE,
+                    level="warn",
+                    message=(
+                        f"{src.repository}: dependency declares {expected} "
+                        f"but common files synced from {actual}"
+                    ),
+                    path=f"{COMMON_DIR}/.sync-manifest.yaml",
+                )
+            )
+
+        for filename in src.missing_files:
+            findings.append(
+                make_finding(
+                    engine_rule=_ENGINE_RULE,
+                    level="warn",
+                    message=(
+                        f"{src.repository}: expected file '{filename}' is "
+                        f"missing from {COMMON_DIR}/"
+                    ),
+                    path=f"{COMMON_DIR}/{filename}",
+                )
+            )
+
+        for filename in src.modified_files:
+            findings.append(
+                make_finding(
+                    engine_rule=_ENGINE_RULE,
+                    level="warn",
+                    message=(
+                        f"{src.repository}: '{filename}' has been modified "
+                        f"since last sync"
+                    ),
+                    path=f"{COMMON_DIR}/{filename}",
+                )
+            )
+
+    return findings

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -229,3 +229,24 @@
     or an allOf combining the $ref with an API-specific ApiEventType
     schema. See implicit-events API template in Commonalities
     artifacts/api-templates/.
+
+# P-021: check-common-cache-sync (DEC-027/030)
+# Safety check: code/common/ files must match the sync manifest written
+# by the RA sync-common handler.  Suppressed on bump PRs via the
+# three-step consistency model (DEC-029).  Version-gated to repos
+# adopting $ref consumption (>=r4.2).
+- id: P-021
+  engine: python
+  engine_rule: check-common-cache-sync
+  applicability:
+    release_plan_changed: false
+    commonalities_release: ">=r4.2"
+  conditional_level:
+    default: warn
+    overrides:
+      - condition:
+          trigger_types: [release-automation]
+        level: error
+  hint: >-
+    Merge the auto-created sync PR or trigger the release automation
+    workflow manually (workflow_dispatch) to update code/common/ files.

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -14,7 +14,7 @@ version: 1
 generated: 2026-04-07
 
 summary:
-  total_implemented: 142
+  total_implemented: 143
   total_gap: 0
   total_manual: 25
   total_pending: 0
@@ -22,7 +22,7 @@ summary:
   by_engine:
     spectral: 84
     gherkin: 25
-    python: 20
+    python: 21
     yamllint: 13
 
 # ---------------------------------------------------------------------------
@@ -204,6 +204,12 @@ gap_rules:
     target_engine: python
     status: implemented
     rule_id: P-020
+
+  - audit_id: DEC-027
+    description: "Common file cache sync safety check — code/common/ must match sync manifest from Commonalities artifacts"
+    target_engine: python
+    status: implemented
+    rule_id: P-021
 
 # ---------------------------------------------------------------------------
 # Fixes needed — implemented rules with incorrect behavior

--- a/validation/schemas/sync-manifest-schema.yaml
+++ b/validation/schemas/sync-manifest-schema.yaml
@@ -1,0 +1,42 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Common File Sync Manifest
+description: >-
+  Written by the camara-release-automation sync-common handler into
+  code/common/.sync-manifest.yaml.  Records the source repository,
+  release tag, and git blob SHA-1 hashes for each synced file.
+  Read by VF P-021 (check-common-cache-sync) and RA derive-state
+  (out_of_sync signal).  See DEC-030.
+type: object
+required:
+  - sources
+additionalProperties: false
+properties:
+  sources:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      required:
+        - repository
+        - release
+        - files
+      additionalProperties: false
+      properties:
+        repository:
+          type: string
+          description: >-
+            Source repository name (e.g. "Commonalities").
+          minLength: 1
+        release:
+          type: string
+          description: >-
+            Release tag the files were synced from (e.g. "r4.2").
+          pattern: "^r[1-9]\\d*\\.[1-9]\\d*$"
+        files:
+          type: object
+          description: >-
+            Map of filename to git blob SHA-1 hash (40-char hex).
+          minProperties: 1
+          additionalProperties:
+            type: string
+            pattern: "^[0-9a-f]{40}$"

--- a/validation/tests/test_python_checks_common_cache.py
+++ b/validation/tests/test_python_checks_common_cache.py
@@ -1,0 +1,199 @@
+"""Unit tests for validation.engines.python_checks.common_cache_checks (P-021).
+
+The core sync logic is tested exhaustively in
+``tooling_lib/tests/test_cache_sync.py``.  These tests verify the VF
+wrapper: context-to-expected-releases mapping and SyncStatus-to-findings
+conversion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from validation.context import ValidationContext
+from validation.context.context_builder import ApiContext
+from validation.engines.python_checks.common_cache_checks import (
+    check_common_cache_sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _blob_sha(content: bytes) -> str:
+    header = f"blob {len(content)}\0".encode("ascii")
+    return hashlib.sha1(header + content).hexdigest()
+
+
+def _make_context(
+    commonalities_release: Optional[str] = None,
+) -> ValidationContext:
+    return ValidationContext(
+        repository="TestRepo",
+        branch_type="main",
+        trigger_type="dispatch",
+        profile="advisory",
+        stage="enabled",
+        target_release_type=None,
+        commonalities_release=commonalities_release,
+        commonalities_version=None,
+        icm_release=None,
+        base_ref=None,
+        is_release_review_pr=False,
+        release_plan_changed=None,
+        pr_number=None,
+        apis=(),
+        workflow_run_url="",
+        tooling_ref="",
+    )
+
+
+def _write_manifest(tmp_path: Path, sources: list) -> None:
+    common_dir = tmp_path / "code" / "common"
+    common_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {"sources": sources}
+    (common_dir / ".sync-manifest.yaml").write_text(
+        yaml.dump(manifest, default_flow_style=False), encoding="utf-8"
+    )
+
+
+def _write_common_file(tmp_path: Path, filename: str, content: str) -> str:
+    common_dir = tmp_path / "code" / "common"
+    common_dir.mkdir(parents=True, exist_ok=True)
+    data = content.encode("utf-8")
+    (common_dir / filename).write_text(content, encoding="utf-8")
+    return _blob_sha(data)
+
+
+# ---------------------------------------------------------------------------
+# Tests — context-to-expected mapping
+# ---------------------------------------------------------------------------
+
+
+class TestContextMapping:
+
+    def test_no_commonalities_release_returns_empty(self, tmp_path: Path):
+        ctx = _make_context(commonalities_release=None)
+        assert check_common_cache_sync(tmp_path, ctx) == []
+
+    def test_commonalities_release_populates_expected(self, tmp_path: Path):
+        """When commonalities_release is set, the check runs."""
+        ctx = _make_context(commonalities_release="r4.2")
+        # No code/common/ dir → should produce a finding.
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "directory" in findings[0]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests — SyncStatus-to-findings conversion
+# ---------------------------------------------------------------------------
+
+
+class TestFindingsConversion:
+
+    def test_no_common_dir(self, tmp_path: Path):
+        ctx = _make_context(commonalities_release="r4.2")
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["engine_rule"] == "check-common-cache-sync"
+        assert f["level"] == "warn"
+        assert "directory" in f["message"].lower()
+        assert f["path"] == "code/common"
+
+    def test_no_manifest(self, tmp_path: Path):
+        (tmp_path / "code" / "common").mkdir(parents=True)
+        ctx = _make_context(commonalities_release="r4.2")
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "manifest" in findings[0]["message"].lower()
+        assert findings[0]["path"] == "code/common/.sync-manifest.yaml"
+
+    def test_all_in_sync(self, tmp_path: Path):
+        sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "ok")
+        _write_manifest(
+            tmp_path,
+            [
+                {
+                    "repository": "Commonalities",
+                    "release": "r4.2",
+                    "files": {"CAMARA_common.yaml": sha},
+                }
+            ],
+        )
+        ctx = _make_context(commonalities_release="r4.2")
+        assert check_common_cache_sync(tmp_path, ctx) == []
+
+    def test_tag_mismatch_finding(self, tmp_path: Path):
+        sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "data")
+        _write_manifest(
+            tmp_path,
+            [
+                {
+                    "repository": "Commonalities",
+                    "release": "r4.1",
+                    "files": {"CAMARA_common.yaml": sha},
+                }
+            ],
+        )
+        ctx = _make_context(commonalities_release="r4.2")
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "r4.2" in findings[0]["message"]
+        assert "r4.1" in findings[0]["message"]
+
+    def test_missing_file_finding(self, tmp_path: Path):
+        (tmp_path / "code" / "common").mkdir(parents=True, exist_ok=True)
+        _write_manifest(
+            tmp_path,
+            [
+                {
+                    "repository": "Commonalities",
+                    "release": "r4.2",
+                    "files": {"CAMARA_common.yaml": "a" * 40},
+                }
+            ],
+        )
+        ctx = _make_context(commonalities_release="r4.2")
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "missing" in findings[0]["message"].lower()
+        assert findings[0]["path"] == "code/common/CAMARA_common.yaml"
+
+    def test_modified_file_finding(self, tmp_path: Path):
+        original_sha = _blob_sha(b"original")
+        _write_common_file(tmp_path, "CAMARA_common.yaml", "modified")
+        _write_manifest(
+            tmp_path,
+            [
+                {
+                    "repository": "Commonalities",
+                    "release": "r4.2",
+                    "files": {"CAMARA_common.yaml": original_sha},
+                }
+            ],
+        )
+        ctx = _make_context(commonalities_release="r4.2")
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "modified" in findings[0]["message"].lower()
+
+    def test_all_findings_are_warn(self, tmp_path: Path):
+        """Every finding from P-021 is 'warn' (post-filter handles escalation)."""
+        ctx = _make_context(commonalities_release="r4.2")
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert all(f["level"] == "warn" for f in findings)
+
+    def test_all_findings_have_engine_rule(self, tmp_path: Path):
+        ctx = _make_context(commonalities_release="r4.2")
+        findings = check_common_cache_sync(tmp_path, ctx)
+        assert all(
+            f["engine_rule"] == "check-common-cache-sync" for f in findings
+        )

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 20
+        assert counts["python"] == 21
         assert counts["spectral"] == 84
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -306,8 +306,8 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 13, (
-            f"Expected 13 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 14, (
+            f"Expected 14 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds P-021 (`check-common-cache-sync`), a new Python validation check that verifies `code/common/` files match the sync manifest written by the release automation sync-common handler. This is the VF safety check specified in the common YAML sync design ([RM#489](https://github.com/camaraproject/ReleaseManagement/issues/489)).

Also introduces `tooling_lib/`, a shared Python library between the validation framework and release automation. This is the first Python-level code sharing between VF and RA, providing a reusable `check_sync_status()` function that both consumers import.

**New files:**
- `tooling_lib/` — shared package with `cache_sync.py` (`SyncStatus`, `SourceStatus`, `check_sync_status`, `git_blob_sha`) + 28 unit tests
- `validation/schemas/sync-manifest-schema.yaml` — JSON Schema for `code/common/.sync-manifest.yaml` (multi-source format, extensible to additional source repositories)
- `validation/engines/python_checks/common_cache_checks.py` — P-021 VF wrapper converting `SyncStatus` to findings + 10 unit tests

**Rule metadata (P-021):**
- Applicability: `release_plan_changed: false` (suppressed on bump PRs per three-step model), `commonalities_release: >=r4.2` (version-gated to repos adopting `$ref` consumption)
- Severity: warn default, error on `trigger_types: [release-automation]` (pre-snapshot hard gate)

**Check behavior:**
- Warns when `code/common/` directory is missing
- Warns when `.sync-manifest.yaml` is missing
- Warns on tag mismatch (dependency bumped but not synced)
- Warns on file integrity issues (missing or modified files)
- Returns empty when no `commonalities_release` dependency is declared

**Manifest format** (written by RA sync-common handler, to be implemented in a follow-up PR):
```yaml
sources:
  - repository: Commonalities
    release: r4.2
    files:
      CAMARA_common.yaml: <git-blob-sha1>
      CAMARA_event_common.yaml: <git-blob-sha1>
```

870/870 tests pass.

#### Which issue(s) this PR fixes:

Part of [RM#489](https://github.com/camaraproject/ReleaseManagement/issues/489) (Session A: VF safety check)

#### Special notes for reviewers:

- `tooling_lib/` is a new top-level package — the first shared Python library between VF and RA. The RA sync-common handler (follow-up PR) will import `check_sync_status` from `tooling_lib.cache_sync` for `out_of_sync` detection.
- P-021 is currently "ready but dormant" — it warns on missing manifest, but no repo has a manifest yet. It activates when the RA sync handler starts writing `.sync-manifest.yaml` files.
- Regression branch deferred until the RA sync handler is implemented and Commonalities r4.2 is tagged.

#### Changelog input

```
 release-note
Add P-021 (check-common-cache-sync): validates code/common/ files against the sync manifest. Introduces tooling_lib/ shared Python package for code reuse between validation framework and release automation.
```

#### Additional documentation

```
docs
New schema: validation/schemas/sync-manifest-schema.yaml defines the format for code/common/.sync-manifest.yaml
```