### PR TITLE
feat(release-automation): flat CHANGELOG.md fallback for maintenance releases

### DIFF
--- a/release_automation/docs/repository-setup.md
+++ b/release_automation/docs/repository-setup.md
@@ -392,16 +392,31 @@ The delimiters are distributed by the `campaign-release-info` campaign in `proje
 
 ## CHANGELOG Structure
 
-The release automation uses a per-cycle directory structure for changelog files:
+The release automation supports two CHANGELOG layouts on the same discriminator:
 
-```
-CHANGELOG/
-  CHANGELOG-r1.md   # All releases in cycle 1 (r1.1, r1.2, ...)
-  CHANGELOG-r2.md   # All releases in cycle 2 (r2.1, r2.2, ...)
-  README.md          # Index pointing to available files and legacy CHANGELOG.md
-```
+- **Per-cycle** (default): `CHANGELOG/CHANGELOG-r{cycle}.md` — one file per release cycle, with newest entries prepended. Used for every release type except maintenance, and for maintenance releases once a per-cycle file for the target cycle already exists.
 
-Each `/create-snapshot` command generates a release section in the appropriate per-cycle file. Multiple releases within the same cycle (e.g., r4.1 alpha, r4.1 RC, r4.2) accumulate in the same file with newest entries at the top.
+  ```
+  CHANGELOG/
+    CHANGELOG-r1.md   # All releases in cycle 1 (r1.1, r1.2, ...)
+    CHANGELOG-r2.md   # All releases in cycle 2 (r2.1, r2.2, ...)
+    README.md         # Index pointing to available files and legacy CHANGELOG.md
+  ```
+
+- **Flat** (fallback for pre-automation maintenance releases): root `CHANGELOG.md` — new section prepended before the first `# r...` heading; manual TOC is replaced by an automation-managed TOC on first write.
+
+### Discriminator
+
+`write_changelog()` and `_sync_changelog()` apply the same rule:
+
+> If `release_type == "maintenance-release"` AND `CHANGELOG/CHANGELOG-r{cycle}.md` does **not** exist → write flat `CHANGELOG.md`. Otherwise → write `CHANGELOG/CHANGELOG-r{cycle}.md` (creating the `CHANGELOG/` directory if needed).
+
+Effect:
+
+- New release cycles on any repo land in `CHANGELOG/CHANGELOG-r{cycle}.md`.
+- Maintenance releases on repos that have not yet migrated their legacy history keep writing to the existing flat `CHANGELOG.md` until `/migrate-changelog` splits the history into per-cycle files. After migration, subsequent maintenance releases for those cycles prepend to the per-cycle file.
+
+The same rule drives the CHANGELOG URL rendered into the README release-info section: flat writes point to `blob/main/CHANGELOG.md`, per-cycle writes point to `tree/main/CHANGELOG`.
 
 ### Onboarding: CHANGELOG.md handling
 
@@ -498,8 +513,8 @@ Validation caller:
 
 ### CHANGELOG Structure
 
-- [ ] `CHANGELOG/README.md` exists as index file
-- [ ] Root `CHANGELOG.md` either: has forward-reference note (repos with history), or is deleted (repos with unchanged template placeholder)
+- [ ] The repo has a live changelog on `main` — either `CHANGELOG/README.md` plus per-cycle `CHANGELOG/CHANGELOG-r{cycle}.md` files (per-cycle mode, default), or a flat root `CHANGELOG.md` (flat-mode fallback, acceptable for maintenance releases on repos that have not yet run `/migrate-changelog`)
+- [ ] Root `CHANGELOG.md` either: has forward-reference note (onboarded repos with legacy history), is the active flat changelog (not yet migrated), or is deleted (repos that were onboarded from the unchanged template placeholder)
 
 ### Smoke Test
 

