### PR TITLE
docs(release-automation): document common cache sync + refresh caller docs

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -199,7 +199,8 @@ jobs:
             }
 
             // ─────────────────────────────────────────────────────────────────
-            // Event: push (release-plan.yaml or code/common changes on main)
+            // Event: push (release-plan.yaml, code/common, or the caller
+            // workflow itself changed on main)
             // ─────────────────────────────────────────────────────────────────
             else if (eventName === 'push') {
               // Classify by which paths changed

--- a/release_automation/docs/repository-setup.md
+++ b/release_automation/docs/repository-setup.md
@@ -1,6 +1,6 @@
 # Repository Setup for Release Automation
 
-**Last Updated**: 2026-03-01
+**Last Updated**: 2026-04-19
 
 ## Overview
 
@@ -8,7 +8,7 @@ API repositories that adopt the CAMARA release automation need specific reposito
 
 This document defines the required configuration for each API repository. It serves as the **specification** that the automated onboarding tooling implements — repository administrators do not need to apply or verify this configuration manually.
 
-**Automated application**: The [release automation onboarding campaign](https://github.com/camaraproject/project-administration/pull/134) in `project-administration` applies the full configuration to API repositories. It includes a campaign workflow (caller workflow, CHANGELOG structure, CODEOWNERS adjustments) and an admin script (repository ruleset). Both support dry-run/plan modes and phased rollout — test repositories first, then volunteering repos, then all.
+**Automated application**: The `campaign-release-automation-onboarding` campaign in [`camaraproject/project-administration`](https://github.com/camaraproject/project-administration) applies the full configuration to API repositories. It installs both the release-automation caller workflow and the CAMARA Validation caller workflow side-by-side, sets up the CHANGELOG directory structure, and uses a stable reconciliation branch so repeated runs update the same PR rather than creating new ones. A separate admin script (`apply-release-rulesets.sh`) applies the repository rulesets. Both support dry-run / plan modes and phased rollout — test repositories first, then volunteering repos, then all.
 
 **New repositories**: After rollout, the configuration will also be applied to `Template_API_Repository` ([camaraproject/tooling#82](https://github.com/camaraproject/tooling/issues/82)), so that newly created API repositories inherit it automatically.
 
@@ -26,7 +26,8 @@ This document defines the required configuration for each API repository. It ser
 |------|---------|---------|
 | Repository ruleset | Branch protection for snapshot branches | [Ruleset](#repository-ruleset) |
 | CODEOWNERS file | Codeowner assignment for `/publish-release` authorization | [CODEOWNERS](#codeowners-requirements) |
-| Caller workflow file | Entry point that connects the repo to the automation | [Caller Workflow](#caller-workflow) |
+| Release-automation caller workflow | Entry point that connects the repo to the release automation | [Caller Workflows](#caller-workflows) |
+| CAMARA Validation caller workflow | Entry point that connects the repo to the validation framework | [Caller Workflows](#caller-workflows) |
 | `release-plan.yaml` | Release configuration (target tag, type, APIs) | [Required Files](#required-files) |
 | README delimiters | Release Information section markers | [Required Files](#required-files) |
 | CHANGELOG structure | Directory layout for per-cycle changelog files | [CHANGELOG Structure](#changelog-structure) |
@@ -297,49 +298,47 @@ The `/publish-release` command checks CODEOWNERS to authorize the publishing use
 
 ---
 
-## Caller Workflow
+## Caller Workflows
 
-The caller workflow is the entry point that connects an API repository to the release automation. It is a static YAML file installed at `.github/workflows/release-automation.yml`.
+API repositories carry **two** caller workflows installed side-by-side by the onboarding campaign:
 
-### Source template
+| Caller file | Connects to | Canonical template in `camaraproject/tooling` |
+|-------------|-------------|------------------------------------------------|
+| `.github/workflows/release-automation.yml` | Release automation | `release_automation/workflows/release-automation-caller.yml` |
+| `.github/workflows/camara-validation.yml` | Validation framework | `validation/workflows/validation-caller.yml` |
 
-The canonical caller workflow template is maintained in the tooling repository:
-
-```
-camaraproject/tooling (release-automation branch)
-  └── release_automation/workflows/release-automation-caller.yml
-```
-
-The onboarding campaign reads this file and copies it to each target repository. Do not maintain separate copies — the template in `tooling` is the single source of truth.
+Both are static files. The onboarding / reconciliation campaign reads them from the tooling repository and copies them into each target repo — do not maintain separate copies.
 
 ### Reference lifecycle
 
-The caller's `uses:` line references the reusable workflow in `camaraproject/tooling`. The reference changes as the automation progresses through rollout phases:
+The callers' `uses:` lines reference reusable workflows in `camaraproject/tooling` via a floating tag. The current RC period uses the unified `@v1-rc` tag for both callers; GA will switch both to `@v1`. See [branching-model.md](branching-model.md) for the full phase model, tag strategy, and how callers transition between refs.
 
-| Phase | `uses:` ref | Who uses it |
-|-------|-------------|-------------|
-| Alpha | `@release-automation` | Test repositories |
-| RC | `@ra-v1-rc` | Test + volunteering repos |
-| GA | `@v1` | All API repositories |
+Transitions between refs are applied by re-dispatching the reconciliation campaign with the new ref inputs — each repo gets a single update PR on the stable reconciliation branch.
 
-See [branching-model.md](branching-model.md) for the full lifecycle and tag strategy.
+### Release automation caller
 
-When transitioning between phases, a campaign updates the `uses:` line across all participating repositories.
-
-### Key configuration in the caller
+Installed at `.github/workflows/release-automation.yml`. Key configuration:
 
 | Aspect | Value | Purpose |
 |--------|-------|---------|
-| **Permissions** | `contents: write`, `issues: write`, `pull-requests: write`, `id-token: write` | Branch/release ops, issue management, PR creation, OIDC claim access for called-workflow repo/SHA resolution |
+| **Permissions** | `contents: write`, `issues: write`, `pull-requests: write`, `id-token: write` | Branch / release ops, issue management, PR creation, OIDC claim access for tooling checkout consistency |
 | **Concurrency** | `release-automation-${{ github.repository }}`, `cancel-in-progress: false` | Serialize runs, prevent race conditions |
-| **Triggers** | `issue_comment`, `issues`, `pull_request`, `push`, `workflow_dispatch` | Slash commands, lifecycle events, auto-sync, manual |
+| **Triggers** | `issue_comment`, `issues`, `pull_request` (on `release-snapshot/**`), `push` (on `main`), `workflow_dispatch` | Slash commands, lifecycle events, auto-sync, manual |
 
-For break-glass or testing, the caller can set `with.tooling_ref_override` in the workflow file.
-This requires committing a workflow file change in the target repository.
-The value must be a full 40-character SHA.
+**Push-path filter on main** (controls when the caller auto-fires):
+- `release-plan.yaml` — triggers sync-issue (release configuration changed)
+- `code/common/**` — triggers sync-issue + common-cache sync handler (cache updated for repos on `commonalities_release >= r4.2`)
+- `.github/workflows/release-automation.yml` — triggers sync-issue so a caller update is picked up immediately after merge
 
-No caller-side repository override is needed for fork testing: the reusable workflow derives the
-tooling repository from OIDC claim `job_workflow_ref`.
+### CAMARA Validation caller
+
+Installed at `.github/workflows/camara-validation.yml`. Runs validation on PRs and on `workflow_dispatch`. Controlled centrally by the stage setting in the validation framework's per-repo config file — repos at stage `disabled` have the caller installed but the reusable workflow exits immediately. See the validation framework documentation for stage semantics.
+
+### Reusable-workflow checkout consistency
+
+Both reusable workflows derive their tooling checkout (Python scripts, shared actions) from OIDC claims on the caller's `id-token: write` — guaranteeing that helper code ships from the same repository + commit as the workflow itself, even when callers reference floating tags such as `@v1-rc` or `@v1`.
+
+For break-glass or testing, the release-automation caller can set `with.tooling_ref_override` to a full 40-character SHA. No caller-side repository override is needed for fork testing — OIDC handles it.
 
 ---
 
@@ -452,16 +451,6 @@ A follow-up campaign moves the legacy content from root `CHANGELOG.md` into the 
 
 ---
 
-## Recommended Enhancements
-
-### Configuration drift protection
-
-When a release snapshot is active, changes to `release-plan.yaml` on `main` can cause the snapshot to diverge from the current configuration. The release automation includes a post-merge warning (config drift warning posted to the Release Issue), but does not block the PR.
-
-For stronger protection, the `pr_validation` workflow can be extended to block PRs that modify `release-plan.yaml` when a `release-snapshot/*` branch exists. This is tracked as [camaraproject/tooling#63](https://github.com/camaraproject/tooling/issues/63) and can be implemented independently on the `main` branch (pr_validation v0).
-
----
-
 ## Verification Checklist
 
 Use this checklist to verify that a repository is correctly configured for release automation. This is the acceptance checklist for test repo setup.
@@ -489,12 +478,18 @@ Use this checklist to verify that a repository is correctly configured for relea
 - [ ] First `*` line lists at least one individual codeowner (`@username`)
 - [ ] `/CHANGELOG.md` and/or `/CHANGELOG.MD` lines present with `@camaraproject/release-management_reviewers`
 
-### Caller Workflow
+### Caller Workflows
 
+Release automation caller:
 - [ ] `.github/workflows/release-automation.yml` exists
-- [ ] `uses:` line references correct org/repo/ref for current phase
-- [ ] `permissions:` includes `contents: write`, `issues: write`, `pull-requests: write`
+- [ ] `uses:` line references correct org/repo/ref for current phase (see [branching-model.md](branching-model.md))
+- [ ] `permissions:` includes `contents: write`, `issues: write`, `pull-requests: write`, `id-token: write`
 - [ ] `concurrency:` group is `release-automation-${{ github.repository }}`
+- [ ] `push.paths` includes `release-plan.yaml`, `code/common/**`, and `.github/workflows/release-automation.yml`
+
+Validation caller:
+- [ ] `.github/workflows/camara-validation.yml` exists
+- [ ] `uses:` line references the validation reusable workflow at the correct ref
 
 ### Required Files
 

--- a/release_automation/docs/technical-architecture.md
+++ b/release_automation/docs/technical-architecture.md
@@ -511,7 +511,7 @@ Creates a sync PR to main after release publication.
 
 ### 2.13 Common Cache Sync
 
-Keeps `code/common/` in sync with the Commonalities release declared under `dependencies.commonalities_release` in `release-plan.yaml`. Only active for repositories declaring `commonalities_release >= r4.2` (earlier releases do not consume common files via `$ref`).
+Keeps `code/common/` in sync with the Commonalities release declared under `dependencies.commonalities_release` in `release-plan.yaml`. The handler runs on every `update-issue` pass. For repositories declaring `commonalities_release >= r4.2` it checks the cache and acts on drift; for earlier releases (which don't consume common files via `$ref`) it reports `common_cache_status = ""` (unchecked) and exits without action.
 
 **Handler location:** Embedded in the `update-issue` job of [release-automation-reusable.yml](../../.github/workflows/release-automation-reusable.yml) rather than a standalone job, so the cache converges on every RA invocation that reaches update-issue (push, `workflow_dispatch`, slash commands ending in a state update).
 

--- a/release_automation/docs/technical-architecture.md
+++ b/release_automation/docs/technical-architecture.md
@@ -509,6 +509,54 @@ Creates a sync PR to main after release publication.
 
 ---
 
+### 2.13 Common Cache Sync
+
+Keeps `code/common/` in sync with the Commonalities release declared under `dependencies.commonalities_release` in `release-plan.yaml`. Only active for repositories declaring `commonalities_release >= r4.2` (earlier releases do not consume common files via `$ref`).
+
+**Handler location:** Embedded in the `update-issue` job of [release-automation-reusable.yml](../../.github/workflows/release-automation-reusable.yml) rather than a standalone job, so the cache converges on every RA invocation that reaches update-issue (push, `workflow_dispatch`, slash commands ending in a state update).
+
+**Signal model:** The `derive-state` job outputs `common_cache_status` with three values:
+
+| Value | Meaning |
+|-------|---------|
+| `""` | Unchecked — repo declares commonalities `< r4.2` or has no cache yet |
+| `in_sync` | Cache matches the declared tag |
+| `stale` | Drift detected (tag mismatch, missing files, or modified files); `common_cache_details` carries the reason |
+
+**Trigger x state matrix:** Sync-PR creation is state-dependent to avoid mixing concerns with an active release:
+
+| Release state | Push to `release-plan.yaml` or `code/common/**` | `/create-snapshot` | `/discard-snapshot` or `/delete-draft` | `workflow_dispatch` |
+|---------------|------------------------------------------------|--------------------|---------------------------------------|---------------------|
+| `NOT_PLANNED` / `PLANNED` / `PUBLISHED` | Create / update sync PR | Block (command rejected when stale) | n/a | Create / update sync PR |
+| `SNAPSHOT_ACTIVE` / `DRAFT_READY` | Drift warning in Release Issue only | n/a | Create / update sync PR | Create / update sync PR |
+
+**Sync PR model:**
+- Branch: `sync-common/{tag}` (e.g., `sync-common/r4.2`)
+- Author: `camara-release-automation` App bot
+- No force-push — codeowners may push fix commits to the PR before merge
+- Stale PRs (wrong tag after a dependency bump) are closed automatically when a new sync is needed
+- Standard CODEOWNERS review applies (one codeowner approval is sufficient; bot is author)
+
+**Data contracts:**
+- [`code/common/.sync-manifest.yaml`](../../validation/schemas/sync-manifest-schema.yaml) — records source repository (Commonalities), declared release tag, and per-file git blob SHA-1. Written by the RA sync handler; read by both RA (`derive-state` drift detection) and the validation framework (`P-021 check-common-cache-sync`).
+- [`tooling_lib/cache_sync.py`](../../tooling_lib/cache_sync.py) — shared drift-detection logic (`SyncStatus`, `SourceStatus`, `check_sync_status`, `git_blob_sha`). Imported by both RA and VF so they produce identical verdicts.
+
+**Notifications:**
+- `common_sync_pr_created.md` — bot comment on the Release Issue when a new sync PR is created (fires once per creation, not once per stale-detection)
+- `common_sync_failed.md` — bot comment when checkout from Commonalities fails (for example, the declared tag has not yet been published)
+- The Release Issue config section shows the `stale` warning on every sync-issue update until the cache converges
+
+**Boundary with validation framework:**
+- RA owns detection and repair (writes common files, creates/updates sync PR, writes manifest)
+- VF's `P-021 check-common-cache-sync` is a read-only safety net. It fires only when codeowners bypass the sync process (e.g., direct edits to `code/common/`) — the design expects it to be silent in normal operation
+- The `camara-release-automation` App has `contents: write`; the `camara-validation` App deliberately does not
+
+**References:**
+- [Commonalities-Consumption-and-Bundling-Design.md §4](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/SupportingDocuments/Commonalities-Consumption-and-Bundling-Design.md) — cache and sync model
+- Upstream tracking: [ReleaseManagement#489](https://github.com/camaraproject/ReleaseManagement/issues/489)
+
+---
+
 ## 3. Workflow Architecture
 
 ### 3.1 Event Flow

--- a/release_automation/workflows/release-automation-caller.yml
+++ b/release_automation/workflows/release-automation-caller.yml
@@ -9,10 +9,11 @@
 # - Slash commands: /create-snapshot, /discard-snapshot, /delete-draft, /publish-release
 # - Issue events: close (with auto-reopen), reopen
 # - PR merge: on release-snapshot branches (creates draft release)
-# - Push to main: when release-plan.yaml, code/common/**, or this caller
-#   workflow itself change. release-plan.yaml and the caller trigger sync-issue;
-#   code/common/** additionally triggers the common-cache sync handler for
-#   repos declaring commonalities_release >= r4.2.
+# - Push to main: on release-plan.yaml, code/common/**, or this caller
+#   workflow itself. All three paths end up running sync-issue so the
+#   Release Issue body reflects the current repo state — most notably,
+#   pushing to code/common/** (typically after a sync PR merge) refreshes
+#   the common-cache status in the Release Issue and clears any stale warning.
 # - Manual: workflow_dispatch triggers sync-issue (reads from release-plan.yaml)
 
 name: CAMARA Release Automation

--- a/release_automation/workflows/release-automation-caller.yml
+++ b/release_automation/workflows/release-automation-caller.yml
@@ -9,7 +9,10 @@
 # - Slash commands: /create-snapshot, /discard-snapshot, /delete-draft, /publish-release
 # - Issue events: close (with auto-reopen), reopen
 # - PR merge: on release-snapshot branches (creates draft release)
-# - Push to main: when release-plan.yaml changes (auto sync-issue)
+# - Push to main: when release-plan.yaml, code/common/**, or this caller
+#   workflow itself change. release-plan.yaml and the caller trigger sync-issue;
+#   code/common/** additionally triggers the common-cache sync handler for
+#   repos declaring commonalities_release >= r4.2.
 # - Manual: workflow_dispatch triggers sync-issue (reads from release-plan.yaml)
 
 name: CAMARA Release Automation
@@ -29,10 +32,15 @@ on:
     branches:
       - 'release-snapshot/**'
 
-  # Push to main with release-plan.yaml or common file changes (auto sync-issue)
+  # Push to main with release-plan.yaml, common file, or caller workflow changes.
+  # Listing the caller itself as a path ensures the workflow runs once right
+  # after it is merged (future caller updates pick up their own trigger).
   push:
     branches: [main]
-    paths: ['release-plan.yaml', 'code/common/**']
+    paths:
+      - 'release-plan.yaml'
+      - 'code/common/**'
+      - '.github/workflows/release-automation.yml'
 
   # Manual trigger for sync-issue only
   # Use this for: initial setup, recovery after manual repo changes, or forced sync


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Documents the common-cache-sync handler that went live recently and refreshes the release-automation setup docs to match what's actually deployed today. Also adds the caller workflow itself to its own push-path filter so that future caller updates pick up their own trigger on merge.

**Caller template** (`release_automation/workflows/release-automation-caller.yml`):
- Header trigger comment now mentions `code/common/**` and the common-cache handler.
- `push.paths` gains `.github/workflows/release-automation.yml` — when a reconciliation campaign lands a caller update, the next automatic sync-issue run picks up right after merge. First merge from the pre-trigger state still needs one manual dispatch.

**`release_automation/docs/technical-architecture.md`**:
- New section **2.13 Common Cache Sync** — purpose, handler location, signal model (`common_cache_status`: empty / `in_sync` / `stale`), trigger x state matrix, sync PR model (`sync-common/{tag}` branch, no force-push), data contracts (`.sync-manifest.yaml` + `tooling_lib/cache_sync.py`), notifications, and the boundary with the validation framework's `P-021 check-common-cache-sync` safety net.
- References the bundling design document (ReleaseManagement) and the upstream tracking issue.

**`release_automation/docs/repository-setup.md`**:
- Overview now describes the current onboarding campaign (installs both RA caller and CAMARA Validation caller, uses a stable reconciliation branch).
- New **Caller Workflows** section (was **Caller Workflow**) covers both files side-by-side with their templates, refs, and the full push-path filter.
- Drops the outdated reference-lifecycle table (defer to `branching-model.md` which is kept up to date).
- Drops the `pr_validation v0`-era "Configuration drift protection" recommendation — addressed by the validation framework.
- Verification checklist updated for both callers and the new push paths.

**`.github/workflows/release-automation-reusable.yml`**:
- Single-comment edit to the push-trigger classification block to mention the caller-self path alongside the existing `release-plan.yaml` and `code/common/`.

#### Which issue(s) this PR fixes:

n/a — supports camaraproject/ReleaseManagement#489 (common-cache sync) and #484 (stage flip & pilot feedback).

#### Special notes for reviewers:

- Targets `validation-framework` — the new caller-self push path matches the ref consumers reference today (`@v1-rc`).
- No behaviour change to the reusable workflow code (only a comment). The caller-template change adds a new push event that wasn't firing before; the push-classification logic in `release-automation-reusable.yml` already handles it correctly (non-release-plan pushes → `push` trigger type → `sync-issue`).
- Docs-only change otherwise; no test impact.

#### Changelog input

```
 release-note
 none
```

#### Additional documentation

n/a

```
docs
none
```