### PR TITLE
fix: add tooling_lib to create-snapshot sparse-checkout

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -950,6 +950,7 @@ jobs:
             shared-actions/run-validation
             validation
             linting/config
+            tooling_lib
 
       # ── Pre-snapshot validation ────────────────────────────────────
       #


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The `create-snapshot` job's sparse-checkout omitted `tooling_lib`, so pre-snapshot validation crashed with `ModuleNotFoundError: No module named 'tooling_lib'` at Python-checks registry import — taking down every Python check, not just P-021.

Sibling jobs `derive-state` and `update-issue` already include `tooling_lib`. One-line fix: add the same entry to `create-snapshot`.

#### Which issue(s) this PR fixes:

None — proactive fix surfaced during canary verification.

#### Special notes for reviewers:

Reproduced on `camaraproject/ReleaseTest` #86 (run 24652312387) after `validate-command` was fixed in #197. The failing run showed every Python check failing at registry import because `python_checks/__init__.py` unconditionally imports `common_cache_checks`, which imports `tooling_lib.cache_sync` at module top.

`v1-rc` tag should be moved forward to include this commit once merged and end-to-end `/create-snapshot` is verified on ReleaseTest.

#### Changelog input

```
 release-note
Fix release-automation `create-snapshot` job crash when Python validation checks import `tooling_lib` — add `tooling_lib` to the sparse-checkout.
```

#### Additional documentation

```
docs
None
```