--- a/release_automation/scripts/changelog_generator.py
+++ b/release_automation/scripts/changelog_generator.py
@@ -158,11 +158,23 @@ class ChangelogGenerator:
         return self.renderer.render(template_content, context)
 
     def write_changelog(
-        self, work_dir: str, content: str, release_tag: str, repo_name: str
+        self,
+        work_dir: str,
+        content: str,
+        release_tag: str,
+        repo_name: str,
+        release_type: str = "",
     ) -> str:
-        """Write CHANGELOG section to the appropriate per-cycle file.
+        """Write CHANGELOG section to the appropriate file.
 
-        File naming: r4.1 -> cycle 4 -> CHANGELOG/CHANGELOG-r4.md
+        Target selection (maintenance releases preserve legacy flat CHANGELOG.md
+        until the repo has been migrated to per-cycle via ``/migrate-changelog``):
+
+            if release_type == "maintenance-release" and
+               CHANGELOG/CHANGELOG-r{cycle}.md does NOT exist:
+                write to CHANGELOG.md at the repo root (flat mode)
+            else:
+                write to CHANGELOG/CHANGELOG-r{cycle}.md (per-cycle mode)
 
         Behavior:
             - If file exists: prepend new section after the header block
@@ -173,17 +185,17 @@ class ChangelogGenerator:
             content: Rendered release section content
             release_tag: Release tag for cycle extraction
             repo_name: Repository name for header generation
+            release_type: Release type from release-plan/metadata; used only
+                to enable flat-mode fallback for maintenance releases.
 
         Returns:
-            Relative path to the written file (e.g., "CHANGELOG/CHANGELOG-r4.md")
+            Relative path to the written file, e.g. ``CHANGELOG/CHANGELOG-r4.md``
+            (per-cycle) or ``CHANGELOG.md`` (flat).
         """
         cycle = self._get_cycle(release_tag)
-        changelog_dir = Path(work_dir) / "CHANGELOG"
-        changelog_dir.mkdir(exist_ok=True)
-
-        filename = f"CHANGELOG-r{cycle}.md"
-        filepath = changelog_dir / filename
-        relative_path = f"CHANGELOG/{filename}"
+        filepath, relative_path = self._resolve_changelog_path(
+            Path(work_dir), cycle, release_type
+        )
 
         if filepath.exists():
             existing = filepath.read_text()
@@ -200,6 +212,27 @@ class ChangelogGenerator:
         self._update_toc(filepath)
 
         return relative_path
+
+    @staticmethod
+    def _resolve_changelog_path(
+        work_dir: Path, cycle: str, release_type: str
+    ) -> Tuple[Path, str]:
+        """Pick flat vs per-cycle target for write_changelog().
+
+        Flat mode (``CHANGELOG.md`` at repo root) activates only when the
+        release is a maintenance release AND no per-cycle file exists yet
+        for the target cycle. Every other case uses per-cycle, and the
+        ``CHANGELOG/`` directory is created if missing.
+
+        Returns:
+            Tuple of (absolute Path to target file, relative path string).
+        """
+        per_cycle_file = work_dir / "CHANGELOG" / f"CHANGELOG-r{cycle}.md"
+        if release_type == "maintenance-release" and not per_cycle_file.exists():
+            return work_dir / "CHANGELOG.md", "CHANGELOG.md"
+
+        per_cycle_file.parent.mkdir(exist_ok=True)
+        return per_cycle_file, f"CHANGELOG/CHANGELOG-r{cycle}.md"
 
     def _find_header_end(self, content: str) -> int:
         """Find the position where release sections start in an existing file.

--- a/release_automation/scripts/post_release_syncer.py
+++ b/release_automation/scripts/post_release_syncer.py
@@ -150,10 +150,13 @@ class PostReleaseSyncer:
         target_branch: str,
         release_tag: str
     ) -> bool:
-        """Copy release-specific CHANGELOG from snapshot branch to target branch.
+        """Copy release CHANGELOG from snapshot branch to target branch.
 
