### PR TITLE
fix: broken YAML output for common_cache_status

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -383,7 +383,8 @@ jobs:
       release_plan_url: ${{ steps.state.outputs.release_plan_url }}
       src_commit_sha_short: ${{ steps.state.outputs.src_commit_sha_short }}
       meta_release: ${{ steps.state.outputs.meta_release }}
-      # Common file cache sync outputs      common_cache_status: ${{ steps.cache-sync.outputs.common_cache_status }}
+      # Common file cache sync outputs
+      common_cache_status: ${{ steps.cache-sync.outputs.common_cache_status }}
       common_cache_details: ${{ steps.cache-sync.outputs.common_cache_details }}
       common_sync_pr_url: ${{ steps.find-sync-pr.outputs.common_sync_pr_url }}
     steps:


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The comment `# Common file cache sync outputs` was on the same line as the `common_cache_status` output key in the derive-state job, making the entire line a YAML comment. The output was never exposed to downstream jobs, causing all sync steps in update-issue to silently skip.

Found during E2E testing on [ReleaseTest run 24566023921](https://github.com/camaraproject/ReleaseTest/actions/runs/24566023921): derive-state correctly detected staleness, but all five sync steps in the sync-issue job were skipped because `needs.derive-state.outputs.common_cache_status` was empty.

#### Which issue(s) this PR fixes:

Follow-up fix for #185.

#### Special notes for reviewers:

One-line fix: split the comment onto its own line.

#### Changelog input

```release-note
N/A (bug fix for #185)
```

#### Additional documentation

This section can be blank.