### PR TITLE
fix: add tooling_lib to sparse checkout in validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -136,6 +136,7 @@ jobs:
             linting/config
             validation
             shared-actions
+            tooling_lib
           path: .tooling
 
       # ── Step 4: Setup Python ───────────────────────────────────────


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The sparse checkout in `validation.yml` did not include the new `tooling_lib/` package introduced in #181, causing `ModuleNotFoundError: No module named 'tooling_lib'` when the Python engine loads the P-021 check registry in CI.

Caught by the regression runner canary: [run 24550615222](https://github.com/camaraproject/tooling/actions/runs/24550615222) failed immediately after #181 merged, because the dispatched validation [run 24550620327](https://github.com/camaraproject/ReleaseTest/actions/runs/24550620327) could not import `tooling_lib.cache_sync`.

#### Which issue(s) this PR fixes:

Follow-up fix for #181.

#### Special notes for reviewers:

One-line addition to the sparse-checkout list. The regression runner will automatically verify the fix once this merges (triggered on every push to `validation-framework`).

#### Changelog input

```release-note
N/A (infrastructure fix)
```

#### Additional documentation

This section can be blank.