### PR TITLE
fix: pass empty JSON context to sync failed bot comment

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -2448,6 +2448,7 @@ jobs:
           template: common_sync_failed
           base_context: ${{ needs.assemble-context.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
+          context: '{}'
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Phase 7: Post final result comment


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The "Post Common Sync Failed" step omitted the `context` input to `post-bot-comment`. The action requires valid JSON — when omitted the env var is empty and `json.loads('')` fails with "Invalid JSON context".

#### Which issue(s) this PR fixes:

Follow-up fix for #187. Found in [ReleaseTest run 24574245091](https://github.com/camaraproject/ReleaseTest/actions/runs/24574245091).

#### Special notes for reviewers:

One-line addition: `context: '{}'`.

#### Changelog input

```release-note
N/A (bug fix for #187)
```

#### Additional documentation

This section can be blank.