### PR TITLE
fix: update Tier 3 fallback ref to v1-rc

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -117,14 +117,10 @@ jobs:
             }
 
             // Tier 3: Hardcoded fallback tag
-            // ┌──────────────────────────────────────────────────────────┐
-            // │ PRE-RC: branch ref — replace with v1-rc tag after tagging │
-            // │   repo: camaraproject/tooling  ref: validation-framework│
-            // └──────────────────────────────────────────────────────────┘
             core.setOutput('tooling_checkout_repo', 'camaraproject/tooling');
-            core.setOutput('tooling_checkout_ref', 'validation-framework');
+            core.setOutput('tooling_checkout_ref', 'v1-rc');
             core.setOutput('tooling_ref_source', 'fallback_tag');
-            core.info('Tooling ref: fallback camaraproject/tooling@validation-framework');
+            core.info('Tooling ref: fallback camaraproject/tooling@v1-rc');
 
       # ── Step 3: Checkout tooling (sparse) ──────────────────────────
       - name: Checkout tooling


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Updates the Tier 3 (hardcoded) fallback in the resolve-ref step from `validation-framework` to `v1-rc`.

Fork PRs cannot obtain OIDC tokens (`ACTIONS_ID_TOKEN_REQUEST_URL` unavailable), so the resolve-ref step falls through to the Tier 3 fallback. The fallback still pointed at the `validation-framework` branch, causing a mismatch between the workflow definition (from `@v1-rc`) and the checked-out tooling code (branch tip). This caused `ModuleNotFoundError: No module named 'tooling_lib'` on fork PRs (e.g. camaraproject/QualityOnDemand#549).

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

After merge, `@v1-rc` tag needs to be moved to the merge commit so the fallback self-references correctly.

#### Changelog input

```
fix: Tier 3 fallback ref updated from validation-framework to v1-rc, fixing fork PR validation failures
```

#### Additional documentation

```
docs

```