### PR TITLE
fix: expand regression runner path triggers

### DIFF
--- a/.github/workflows/regression-runner.yml
+++ b/.github/workflows/regression-runner.yml
@@ -24,6 +24,8 @@ on:
     paths:
       - 'validation/**'
       - 'shared-actions/**'
+      - 'tooling_lib/**'
+      - '.github/workflows/validation.yml'
       - '.github/workflows/regression-runner.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Adds `tooling_lib/**` and `.github/workflows/validation.yml` to the regression runner's push path filter. Without these, changes to the reusable validation workflow or the shared Python library don't trigger the canary — as happened when #182 merged without a regression run.

Manual dispatch [24551472798](https://github.com/camaraproject/tooling/actions/runs/24551472798) confirmed #182 works (PASS 4/4 branches). This PR ensures future changes to these paths are caught automatically.

#### Which issue(s) this PR fixes:

Follow-up to #182 / #181.

#### Special notes for reviewers:

Two lines added to the `paths` filter. This PR itself will trigger the regression runner on merge (it changes `regression-runner.yml`, which is already in the paths list).

#### Changelog input

```release-note
N/A (infrastructure)
```

#### Additional documentation

This section can be blank.