### PR TITLE
fix(validation): gate P-015/P-020 to r4.2 and fix r3.4 casing rule

### DIFF
--- a/linting/config/.spectral-r3.4.yaml
+++ b/linting/config/.spectral-r3.4.yaml
@@ -15,6 +15,7 @@ functions:
   - camara-reserved-words
   - camara-language-avoid-telco
   - camara-security-no-secrets-in-path-or-query-parameters
+  - camara-schema-casing-convention
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -250,14 +251,17 @@ rules:
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-schema-casing-convention:
-    description: This rule checks schema should follow a specific case convention pascal case.
-    message: "{{property}} should be pascal case (UppperCamelCase)"
+    description: >
+      Schema names must be PascalCase (UpperCamelCase). CloudEvents schema
+      names (HTTPSettings, MQTTSettings, AMQPSettings, NATSSettings and their
+      SubscriptionRequest/SubscriptionResponse counterparts, plus
+      PrivateKeyJWTCredential) are allowed as explicit exceptions to stay
+      aligned with upstream CloudEvents naming.
+    message: "{{error}}"
     severity: warn
     given: $.components.schemas[*]~
     then:
-      function: casing
-      functionOptions:
-        type: pascal
+      function: camara-schema-casing-convention
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-parameter-casing-convention:

--- a/linting/config/lint_function/camara-schema-casing-convention.js
+++ b/linting/config/lint_function/camara-schema-casing-convention.js
@@ -7,6 +7,15 @@ const ALLOWED = new Set([
   "HTTPSettings",
   "HTTPSubscriptionRequest",
   "HTTPSubscriptionResponse",
+  "MQTTSettings",
+  "MQTTSubscriptionRequest",
+  "MQTTSubscriptionResponse",
+  "AMQPSettings",
+  "AMQPSubscriptionRequest",
+  "AMQPSubscriptionResponse",
+  "NATSSettings",
+  "NATSSubscriptionRequest",
+  "NATSSubscriptionResponse",
   "PrivateKeyJWTCredential",
 ]);
 

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -146,19 +146,20 @@
 
 # P-015: check-event-type-format (DG-086)
 # Event types must follow org.camaraproject.<api-name>.<vN>.<event-name>.
+# Gated to Commonalities >=r4.2, where the named ApiEventType schema
+# pattern (via $ref to CAMARA_event_common.yaml) is established and the
+# hint below is actionable.
 #
 # Level is conditional on api_pattern:
-#   - explicit-subscription: error (named EventType schema expected today)
-#   - implicit-subscription: warn (r4.1-era specs often inline the enum at
-#     CloudEvent.properties.type.enum, which the detector cannot see; the
-#     r4.2 migration path replaces inline CloudEvent with a $ref to
-#     CAMARA_event_common.yaml and a named ApiEventType schema, at which
-#     point this rule detects the event type correctly).
+#   - explicit-subscription: error
+#   - implicit-subscription: warn (conservative during migration to the
+#     named ApiEventType pattern)
 - id: P-015
   engine: python
   engine_rule: check-event-type-format
   applicability:
     api_pattern: [explicit-subscription, implicit-subscription]
+    commonalities_release: ">=r4.2"
   conditional_level:
     default: error
     overrides:
@@ -216,11 +217,13 @@
 # Detection: components.schemas.CloudEvent exists with top-level
 # `properties`. The $ref-only and `allOf: [{$ref: ...}]` forms have no
 # top-level `properties` and are not flagged.
+# Gated to Commonalities >=r4.2, where CAMARA_event_common.yaml exists.
 - id: P-020
   engine: python
   engine_rule: check-cloudevent-via-ref
   applicability:
     api_pattern: [explicit-subscription, implicit-subscription]
+    commonalities_release: ">=r4.2"
   conditional_level:
     default: warn
   hint: >-

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -318,10 +318,8 @@ class TestMetadataQuality:
     def test_p015_conditional_on_api_pattern(self, rule_index):
         """P-015 stays error on explicit-subscription, warn on implicit.
 
-        Implicit-subscription APIs using the r4.1-era inline CloudEvent
-        pattern (enum at CloudEvent.properties.type.enum) cannot be
-        detected by the check, so the rule downgrades to warn until the
-        r4.2 migration to $ref + named ApiEventType schema is complete.
+        Implicit-subscription APIs remain at warn as a conservative level
+        during migration to the named ApiEventType pattern.
         """
         rule = rule_index[("python", "check-event-type-format")]
         assert rule.id == "P-015"


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Two corrections surfaced while onboarding `camaraproject/IoTSIMFraudPrevention`
(commonalities_release r3.4) to the validation framework.

- **P-015 / P-020**: both rules' findings and hints reference artifacts
  introduced only in Commonalities r4.2 (the implicit-events template and
  `CAMARA_event_common.yaml`). Gate them to `commonalities_release: ">=r4.2"`
  so they don't change validation behavior for r3.4 repositories. `P-016`
  is deliberately kept for r3.4 — it encodes a security property that
  applies to both version lines.

- **camara-schema-casing-convention (S-015)**: the r3.4 ruleset still used
  the strict built-in `casing: pascal`, which rejects standard CloudEvents
  transport schemas (`HTTPSettings`, `MQTTSettings`, …). Switch it to the
  custom function already used by the r4 ruleset and extend the allowlist
  with the MQTT / AMQP / NATS variants.

#### Which issue(s) this PR fixes:

Fixes #200
Fixes #201

#### Special notes for reviewers:

Verified on `camaraproject/IoTSIMFraudPrevention` (run 24658792816): these
changes drop 5 errors + 14 warnings of noise from the current r3.4 output
without affecting genuine findings. Full validation test suite (861/861)
still passes.

#### Changelog input

```
 release-note
P-015 and P-020 are now gated to Commonalities >=r4.2.
Spectral rule camara-schema-casing-convention on the r3.4 ruleset no longer
false-positives on CloudEvents transport schemas.
```

#### Additional documentation

```
docs
none
```