### PR TITLE
Pin 11 rules via regression/r4.1-broken-spec-routing

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 65
+  total_tested: 76
   by_engine:
     spectral: 84
     gherkin: 25
@@ -311,9 +311,14 @@ tested_rules:
   P-004: [regression/r4.1-broken-spec-test-files]
   P-005: [regression/r4.1-broken-spec-test-files]
   P-006: [regression/r4.1-main-baseline]
+  S-002: [regression/r4.1-broken-spec-routing]
+  S-003: [regression/r4.1-broken-spec-routing]
   S-005: [regression/r4.1-broken-spec-yaml-fundamentals]
   S-006: [regression/r4.1-broken-spec-descriptions]
+  S-007: [regression/r4.1-broken-spec-routing]
+  S-008: [regression/r4.1-broken-spec-routing]
   S-009: [regression/r4.1-broken-spec-descriptions]
+  S-010: [regression/r4.1-broken-spec-routing]
   S-011: [regression/r4.1-broken-spec-descriptions]
   S-013: [regression/r4.1-broken-spec-descriptions]
   S-014: [regression/r4.1-broken-spec-descriptions]
@@ -337,10 +342,16 @@ tested_rules:
   S-211: [regression/r4.1-main-baseline]
   S-215: [regression/r4.1-broken-spec-descriptions]
   S-216: [regression/r4.1-broken-spec-descriptions]
+  S-217: [regression/r4.1-broken-spec-routing]
+  S-220: [regression/r4.1-broken-spec-routing]
   S-221: [regression/r4.1-broken-spec-error-handling]
+  S-222: [regression/r4.1-broken-spec-routing]
   S-223: [regression/r4.1-broken-spec-descriptions]
+  S-225: [regression/r4.1-broken-spec-routing]
+  S-227: [regression/r4.1-broken-spec-routing]
   S-300: [regression/r4.1-broken-spec-schema-constraints]
   S-303: [regression/r4.1-broken-spec-schema-constraints]
+  S-306: [regression/r4.1-broken-spec-routing]
   S-307: [regression/r4.1-broken-spec-error-handling]
   S-308: [regression/r4.1-broken-spec-schema-constraints]
   S-309: [regression/r4.1-broken-spec-schema-constraints]


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Add S-002, S-003, S-007, S-008, S-010, S-217, S-220, S-222, S-225, S-227, S-306
to `tested_rules` in `validation/rules/rule-inventory.yaml` and update
`total_tested` from 65 to 76.

Branch 6 of the 7+1-branch broken-spec regression roadmap. The corresponding
broken-spec branch on `camaraproject/ReleaseTest` introduces 10 surgical edits
to `code/API_definitions/sample-service.yaml` targeting routing concerns:
path naming (kebab-case), HTTP method discipline (no body on GET/DELETE,
allowed-method set), operationId conventions (camelCase, uniqueness), path
parameter declaration, tags (singular, defined), and server URL protocol
(HTTPS-only).

Single-branch verification: PASS 1/1 — https://github.com/camaraproject/ReleaseTest/actions/runs/24625648816

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/camaraproject/ReleaseManagement/issues/483

#### Special notes for reviewers:

- The rule surface (paths, operationIds, parameters, server URLs) is stable
  across r4.1 -> r4.2.
- S-008 fires twice: on `/resources/` (the trailing-slash path also fails the
  kebab-case regex because the pattern requires content between slashes) and
  on `/Widgets/{widgetId}` (PascalCase first segment). The trailing-slash path
  is the primary trigger for S-225; the S-008 cascade is structural.
- One rule originally planned was dropped: **S-224** /
  `path-declarations-must-exist`. The Spectral rule actually checks for empty
  parameter declarations (`/path/{}`), not for missing parameter definitions
  (which is S-227's territory). Pinning S-224 would require introducing an
  empty `{}` parameter, which also fails `oas3-schema` validation.
- Cascades into already-pinned rules (S-024 / S-307 / S-318) come from the new
  `trace:` and `getWidget` operations missing 401/403/422 responses -- expected
  and recorded in the captured fixture.

#### Changelog input

```
 release-note

 NONE
```

#### Additional documentation

```
docs

NONE
```