-        Copies CHANGELOG/CHANGELOG-rX.md where X is the release cycle number
-        extracted from the release tag (e.g., r4.1 → CHANGELOG/CHANGELOG-r4.md).
+        Prefers the per-cycle file ``CHANGELOG/CHANGELOG-rX.md`` (where X is
+        the release cycle number from the release tag). Falls back to flat
+        ``CHANGELOG.md`` if the per-cycle file does not exist on the
+        snapshot branch (maintenance releases on repos that have not yet
+        migrated to per-cycle structure).
 
         Args:
             snapshot_branch: Source branch with release CHANGELOG
@@ -171,12 +174,19 @@ class PostReleaseSyncer:
             return False
 
         cycle = match.group(1)
-        changelog_path = f"CHANGELOG/CHANGELOG-r{cycle}.md"
+        per_cycle_path = f"CHANGELOG/CHANGELOG-r{cycle}.md"
+        flat_path = "CHANGELOG.md"
 
-        # Get CHANGELOG from snapshot branch
+        # Probe per-cycle first, fall back to flat CHANGELOG.md
+        changelog_path = per_cycle_path
         changelog_content = self.gh.get_file_content(changelog_path, ref=snapshot_branch)
         if not changelog_content:
-            logger.warning(f"No {changelog_path} found on {snapshot_branch}")
+            changelog_path = flat_path
+            changelog_content = self.gh.get_file_content(changelog_path, ref=snapshot_branch)
+        if not changelog_content:
+            logger.warning(
+                f"No {per_cycle_path} or {flat_path} found on {snapshot_branch}"
+            )
             return False
 
         # Write to target branch

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -877,9 +877,15 @@ class SnapshotCreator:
             for api_name, version in api_versions.items()
         ]
 
+        cycle_match = re.match(r"r(\d+)\.", config.release_tag)
+        cycle = cycle_match.group(1) if cycle_match else ""
+
         # Build data dict
         data = {
             "repo_name": repo_name,
+            "changelog_url": self._changelog_url(
+                temp_dir, org, repo_name, release_type, cycle
+            ),
         }
 
         if release_state in ("public_release", "public_with_prerelease"):
@@ -928,6 +934,29 @@ class SnapshotCreator:
         updater = ReadmeUpdater()
         return updater.update_release_info(readme_path, release_state, data)
 
+    @staticmethod
+    def _changelog_url(
+        temp_dir: str,
+        org: str,
+        repo_name: str,
+        release_type: str,
+        cycle: str,
+    ) -> str:
+        """Build the CHANGELOG link used in README release-info.
+
+        Mirrors the generator's dual-mode rule: a maintenance release
+        into a cycle with no per-cycle file writes flat ``CHANGELOG.md``
+        and the link points there. Every other case uses the per-cycle
+        ``CHANGELOG/`` directory tree view.
+        """
+        base = f"https://github.com/{org}/{repo_name}"
+        per_cycle_file = os.path.join(
+            temp_dir, "CHANGELOG", f"CHANGELOG-r{cycle}.md"
+        )
+        if release_type == "maintenance-release" and not os.path.isfile(per_cycle_file):
+            return f"{base}/blob/main/CHANGELOG.md"
+        return f"{base}/tree/main/CHANGELOG"
+
     def _generate_changelog(
         self,
         temp_dir: str,
@@ -970,7 +999,13 @@ class SnapshotCreator:
             repo_name=repo_name,
             candidate_changes=candidate_changes,
         )
