### PR TITLE
fix: add continue-on-error to sync checkouts + post failure comment

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -2101,7 +2101,9 @@ jobs:
       # sync failures don't prevent the issue update.
 
       - name: Checkout API repo (for common sync)
+        id: sync-checkout-api
         if: needs.derive-state.outputs.common_cache_status == 'stale'
+        continue-on-error: true
         uses: actions/checkout@v6
         with:
           path: _api_repo
@@ -2109,7 +2111,9 @@ jobs:
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Checkout Commonalities at declared tag (sparse)
-        if: needs.derive-state.outputs.common_cache_status == 'stale'
+        id: sync-checkout-commonalities
+        if: steps.sync-checkout-api.outcome == 'success'
+        continue-on-error: true
         uses: actions/checkout@v6
         with:
           repository: camaraproject/Commonalities
@@ -2120,7 +2124,7 @@ jobs:
 
       - name: Copy Commonalities files and write manifest
         id: sync-common
-        if: needs.derive-state.outputs.common_cache_status == 'stale'
+        if: steps.sync-checkout-commonalities.outcome == 'success'
         continue-on-error: true
         env:
           COMMONALITIES_RELEASE: ${{ needs.derive-state.outputs.commonalities_release }}
@@ -2431,6 +2435,19 @@ jobs:
               "common_cache_details": "${{ needs.derive-state.outputs.common_cache_details }}",
               "common_sync_pr_url": "${{ steps.sync-pr.outputs.sync_pr_url }}"
             }
+
+      - name: Post Common Sync Failed
+        if: |
+          steps.sync-checkout-commonalities.outcome == 'failure' &&
+          (needs.derive-state.outputs.release_issue_number != '' || steps.sync.outputs.issue_number != '')
+        uses: ./_tooling/shared-actions/post-bot-comment
+        with:
+          issue_number: ${{ needs.derive-state.outputs.release_issue_number || steps.sync.outputs.issue_number }}
+          release_tag: ${{ needs.derive-state.outputs.release_tag }}
+          run_id: ${{ github.run_id }}
+          template: common_sync_failed
+          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          github_token: ${{ steps.app-token.outputs.token || github.token }}
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Phase 7: Post final result comment

--- a/release_automation/templates/bot_messages/common_sync_failed.md
+++ b/release_automation/templates/bot_messages/common_sync_failed.md
@@ -1,0 +1,6 @@
+**⚠️ Common file sync failed**
+Could not sync `code/common/` files from Commonalities `{{commonalities_release}}`: the release tag may not exist yet.
+
+The `/create-snapshot` command remains blocked until common files are in sync. Once the Commonalities release is published, trigger sync via `workflow_dispatch` or push to `release-plan.yaml`.
+
+{{#workflow_run_url}}[View workflow logs]({{workflow_run_url}}){{/workflow_run_url}}

--- a/release_automation/tests/test_template_context_contract.py
+++ b/release_automation/tests/test_template_context_contract.py
@@ -15,6 +15,7 @@ from release_automation.scripts.context_builder import build_context
 
 KNOWN_TEMPLATES = [
     "command_rejected",
+    "common_sync_failed",
     "common_sync_pr_created",
     "config_drift_warning",
     "config_error",
@@ -117,10 +118,10 @@ class TestTemplateContextContract:
             )
 
     def test_list_templates_returns_expected_count(self, responder):
-        """list_templates() returns at least 13 templates."""
+        """list_templates() returns at least 14 templates."""
         templates = responder.list_templates()
         assert len(templates) >= 13, (
-            f"Expected at least 13 templates, got {len(templates)}: {templates}"
+            f"Expected at least 14 templates, got {len(templates)}: {templates}"
         )
 
     def test_build_context_no_none_values(self):


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Two fixes for the sync steps in the update-issue job:

1. **continue-on-error on checkout steps** — both the API repo and Commonalities checkouts now use `continue-on-error: true`, so a checkout failure (e.g. Commonalities tag doesn't exist yet) skips the sync gracefully without killing the Release Issue update.

2. **"sync failed" bot comment** — when the Commonalities checkout fails, a bot comment is posted on the Release Issue explaining that the tag may not exist yet, with a link to the workflow logs and guidance to retry after the Commonalities release is published.

Previously, a Commonalities checkout failure cascaded to skip all remaining steps including `Sync Release Issue` and produced no user-visible error message.

#### Which issue(s) this PR fixes:

Follow-up fix for #185 and #186. Found during E2E testing on [ReleaseTest run 24573353692](https://github.com/camaraproject/ReleaseTest/actions/runs/24573353692): derive-state correctly detected staleness and the output fix (#186) worked, but the Commonalities `r4.2` tag does not exist yet, causing the checkout to fail and cascade.

#### Special notes for reviewers:

The downstream sync steps already gate on `steps.sync-common.outputs.synced == 'true'`, so they skip cleanly when the checkout fails. The new step chains are: API checkout → Commonalities checkout (gates on API success) → copy+manifest (gates on Commonalities success).

#### Changelog input

```release-note
N/A (bug fix for #185)
```

#### Additional documentation

This section can be blank.