### PR TITLE
Pin 8 rules via regression/r4.1-broken-spec-schema-constraints

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 57
+  total_tested: 65
   by_engine:
     spectral: 84
     gherkin: 25
@@ -330,6 +330,7 @@ tested_rules:
   S-027: [regression/r4.1-broken-spec-error-handling]
   S-028: [regression/r4.1-broken-spec-descriptions]
   S-029: [regression/r4.1-broken-spec-descriptions]
+  S-030: [regression/r4.1-broken-spec-schema-constraints]
   S-031: [regression/r4.1-broken-spec-descriptions]
   S-201: [regression/r4.1-broken-spec-api-metadata]
   S-210: [regression/r4.1-broken-spec-api-metadata]
@@ -338,7 +339,14 @@ tested_rules:
   S-216: [regression/r4.1-broken-spec-descriptions]
   S-221: [regression/r4.1-broken-spec-error-handling]
   S-223: [regression/r4.1-broken-spec-descriptions]
+  S-300: [regression/r4.1-broken-spec-schema-constraints]
+  S-303: [regression/r4.1-broken-spec-schema-constraints]
   S-307: [regression/r4.1-broken-spec-error-handling]
+  S-308: [regression/r4.1-broken-spec-schema-constraints]
+  S-309: [regression/r4.1-broken-spec-schema-constraints]
+  S-310: [regression/r4.1-broken-spec-schema-constraints]
+  S-311: [regression/r4.1-broken-spec-schema-constraints]
+  S-312: [regression/r4.1-broken-spec-schema-constraints]
   S-313: [regression/r4.1-main-baseline]
   S-314: [regression/r4.1-main-baseline]
   S-316: [regression/r4.1-main-baseline]


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Add S-030, S-300, S-303, S-308, S-309, S-310, S-311, S-312 to
`tested_rules` in `rule-inventory.yaml` and update `total_tested`
from 57 to 65.

Branch 5 of the 7-branch broken-spec regression roadmap. The corresponding
broken-spec branch on `camaraproject/ReleaseTest` introduces 7 surgical
edits to `sample-service.yaml`, targeting OWASP resource-consumption
limits, required-properties integrity, OWASP numeric-id avoidance, and
operation-level security restrictions.

Single-branch verification: PASS 1/1 (29 matched, 0 missing, 0 unexpected)
— run https://github.com/camaraproject/ReleaseTest/actions/runs/24623600430

**Stacked on #190** — this PR contains the commit from #190
(`Pin 11 rules via regression/r4.1-broken-spec-descriptions`) plus the
new schema-constraints commit. GitHub's comparison against
`validation-framework` will show both commits until #190 merges.

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/camaraproject/ReleaseManagement/issues/483

#### Special notes for reviewers:

Schema-constraints was originally scoped for 10 rules (S-012, S-017, S-030,
S-300, S-303, S-308, S-309, S-310, S-311, S-312). Two rules were excluded
after investigation revealed upstream bugs in the custom Spectral function
implementations at `linting/config/lint_function/`:

- `camara-reserved-words.js` (S-012)
- `camara-security-no-secrets-in-path-or-query-parameters.js` (S-017)

Both use `console.log` to report matches but do not return an
`errors: [{ message, path }]` array, so Spectral emits no findings
regardless of input. Both rules are wired as `severity: warn` and
`recommended: true` but are effectively dormant. The branch's
[.regression/REGRESSION.md](https://github.com/camaraproject/ReleaseTest/blob/regression/r4.1-broken-spec-schema-constraints/.regression/REGRESSION.md)
documents the exclusion; separate rule-side fixes are needed before
either can be pinned.

#### Changelog input

 release-note
```
NONE
```

#### Additional documentation

 docs
```
NONE
```