-        return generator.write_changelog(temp_dir, content, config.release_tag, repo_name)
+        return generator.write_changelog(
+            temp_dir,
+            content,
+            config.release_tag,
+            repo_name,
+            release_type=release_type,
+        )
 
     def _cleanup_branches(
         self,

--- a/release_automation/templates/readme/release-info-prerelease-only.mustache
+++ b/release_automation/templates/readme/release-info-prerelease-only.mustache
@@ -7,6 +7,6 @@
 
 * The latest pre-release is [{{newest_prerelease}}]({{prerelease_github_url}}) ({{prerelease_type}}), with the following API versions:
 {{{formatted_prerelease_apis}}}
-* For changes see [CHANGELOG](https://github.com/camaraproject/{{repo_name}}/tree/main/CHANGELOG)
+* For changes see [CHANGELOG]({{changelog_url}})
 
 _The above section is automatically synchronized by CAMARA project-administration._

--- a/release_automation/templates/readme/release-info-public-with-prerelease.mustache
+++ b/release_automation/templates/readme/release-info-public-with-prerelease.mustache
@@ -9,7 +9,7 @@
 {{{formatted_apis}}}
 * The latest public release is always available here: https://github.com/camaraproject/{{repo_name}}/releases/latest
 * Other releases of this repository are available in https://github.com/camaraproject/{{repo_name}}/releases
-* For changes see [CHANGELOG](https://github.com/camaraproject/{{repo_name}}/tree/main/CHANGELOG)
+* For changes see [CHANGELOG]({{changelog_url}})
 
 ### Upcoming Release Preview
 

--- a/release_automation/templates/readme/release-info-public.mustache
+++ b/release_automation/templates/readme/release-info-public.mustache
@@ -9,6 +9,6 @@
 {{{formatted_apis}}}
 * The latest public release is always available here: https://github.com/camaraproject/{{repo_name}}/releases/latest
 * Other releases of this repository are available in https://github.com/camaraproject/{{repo_name}}/releases
-* For changes see [CHANGELOG](https://github.com/camaraproject/{{repo_name}}/tree/main/CHANGELOG)
+* For changes see [CHANGELOG]({{changelog_url}})
 
 _The above section is automatically synchronized by CAMARA project-administration._

--- a/release_automation/tests/test_changelog_generator.py
+++ b/release_automation/tests/test_changelog_generator.py
@@ -352,6 +352,176 @@ class TestFileWriting:
         assert "best results, use the latest published release" in header
 
 
+# --- File Writing: Dual-Mode (flat vs per-cycle) ---
+
+
+class TestFileWritingFlatMode:
+    """Flat-mode (CHANGELOG.md at repo root) activates only for maintenance
+    releases when no per-cycle file exists yet. Every other release type
+    stays on per-cycle even if a legacy flat CHANGELOG.md is present."""
+
+    def test_maintenance_release_with_no_cycle_file_writes_flat(self, generator, tmp_path):
+        content = "# r2.3\n\n## Release Notes\n\nMaintenance patch\n"
+        path = generator.write_changelog(
+            str(tmp_path),
+            content,
+            "r2.3",
+            "SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+        )
+        assert path == "CHANGELOG.md"
+        flat = tmp_path / "CHANGELOG.md"
+        assert flat.exists()
+        assert "# r2.3" in flat.read_text()
+        # No per-cycle directory should be created when writing flat
+        assert not (tmp_path / "CHANGELOG" / "CHANGELOG-r2.md").exists()
+
+    def test_maintenance_release_with_existing_cycle_file_uses_per_cycle(
+        self, generator, tmp_path
+    ):
+        # Pre-seed the per-cycle file
+        (tmp_path / "CHANGELOG").mkdir()
+        per_cycle = tmp_path / "CHANGELOG" / "CHANGELOG-r2.md"
+        per_cycle.write_text(
+            "# Changelog SimpleEdgeDiscovery\n\n"
+            "Recording rules...\n\n"
+            "# r2.2\n\n## Release Notes\n\nPrior public\n"
+        )
+        flat_before = "legacy content\n"
+        (tmp_path / "CHANGELOG.md").write_text(flat_before)
+
+        new_section = "# r2.3\n\n## Release Notes\n\nMaintenance patch\n"
+        path = generator.write_changelog(
+            str(tmp_path),
+            new_section,
+            "r2.3",
+            "SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+        )
+        assert path == "CHANGELOG/CHANGELOG-r2.md"
+        # Per-cycle file was updated (r2.3 prepended), flat file untouched
+        assert "# r2.3" in per_cycle.read_text()
+        assert (tmp_path / "CHANGELOG.md").read_text() == flat_before
+
+    def test_public_release_always_uses_per_cycle(self, generator, tmp_path):
+        # Flat CHANGELOG.md present, no CHANGELOG/ directory
+        (tmp_path / "CHANGELOG.md").write_text("legacy content\n")
+
+        content = "# r4.2\n\n## Release Notes\n\nPublic\n"
+        path = generator.write_changelog(
+            str(tmp_path),
+            content,
+            "r4.2",
+            "QualityOnDemand",
+            release_type="public-release",
+        )
+        assert path == "CHANGELOG/CHANGELOG-r4.md"
+        assert (tmp_path / "CHANGELOG" / "CHANGELOG-r4.md").exists()
+
+    def test_pre_release_rc_always_uses_per_cycle(self, generator, tmp_path):
+        (tmp_path / "CHANGELOG.md").write_text("legacy content\n")
+
+        content = "# r4.1\n\n## Release Notes\n\nRC\n"
+        path = generator.write_changelog(
+            str(tmp_path),
+            content,
+            "r4.1",
+            "QualityOnDemand",
+            release_type="pre-release-rc",
+        )
+        assert path == "CHANGELOG/CHANGELOG-r4.md"
+
+    def test_empty_release_type_defaults_to_per_cycle(self, generator, tmp_path):
+        (tmp_path / "CHANGELOG.md").write_text("legacy content\n")
+
+        content = "# r4.1\n\n## Release Notes\n\nNo type\n"
+        path = generator.write_changelog(
+            str(tmp_path), content, "r4.1", "QualityOnDemand"
+        )
+        assert path == "CHANGELOG/CHANGELOG-r4.md"
+
+    def test_flat_write_prepends_before_first_release_heading(self, generator, tmp_path):
+        # Shape mirrors SimpleEdgeDiscovery's CHANGELOG.md:
+        # title + manual TOC + NOTE + preamble + release sections
+        legacy = (
+            "# Changelog Simple Edge Discovery\n\n"
+            "NOTE: \n\n"
+            "## Table of contents\n\n"
+            "- [r2.2](#r22)\n"
+            "- [r2.1 - rc](#r21---rc)\n\n"
+            "**Please use the latest published release.**\n\n"
+            "# r2.2 - Fall25 public release\n\n"
+            "Prior public release content\n"
+        )
+        (tmp_path / "CHANGELOG.md").write_text(legacy)
+
+        new_section = "# r2.3\n\n## Release Notes\n\nMaintenance patch\n"
+        generator.write_changelog(
+            str(tmp_path),
+            new_section,
+            "r2.3",
+            "SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+        )
+
+        result = (tmp_path / "CHANGELOG.md").read_text()
+        r23 = result.index("# r2.3")
+        r22 = result.index("# r2.2")
+        assert r23 < r22
+
+    def test_flat_write_injects_toc_markers_on_first_run(self, generator, tmp_path):
+        # Legacy CHANGELOG.md has no automation TOC markers
+        legacy = (
+            "# Changelog Simple Edge Discovery\n\n"
+            "## Table of contents\n\n"
+            "- [r2.2](#r22)\n\n"
+            "# r2.2\n\nPrior content\n"
+        )
+        (tmp_path / "CHANGELOG.md").write_text(legacy)
+
+        new_section = "# r2.3\n\nThis maintenance release contains something\n"
+        generator.write_changelog(
+            str(tmp_path),
+            new_section,
+            "r2.3",
+            "SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+        )
+
+        result = (tmp_path / "CHANGELOG.md").read_text()
+        assert TOC_START_MARKER in result
+        assert TOC_END_MARKER in result
+
+    def test_flat_write_updates_toc_idempotently(self, generator, tmp_path):
+        # First maintenance write inserts markers
+        (tmp_path / "CHANGELOG.md").write_text(
+            "# Changelog Simple Edge Discovery\n\n"
+            "# r2.2\n\nPrior content\n"
+        )
+        generator.write_changelog(
+            str(tmp_path),
+            "# r2.3\n\nThis maintenance release contains A\n",
+            "r2.3",
+            "SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+        )
+        # Second maintenance write (hypothetical r2.4 still before migration)
+        generator.write_changelog(
+            str(tmp_path),
+            "# r2.4\n\nThis maintenance release contains B\n",
+            "r2.4",
+            "SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+        )
+
+        result = (tmp_path / "CHANGELOG.md").read_text()
+        assert result.count(TOC_START_MARKER) == 1
+        assert result.count(TOC_END_MARKER) == 1
+        # Both release entries present in TOC
+        assert "[r2.4](#r24)" in result
+        assert "[r2.3](#r23)" in result
+
+
 # --- Table of Contents ---
 
 

--- a/release_automation/tests/test_post_release_syncer.py
+++ b/release_automation/tests/test_post_release_syncer.py
@@ -164,6 +164,70 @@ class TestSyncChangelog:
         assert result is False
         mock_github_client.get_file_content.assert_not_called()
 
+    def test_sync_changelog_prefers_per_cycle(self, syncer, mock_github_client):
+        """When the per-cycle file is present on the snapshot, sync it and
+        do not probe the flat fallback."""
+        mock_github_client.get_file_content.return_value = "# per-cycle content"
+
+        result = syncer._sync_changelog(
+            "release-snapshot/r4.1-abc123",
+            "pr-to-main/r4.1",
+            "r4.1",
+        )
+
+        assert result is True
+        # Only one probe — for the per-cycle path
+        mock_github_client.get_file_content.assert_called_once_with(
+            "CHANGELOG/CHANGELOG-r4.md", ref="release-snapshot/r4.1-abc123"
+        )
+        mock_github_client.update_file.assert_called_once()
+        assert (
+            mock_github_client.update_file.call_args.kwargs["path"]
+            == "CHANGELOG/CHANGELOG-r4.md"
+        )
+
+    def test_sync_changelog_falls_back_to_flat_when_per_cycle_missing(
+        self, syncer, mock_github_client
+    ):
+        """Maintenance releases on unmigrated repos write flat CHANGELOG.md;
+        the syncer must pick that up when the per-cycle probe returns None."""
+        mock_github_client.get_file_content.side_effect = [None, "# flat content"]
+
+        result = syncer._sync_changelog(
+            "release-snapshot/r2.3-abc123",
+            "pr-to-main/r2.3",
+            "r2.3",
+        )
+
+        assert result is True
+        assert mock_github_client.get_file_content.call_count == 2
+        mock_github_client.get_file_content.assert_any_call(
+            "CHANGELOG/CHANGELOG-r2.md", ref="release-snapshot/r2.3-abc123"
+        )
+        mock_github_client.get_file_content.assert_any_call(
+            "CHANGELOG.md", ref="release-snapshot/r2.3-abc123"
+        )
+        mock_github_client.update_file.assert_called_once()
+        assert (
+            mock_github_client.update_file.call_args.kwargs["path"] == "CHANGELOG.md"
+        )
+
+    def test_sync_changelog_neither_present_returns_false(
+        self, syncer, mock_github_client
+    ):
+        """Both probes return None → False and no update attempt."""
+        mock_github_client.get_file_content.side_effect = [None, None]
+
+        result = syncer._sync_changelog(
+            "release-snapshot/r2.3-abc123",
+            "pr-to-main/r2.3",
+            "r2.3",
+        )
+
+        assert result is False
+        assert mock_github_client.get_file_content.call_count == 2
+        mock_github_client.update_file.assert_not_called()
+
 
 class TestCreatePR:
     """Tests for _create_pr method."""

--- a/release_automation/tests/test_readme_updater.py
+++ b/release_automation/tests/test_readme_updater.py
@@ -59,6 +59,7 @@ def public_release_data():
         "latest_public_release": "r3.2",
         "github_url": "https://github.com/camaraproject/QualityOnDemand/releases/tag/r3.2",
         "meta_release": "Spring25",
+        "changelog_url": "https://github.com/camaraproject/QualityOnDemand/tree/main/CHANGELOG",
         "formatted_apis": (
             "  * **quality-on-demand v1.1.0**\n"
             "  [[YAML]](https://github.com/camaraproject/QualityOnDemand/blob/r3.2/"
@@ -81,6 +82,7 @@ def prerelease_data():
         "newest_prerelease": "r4.1-rc.1",
         "prerelease_github_url": "https://github.com/camaraproject/QualityOnDemand/releases/tag/r4.1-rc.1",
         "prerelease_type": "release candidate",
+        "changelog_url": "https://github.com/camaraproject/QualityOnDemand/tree/main/CHANGELOG",
         "formatted_prerelease_apis": (
             "  * **quality-on-demand v1.2.0-rc.1**\n"
             "  [[YAML]](https://github.com/camaraproject/QualityOnDemand/blob/r4.1-rc.1/"
@@ -168,6 +170,32 @@ class TestTemplateRendering:
         assert "r4.1-rc.1" in result
         assert "Upcoming Release Preview" in result
         assert "NOTE" in result
+
+    def test_changelog_url_renders_directory_link_in_all_release_templates(
+        self, updater, public_release_data, prerelease_data
+    ):
+        """changelog_url variable is honored by every release template."""
+        dir_url = "https://github.com/camaraproject/QualityOnDemand/tree/main/CHANGELOG"
+        public_release_data["changelog_url"] = dir_url
+        prerelease_data["changelog_url"] = dir_url
+
+        public_result = updater._render_template("public_release", public_release_data)
+        prerelease_result = updater._render_template("prerelease_only", prerelease_data)
+        combined_result = updater._render_template(
+            "public_with_prerelease", {**public_release_data, **prerelease_data}
+        )
+
+        for result in (public_result, prerelease_result, combined_result):
+            assert f"[CHANGELOG]({dir_url})" in result
+
+    def test_changelog_url_renders_flat_file_link(self, updater, public_release_data):
+        """Flat-mode URL (blob/main/CHANGELOG.md) also renders cleanly."""
+        flat_url = "https://github.com/camaraproject/SimpleEdgeDiscovery/blob/main/CHANGELOG.md"
+        public_release_data["changelog_url"] = flat_url
+        public_release_data["repo_name"] = "SimpleEdgeDiscovery"
+
+        result = updater._render_template("public_release", public_release_data)
+        assert f"[CHANGELOG]({flat_url})" in result
 
 
 # --- Content Replacement ---

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -264,7 +264,63 @@ class TestGenerateSnapshotId:
         ) == "v1.0.0-abc1234"
 
 
+# --- Tests for _changelog_url ---
+
+
+class TestChangelogUrl:
+    """Tests for the CHANGELOG link rendered into README release-info.
+
+    Mirrors the dual-mode rule used by the generator: maintenance releases
+    into a cycle without a per-cycle file link to the flat CHANGELOG.md;
+    every other case links to the per-cycle CHANGELOG/ directory view.
+    """
+
+    def test_maintenance_with_no_per_cycle_file_points_to_flat(self, tmp_path):
+        (tmp_path / "CHANGELOG.md").write_text("legacy\n")
+        url = SnapshotCreator._changelog_url(
+            str(tmp_path),
+            org="camaraproject",
+            repo_name="SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+            cycle="2",
+        )
+        assert url == (
+            "https://github.com/camaraproject/SimpleEdgeDiscovery/blob/main/CHANGELOG.md"
+        )
+
+    def test_maintenance_with_existing_per_cycle_file_points_to_dir(self, tmp_path):
+        (tmp_path / "CHANGELOG").mkdir()
+        (tmp_path / "CHANGELOG" / "CHANGELOG-r2.md").write_text("per-cycle\n")
+        url = SnapshotCreator._changelog_url(
+            str(tmp_path),
+            org="camaraproject",
+            repo_name="SimpleEdgeDiscovery",
+            release_type="maintenance-release",
+            cycle="2",
+        )
+        assert url == (
+            "https://github.com/camaraproject/SimpleEdgeDiscovery/tree/main/CHANGELOG"
+        )
+
+    def test_non_maintenance_always_points_to_dir(self, tmp_path):
+        # Even a repo with a flat CHANGELOG.md and no CHANGELOG/ yet gets
+        # the directory link when the release is not a maintenance release,
+        # because the generator will create the per-cycle file on first run.
+        (tmp_path / "CHANGELOG.md").write_text("legacy\n")
+        url = SnapshotCreator._changelog_url(
+            str(tmp_path),
+            org="camaraproject",
+            repo_name="QualityOnDemand",
+            release_type="public-release",
+            cycle="4",
+        )
+        assert url == (
+            "https://github.com/camaraproject/QualityOnDemand/tree/main/CHANGELOG"
+        )
+
+
 # --- Tests for validate_preconditions ---
+
 
 class TestValidatePreconditions:
     """Tests for precondition validation."""


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Extends the release-automation changelog generator and post-release syncer
with a narrow maintenance-mode fallback:

- If `release_type == "maintenance-release"` AND
  `CHANGELOG/CHANGELOG-r{cycle}.md` does not exist → write/sync flat
  `CHANGELOG.md` at the repository root.
- Otherwise → per-cycle `CHANGELOG/CHANGELOG-r{cycle}.md` (unchanged default).

The same rule drives the CHANGELOG URL rendered into the README release-info
section (`blob/main/CHANGELOG.md` vs `tree/main/CHANGELOG`).

Effect:

- New release cycles on any repo continue to use the per-cycle structure.
- Maintenance releases on repos that have not yet run `/migrate-changelog`
  keep prepending to the existing flat `CHANGELOG.md` until the history is
  migrated. After migration, subsequent maintenance releases in those cycles
  use the per-cycle file.

Motivation: `SimpleEdgeDiscovery` plans a maintenance release
(`simple-edge-discovery 2.0.1`) to patch `r2.2`; without this fallback the
maintenance entry would land in a fresh `CHANGELOG/CHANGELOG-r2.md`, split
from the rest of the cycle's history in the existing `CHANGELOG.md`.

#### Which issue(s) this PR fixes:

Fixes camaraproject/ReleaseManagement#496

Preparation for camaraproject/ReleaseManagement#356 (C5 maintenance branch
releases).

#### Special notes for reviewers:

- Generator change is in `release_automation/scripts/changelog_generator.py`
  (`_resolve_changelog_path()` helper + `release_type` kwarg on
  `write_changelog()`).
- Syncer probes per-cycle first, falls back to flat, in
  `release_automation/scripts/post_release_syncer.py::_sync_changelog()`.
- README link change threads `changelog_url` through
  `snapshot_creator._update_readme()` into three Mustache templates
  (`release-info-public.mustache`,
  `release-info-public-with-prerelease.mustache`,
  `release-info-prerelease-only.mustache`).
- Tests: 16 new unit tests covering generator dual-mode, syncer probe order,
  `_changelog_url()` helper, and template rendering. Full suite:
  1445/1445 passing.
- No changes to v0 (`pr_validation.yml`), validation rules, workflows, or
  release_automation orchestration — only the changelog write/sync path and
  README link.

#### Changelog input

```
 release-note
release-automation: maintenance releases now preserve flat `CHANGELOG.md` at
the repository root when no per-cycle file exists yet for the target cycle;
per-cycle `CHANGELOG/CHANGELOG-r{cycle}.md` remains the default for every
other release type.
```

#### Additional documentation

Updated `release_automation/docs/repository-setup.md` — CHANGELOG Structure
section now documents the dual-mode discriminator, and the verification
checklist accepts either structure.

```
docs
release_automation/docs/repository-setup.md
```