### PR TITLE
fix: validate-command crashes with SyntaxError on every slash command

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -738,7 +738,8 @@ jobs:
               return;
             }
 
-            // Block /create-snapshot when common file cache is stale            if (command === 'create-snapshot') {
+            // Block /create-snapshot when common file cache is stale
+            if (command === 'create-snapshot') {
               const cacheStatus = '${{ needs.derive-state.outputs.common_cache_status }}';
               const cacheDetails = '${{ needs.derive-state.outputs.common_cache_details }}';
               const syncPrUrl = '${{ needs.derive-state.outputs.common_sync_pr_url }}';


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes a parse-time `SyntaxError: Unexpected identifier 'console'` in `validate-command` that blocks every slash command on Release Issues for repos pinned to `@v1-rc` or the `validation-framework` branch tip.

A `//` comment and the following `if (command === 'create-snapshot') {` were on the same line in `.github/workflows/release-automation-reusable.yml`. The comment extends to EOL, so the guarded block never opened and the matching `}` prematurely closed the `AsyncFunction` wrapper that `actions/github-script` builds around the script body.

One-line fix: insert a newline between the comment and the `if`.

#### Which issue(s) this PR fixes:

Fixes #196

#### Special notes for reviewers:

Reproduced on `camaraproject/ReleaseTest` #86 (run 24651924901) and `camaraproject/IoTSIMFraudPrevention` #31 (run 24645069881).

`v1-rc` tag should be moved forward to include this commit once merged.

#### Changelog input

```
 release-note
Fix release-automation `validate-command` parse error that blocked all slash commands on repos pinned to `@v1-rc`.
```

#### Additional documentation

This section can be blank.

```
docs
None
```