### PR TITLE
Pin 11 rules via regression/r4.1-broken-spec-descriptions

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 46
+  total_tested: 57
   by_engine:
     spectral: 84
     gherkin: 25
@@ -312,6 +312,11 @@ tested_rules:
   P-005: [regression/r4.1-broken-spec-test-files]
   P-006: [regression/r4.1-main-baseline]
   S-005: [regression/r4.1-broken-spec-yaml-fundamentals]
+  S-006: [regression/r4.1-broken-spec-descriptions]
+  S-009: [regression/r4.1-broken-spec-descriptions]
+  S-011: [regression/r4.1-broken-spec-descriptions]
+  S-013: [regression/r4.1-broken-spec-descriptions]
+  S-014: [regression/r4.1-broken-spec-descriptions]
   S-016: [regression/r4.1-broken-spec-yaml-fundamentals]
   S-018: [regression/r4.1-broken-spec-api-metadata]
   S-019: [regression/r4.1-broken-spec-api-metadata]
@@ -323,10 +328,16 @@ tested_rules:
   S-025: [regression/r4.1-broken-spec-error-handling]
   S-026: [regression/r4.1-broken-spec-error-handling]
   S-027: [regression/r4.1-broken-spec-error-handling]
+  S-028: [regression/r4.1-broken-spec-descriptions]
+  S-029: [regression/r4.1-broken-spec-descriptions]
+  S-031: [regression/r4.1-broken-spec-descriptions]
   S-201: [regression/r4.1-broken-spec-api-metadata]
   S-210: [regression/r4.1-broken-spec-api-metadata]
   S-211: [regression/r4.1-main-baseline]
+  S-215: [regression/r4.1-broken-spec-descriptions]
+  S-216: [regression/r4.1-broken-spec-descriptions]
   S-221: [regression/r4.1-broken-spec-error-handling]
+  S-223: [regression/r4.1-broken-spec-descriptions]
   S-307: [regression/r4.1-broken-spec-error-handling]
   S-313: [regression/r4.1-main-baseline]
   S-314: [regression/r4.1-main-baseline]


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Add S-006, S-009, S-011, S-013, S-014, S-028, S-029, S-031, S-215, S-216,
S-223 to `tested_rules` in `rule-inventory.yaml` and update `total_tested`
from 46 to 57.

Branch 4 of the 7-branch broken-spec regression roadmap. The corresponding
broken-spec branch on `camaraproject/ReleaseTest` introduces 8 surgical
deletions and 3 synthetic schema additions to `sample-service.yaml`,
targeting description rules on operations, parameters, properties,
responses, and array items.

Single-branch verification: PASS 1/1 (33 matched, 0 missing, 0 unexpected)
— run https://github.com/camaraproject/ReleaseTest/actions/runs/24622355098

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/camaraproject/ReleaseManagement/issues/483

#### Special notes for reviewers:

Description rules live on MEDIUM rebase risk — edits 9-11 introduce
synthetic properties (`createdAt`, `validFor`, `labels`) with carefully
chosen constraints to avoid cascading into S-309/S-312 noise. The S-014 /
S-215 pair both target operation descriptions; both fire per edit, giving
count=2 on each. See the branch's
[.regression/REGRESSION.md](https://github.com/camaraproject/ReleaseTest/blob/regression/r4.1-broken-spec-descriptions/.regression/REGRESSION.md)
for the full edit-to-rule mapping.

#### Changelog input

 release-note
```
NONE
```

#### Additional documentation

 docs
```
NONE
```