### PR TITLE
feat(validation): add P-022 exclusivity, P-023 tag existence, and commonalities-advance engine suppression

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -152,11 +152,143 @@ jobs:
         id: detect-changes
         if: github.event_name == 'pull_request'
         run: |
+          # Emit the list of non-release-plan files touched in this PR so
+          # P-022 (exclusivity) can report them.  Empty JSON array when
+          # release-plan.yaml is the only change.
           if git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- release-plan.yaml | grep -q .; then
             echo "release_plan_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "release_plan_changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+          OTHER_FILES=$(
+            git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+              | grep -v '^release-plan\.yaml$' \
+              | python3 -c 'import json, sys; print(json.dumps([line for line in sys.stdin.read().splitlines() if line]))'
+          )
+          echo "non_release_plan_files_changed=${OTHER_FILES}" >> "$GITHUB_OUTPUT"
+
+      # ── Step 6b: Resolve dependency changes and declared-tag existence
+      #
+      # When release-plan.yaml changed, diff base vs head to detect which
+      # dependency declarations advanced (commonalities_release,
+      # identity_consent_management_release).  For each advanced tag,
+      # look it up in the source repository via the GitHub API.  Emit a
+      # tri-state existence flag: 'true' / 'false' / '' (empty = lookup
+      # failed or skipped).  release_plan_check_only is set only when
+      # commonalities_release advances — that's the dependency whose
+      # content (code/common/*) is stale under the new ruleset, which is
+      # why the orchestrator suppresses the Spectral + gherkin engines.
+      # ICM has no common files to sync, so an ICM advance does not
+      # trigger engine suppression.
+      - name: Resolve dependency changes and declared tags
+        id: detect-deps
+        if: >-
+          github.event_name == 'pull_request'
+          && steps.detect-changes.outputs.release_plan_changed == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const fs = require('fs');
+            const path = require('path');
+            // js-yaml is bundled with actions/github-script v9+ and its
+            // dependencies; require by name.
+            const yaml = require('js-yaml');
+
+            function readYamlAtRef(ref, filePath) {
+              // Returns the parsed YAML at origin/<ref>:<filePath>, or
+              // {} when the file is absent at that ref.
+              try {
+                const raw = execSync(
+                  `git show origin/${ref}:${filePath}`,
+                  { stdio: ['ignore', 'pipe', 'pipe'] }
+                ).toString('utf8');
+                const parsed = yaml.load(raw);
+                return parsed && typeof parsed === 'object' ? parsed : {};
+              } catch (err) {
+                return {};
+              }
+            }
+
+            function readYamlAtPath(filePath) {
+              try {
+                const raw = fs.readFileSync(filePath, 'utf8');
+                const parsed = yaml.load(raw);
+                return parsed && typeof parsed === 'object' ? parsed : {};
+              } catch (err) {
+                return {};
+              }
+            }
+
+            function getDep(plan, field) {
+              const deps = (plan && plan.dependencies) || {};
+              return deps[field] || null;
+            }
+
+            const baseRef = context.payload.pull_request.base.ref;
+            const planPath = 'release-plan.yaml';
+            const basePlan = readYamlAtRef(baseRef, planPath);
+            const headPlan = readYamlAtPath(
+              path.join(process.env.GITHUB_WORKSPACE, planPath)
+            );
+
+            const DEPENDENCIES = [
+              {
+                field: 'commonalities_release',
+                sourceRepo: 'camaraproject/Commonalities',
+                changedOutput: 'commonalities_release_changed',
+                tagExistsOutput: 'commonalities_tag_exists',
+              },
+              {
+                field: 'identity_consent_management_release',
+                sourceRepo: 'camaraproject/IdentityAndConsentManagement',
+                changedOutput: 'icm_release_changed',
+                tagExistsOutput: 'icm_tag_exists',
+              },
+            ];
+
+            async function tagExists(owner, repo, tag) {
+              try {
+                await github.rest.git.getRef({
+                  owner, repo, ref: `tags/${tag}`,
+                });
+                return 'true';
+              } catch (err) {
+                if (err && err.status === 404) return 'false';
+                // 5xx, rate-limit, network, auth issues — let P-023
+                // surface a warn-level finding rather than blocking.
+                core.warning(
+                  `Tag lookup for ${owner}/${repo}@${tag} failed: ${err.message}`
+                );
+                return '';
+              }
+            }
+
+            let commonalitiesChanged = false;
+            for (const dep of DEPENDENCIES) {
+              const baseTag = getDep(basePlan, dep.field);
+              const headTag = getDep(headPlan, dep.field);
+              const changed = baseTag !== headTag;
+              core.setOutput(dep.changedOutput, changed ? 'true' : 'false');
+
+              if (changed && dep.field === 'commonalities_release') {
+                commonalitiesChanged = true;
+              }
+
+              if (changed && headTag) {
+                const [owner, repo] = dep.sourceRepo.split('/');
+                const exists = await tagExists(owner, repo, headTag);
+                core.setOutput(dep.tagExistsOutput, exists);
+              } else {
+                core.setOutput(dep.tagExistsOutput, '');
+              }
+            }
+
+            core.setOutput(
+              'release_plan_check_only',
+              commonalitiesChanged ? 'true' : 'false'
+            );
 
       # ── Step 7: Run validation (shared action) ─────────────────────
       #
@@ -171,6 +303,12 @@ jobs:
           mode: ${{ inputs.mode }}
           profile: ${{ inputs.profile }}
           release_plan_changed: ${{ steps.detect-changes.outputs.release_plan_changed || 'false' }}
+          release_plan_check_only: ${{ steps.detect-deps.outputs.release_plan_check_only || 'false' }}
+          commonalities_release_changed: ${{ steps.detect-deps.outputs.commonalities_release_changed || 'false' }}
+          icm_release_changed: ${{ steps.detect-deps.outputs.icm_release_changed || 'false' }}
+          commonalities_tag_exists: ${{ steps.detect-deps.outputs.commonalities_tag_exists || '' }}
+          icm_tag_exists: ${{ steps.detect-deps.outputs.icm_tag_exists || '' }}
+          non_release_plan_files_changed: ${{ steps.detect-changes.outputs.non_release_plan_files_changed || '[]' }}
           tooling_ref: ${{ steps.resolve-ref.outputs.tooling_checkout_ref }}
 
       # ── Step 8: Mint validation app token (PR only) ──────────────

--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -28,6 +28,48 @@ inputs:
     description: 'Whether release-plan.yaml changed in this PR (true/false)'
     required: false
     default: 'false'
+  release_plan_check_only:
+    description: >
+      When true, a Commonalities dependency declaration advanced in this
+      PR — orchestrator skips Spectral + gherkin engines and post-filter
+      keeps only release-plan-validation rules.  Set by the caller
+      workflow''s release-plan detection step.
+    required: false
+    default: 'false'
+  commonalities_release_changed:
+    description: >
+      Whether dependencies.commonalities_release differs between base and
+      head in this PR diff (true/false).  Used by P-023 to gate the
+      tag-existence check.
+    required: false
+    default: 'false'
+  icm_release_changed:
+    description: >
+      Whether dependencies.icm_release (or identity_consent_management_release)
+      differs between base and head in this PR diff (true/false).
+    required: false
+    default: 'false'
+  commonalities_tag_exists:
+    description: >
+      Tri-state result of the GitHub API lookup for the declared
+      commonalities_release tag.  ''true'' = confirmed present, ''false''
+      = confirmed 404, '''' (empty) = lookup skipped or failed.  Consumed
+      by P-023.
+    required: false
+    default: ''
+  icm_tag_exists:
+    description: >
+      Tri-state result for the declared icm_release tag.  Same semantics
+      as commonalities_tag_exists.
+    required: false
+    default: ''
+  non_release_plan_files_changed:
+    description: >
+      JSON array of file paths changed in the PR alongside
+      release-plan.yaml.  Empty array (''[]'') when release-plan.yaml is
+      the only changed file.  Consumed by P-022 (exclusivity check).
+    required: false
+    default: '[]'
   tooling_ref:
     description: 'Tooling ref used for this run (for diagnostics)'
     required: false
@@ -111,6 +153,12 @@ runs:
         VALIDATION_PROFILE: ${{ inputs.profile }}
         VALIDATION_PR_NUMBER: ${{ github.event.pull_request.number }}
         VALIDATION_RELEASE_PLAN_CHANGED: ${{ inputs.release_plan_changed }}
+        VALIDATION_RELEASE_PLAN_CHECK_ONLY: ${{ inputs.release_plan_check_only }}
+        VALIDATION_COMMONALITIES_RELEASE_CHANGED: ${{ inputs.commonalities_release_changed }}
+        VALIDATION_ICM_RELEASE_CHANGED: ${{ inputs.icm_release_changed }}
+        VALIDATION_COMMONALITIES_TAG_EXISTS: ${{ inputs.commonalities_tag_exists }}
+        VALIDATION_ICM_TAG_EXISTS: ${{ inputs.icm_tag_exists }}
+        VALIDATION_NON_RELEASE_PLAN_FILES_CHANGED: ${{ inputs.non_release_plan_files_changed }}
         VALIDATION_WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         VALIDATION_TOOLING_REF: ${{ inputs.tooling_ref }}
         VALIDATION_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/validation/context/context_builder.py
+++ b/validation/context/context_builder.py
@@ -123,6 +123,24 @@ class ValidationContext:
     workflow_run_url: str
     tooling_ref: str
 
+    # Release-plan validation context (Step 6b outputs; defaults when absent)
+    # commonalities_release_changed / icm_release_changed: True when the
+    # respective dependency declaration differs between base and head.
+    # release_plan_check_only: True when a Commonalities advance is detected —
+    # orchestrator skips Spectral/gherkin engines and post-filter keeps only
+    # rules in the release-plan-validation group.  ICM advance does NOT set
+    # this flag (no common files to sync).
+    # *_tag_exists: tri-state — True (confirmed), False (confirmed missing),
+    # None (check did not run or API lookup failed).
+    # non_release_plan_files_changed: files co-changed alongside release-plan.yaml
+    # in the current PR diff (P-022 exclusivity input).
+    commonalities_release_changed: bool = False
+    icm_release_changed: bool = False
+    release_plan_check_only: bool = False
+    commonalities_tag_exists: Optional[bool] = None
+    icm_tag_exists: Optional[bool] = None
+    non_release_plan_files_changed: Tuple[str, ...] = ()
+
     def to_dict(self) -> dict:
         """Serialize to dict with all keys present.
 
@@ -264,6 +282,12 @@ def build_validation_context(
     workflow_run_url: str = "",
     tooling_ref: str = "",
     commonalities_version: Optional[str] = None,
+    release_plan_check_only: bool = False,
+    commonalities_release_changed: bool = False,
+    icm_release_changed: bool = False,
+    commonalities_tag_exists: Optional[bool] = None,
+    icm_tag_exists: Optional[bool] = None,
+    non_release_plan_files_changed: Tuple[str, ...] = (),
 ) -> ValidationContext:
     """Assemble the unified validation context.
 
@@ -348,4 +372,10 @@ def build_validation_context(
         apis=api_contexts,
         workflow_run_url=workflow_run_url,
         tooling_ref=tooling_ref,
+        commonalities_release_changed=commonalities_release_changed,
+        icm_release_changed=icm_release_changed,
+        release_plan_check_only=release_plan_check_only,
+        commonalities_tag_exists=commonalities_tag_exists,
+        icm_tag_exists=icm_tag_exists,
+        non_release_plan_files_changed=non_release_plan_files_changed,
     )

--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -12,7 +12,12 @@ from .filename_checks import check_filename_kebab_case, check_filename_matches_a
 from .metadata_checks import check_commonalities_version
 from .readme_checks import check_readme_placeholder_removal
 from .common_cache_checks import check_common_cache_sync
-from .release_plan_checks import check_orphan_api_definitions, check_release_plan_semantics
+from .release_plan_checks import (
+    check_declared_dependency_tags_exist,
+    check_orphan_api_definitions,
+    check_release_plan_exclusivity,
+    check_release_plan_semantics,
+)
 from .release_review_checks import check_release_review_file_restriction
 from .subscription_checks import (
     check_cloudevent_via_ref,
@@ -57,6 +62,8 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-release-review-file-restriction", CheckScope.REPO, check_release_review_file_restriction),
     CheckDescriptor("check-orphan-api-definitions", CheckScope.REPO, check_orphan_api_definitions),
     CheckDescriptor("check-common-cache-sync", CheckScope.REPO, check_common_cache_sync),
+    CheckDescriptor("check-release-plan-exclusivity", CheckScope.REPO, check_release_plan_exclusivity),
+    CheckDescriptor("check-declared-dependency-tags-exist", CheckScope.REPO, check_declared_dependency_tags_exist),
 ]
 
 __all__ = ["CHECKS", "CheckDescriptor", "CheckScope"]

--- a/validation/engines/python_checks/release_plan_checks.py
+++ b/validation/engines/python_checks/release_plan_checks.py
@@ -329,3 +329,154 @@ def check_orphan_api_definitions(
         )
         for name in orphans
     ]
+
+
+# ---------------------------------------------------------------------------
+# P-022: check-release-plan-exclusivity
+# ---------------------------------------------------------------------------
+
+
+def check_release_plan_exclusivity(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Flag non-release-plan files co-changed with release-plan.yaml.
+
+    Repo-level check.  Reads ``context.non_release_plan_files_changed``
+    (populated by the workflow layer when release-plan.yaml is in the
+    diff).  Emits one error finding listing the co-changed files so the
+    codeowner can split the PR.
+    """
+    other_files = context.non_release_plan_files_changed
+    if not other_files:
+        return []
+
+    # Cap the listed files to keep the message readable; full list is
+    # still visible in the PR diff.
+    preview_limit = 10
+    file_list = list(other_files)
+    if len(file_list) > preview_limit:
+        preview = ", ".join(file_list[:preview_limit])
+        suffix = f", and {len(file_list) - preview_limit} more"
+    else:
+        preview = ", ".join(file_list)
+        suffix = ""
+
+    return [
+        make_finding(
+            engine_rule="check-release-plan-exclusivity",
+            level="error",
+            message=(
+                f"release-plan.yaml was changed alongside "
+                f"{len(file_list)} other file(s): {preview}{suffix}. "
+                f"release-plan.yaml changes should be submitted in a "
+                f"dedicated PR so that any new validation findings remain "
+                f"clearly attributable to the release-plan change."
+            ),
+            path=_RELEASE_PLAN_PATH,
+            line=1,
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# P-023: check-declared-dependency-tags-exist
+# ---------------------------------------------------------------------------
+
+# Dependency spec: (YAML field name, display name, source repo,
+# context-flag attribute, context-tag-exists attribute).  YAML field
+# names match release-plan-schema.yaml; display names mirror the short
+# form used in user-facing messages.
+_DEPENDENCY_SPEC = [
+    (
+        "commonalities_release",
+        "commonalities_release",
+        "camaraproject/Commonalities",
+        "commonalities_release_changed",
+        "commonalities_tag_exists",
+    ),
+    (
+        "identity_consent_management_release",
+        "icm_release",
+        "camaraproject/IdentityAndConsentManagement",
+        "icm_release_changed",
+        "icm_tag_exists",
+    ),
+]
+
+
+def check_declared_dependency_tags_exist(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Verify that declared dependency tags exist in their source repos.
+
+    Repo-level check.  For each dependency (``commonalities_release``,
+    ``identity_consent_management_release``):
+
+    - If the declaration did not change in this PR's diff, skip (the
+      existing state is not this PR's responsibility).
+    - If the declaration changed and the tag was confirmed absent by the
+      workflow layer (``<dep>_tag_exists == False``), emit an error.
+    - If the declaration changed and the workflow layer could not verify
+      the tag (``<dep>_tag_exists is None``), emit a warn finding so the
+      codeowner is aware the check was skipped.
+    """
+    plan_path = repo_path / _RELEASE_PLAN_PATH
+    release_plan = load_yaml_safe(plan_path)
+    if release_plan is None:
+        return []
+
+    dependencies = release_plan.get("dependencies") or {}
+
+    findings: List[dict] = []
+
+    for (
+        yaml_field,
+        display_name,
+        source_repo,
+        changed_attr,
+        exists_attr,
+    ) in _DEPENDENCY_SPEC:
+        if not getattr(context, changed_attr, False):
+            # Declaration unchanged in this PR — skip (fail open).
+            continue
+
+        declared_tag = dependencies.get(yaml_field)
+        if not declared_tag:
+            # Declaration advanced to null/removed — not P-023's concern
+            # (schema or P-009 semantics handle this).
+            continue
+
+        exists = getattr(context, exists_attr, None)
+
+        if exists is False:
+            findings.append(
+                make_finding(
+                    engine_rule="check-declared-dependency-tags-exist",
+                    level="error",
+                    message=(
+                        f"Declared {display_name} tag '{declared_tag}' "
+                        f"does not exist in {source_repo}. Verify the "
+                        f"tag name or publish it before advancing the "
+                        f"dependency."
+                    ),
+                    path=_RELEASE_PLAN_PATH,
+                    line=1,
+                )
+            )
+        elif exists is None:
+            findings.append(
+                make_finding(
+                    engine_rule="check-declared-dependency-tags-exist",
+                    level="warn",
+                    message=(
+                        f"Could not verify that {display_name} tag "
+                        f"'{declared_tag}' exists in {source_repo} "
+                        f"(GitHub API lookup unavailable). Re-run the "
+                        f"workflow to retry, or confirm the tag manually."
+                    ),
+                    path=_RELEASE_PLAN_PATH,
+                    line=1,
+                )
+            )
+
+    return findings

--- a/validation/orchestrator.py
+++ b/validation/orchestrator.py
@@ -88,6 +88,14 @@ class OrchestratorArgs:
     commit_sha: str
     commonalities_version: Optional[str]
 
+    # Release-plan validation context (Step 6b outputs from validation.yml)
+    release_plan_check_only: bool
+    commonalities_release_changed: bool
+    icm_release_changed: bool
+    commonalities_tag_exists: Optional[bool]
+    icm_tag_exists: Optional[bool]
+    non_release_plan_files_changed: Tuple[str, ...]
+
 
 def _env(name: str, default: str = "") -> str:
     """Read a VALIDATION_* environment variable."""
@@ -115,6 +123,32 @@ def _env_optional_bool(name: str) -> Optional[bool]:
     return None
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Read an env var as a bool with an explicit default."""
+    raw = _env(name).lower()
+    if raw in ("true", "1", "yes"):
+        return True
+    if raw in ("false", "0", "no"):
+        return False
+    return default
+
+
+def _env_json_list(name: str) -> Tuple[str, ...]:
+    """Read an env var as a JSON array of strings.  Returns empty tuple
+    on missing/invalid input.
+    """
+    raw = _env(name)
+    if not raw:
+        return ()
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(v) for v in value)
+
+
 def parse_args() -> OrchestratorArgs:
     """Parse all inputs from VALIDATION_* environment variables."""
     return OrchestratorArgs(
@@ -134,6 +168,18 @@ def parse_args() -> OrchestratorArgs:
         tooling_ref=_env("TOOLING_REF"),
         commit_sha=_env("COMMIT_SHA"),
         commonalities_version=_env("COMMONALITIES_VERSION") or None,
+        release_plan_check_only=_env_bool("RELEASE_PLAN_CHECK_ONLY"),
+        commonalities_release_changed=_env_bool(
+            "COMMONALITIES_RELEASE_CHANGED"
+        ),
+        icm_release_changed=_env_bool("ICM_RELEASE_CHANGED"),
+        commonalities_tag_exists=_env_optional_bool(
+            "COMMONALITIES_TAG_EXISTS"
+        ),
+        icm_tag_exists=_env_optional_bool("ICM_TAG_EXISTS"),
+        non_release_plan_files_changed=_env_json_list(
+            "NON_RELEASE_PLAN_FILES_CHANGED"
+        ),
     )
 
 
@@ -200,7 +246,19 @@ def run_engines(
     all_findings: List[dict] = []
     engine_statuses: Dict[str, str] = {}
 
+    # When release_plan_check_only is true, a Commonalities dependency
+    # declaration advanced in this PR.  The code/common/ cache and API
+    # spec content on disk are still tied to the previous tag — running
+    # Spectral with the new ruleset or gherkin-lint against those files
+    # produces misleading findings (DEC-029 exclusivity principle).
+    # Skip those engines entirely; Python engine still runs but its
+    # post-filter keeps only rules gated on release_plan_changed=true.
+    skip_context_dependent = bool(
+        getattr(context, "release_plan_check_only", False)
+    )
+
     # --- yamllint ---
+    # yamllint is structural (syntax/formatting) — always safe to run.
     try:
         yamllint_config = paths.linting_config_dir / ".yamllint.yaml"
         findings = run_yamllint_engine(
@@ -215,21 +273,29 @@ def run_engines(
         logger.error("yamllint failed: %s", exc)
 
     # --- Spectral ---
-    try:
-        commonalities_release = getattr(context, "commonalities_release", None)
-        findings = run_spectral_engine(
-            repo_path=repo_path,
-            config_dir=paths.linting_config_dir,
-            commonalities_release=commonalities_release,
-        )
-        all_findings.extend(findings)
-        engine_statuses["spectral"] = f"{len(findings)} finding(s)"
-        logger.info("Spectral: %d finding(s)", len(findings))
-    except Exception as exc:
-        engine_statuses["spectral"] = f"error: {exc}"
-        logger.error("Spectral failed: %s", exc)
+    if skip_context_dependent:
+        engine_statuses["spectral"] = "skipped (release-plan-check-only mode)"
+        logger.info("Spectral: skipped (release-plan-check-only mode)")
+    else:
+        try:
+            commonalities_release = getattr(
+                context, "commonalities_release", None
+            )
+            findings = run_spectral_engine(
+                repo_path=repo_path,
+                config_dir=paths.linting_config_dir,
+                commonalities_release=commonalities_release,
+            )
+            all_findings.extend(findings)
+            engine_statuses["spectral"] = f"{len(findings)} finding(s)"
+            logger.info("Spectral: %d finding(s)", len(findings))
+        except Exception as exc:
+            engine_statuses["spectral"] = f"error: {exc}"
+            logger.error("Spectral failed: %s", exc)
 
     # --- Python checks ---
+    # Python engine always runs; post-filter drops non-release-plan rules
+    # when release_plan_check_only is true.
     try:
         findings = run_python_engine(
             repo_path=repo_path,
@@ -243,7 +309,10 @@ def run_engines(
         logger.error("Python checks failed: %s", exc)
 
     # --- gherkin-lint ---
-    if not test_files:
+    if skip_context_dependent:
+        engine_statuses["gherkin"] = "skipped (release-plan-check-only mode)"
+        logger.info("gherkin-lint: skipped (release-plan-check-only mode)")
+    elif not test_files:
         engine_statuses["gherkin"] = "skipped (no test files)"
         logger.info("gherkin-lint: skipped (no test files)")
     else:
@@ -432,6 +501,12 @@ def main() -> int:
         workflow_run_url=args.workflow_run_url,
         tooling_ref=args.tooling_ref,
         commonalities_version=args.commonalities_version,
+        release_plan_check_only=args.release_plan_check_only,
+        commonalities_release_changed=args.commonalities_release_changed,
+        icm_release_changed=args.icm_release_changed,
+        commonalities_tag_exists=args.commonalities_tag_exists,
+        icm_tag_exists=args.icm_tag_exists,
+        non_release_plan_files_changed=args.non_release_plan_files_changed,
     )
     logger.info(
         "Context: branch=%s trigger=%s profile=%s release_review=%s apis=%d",

--- a/validation/postfilter/engine.py
+++ b/validation/postfilter/engine.py
@@ -263,6 +263,21 @@ def run_post_filter(
             if not is_applicable(rule.applicability, context, api_ctx):
                 continue
 
+            # Release-plan-check-only gate — when a Commonalities dependency
+            # declaration has advanced in this PR, the code/common/ cache
+            # and on-disk content are stale relative to the declared tag.
+            # Running version-context-dependent rules against that stale
+            # content produces misleading findings (DEC-029 exclusivity
+            # principle).  Only rules that explicitly gate on
+            # release_plan_changed: true survive — those are release-plan
+            # validation rules (P-009, P-022, P-023) which check the
+            # release-plan.yaml content itself, not the consumption side.
+            if (
+                context.release_plan_check_only
+                and rule.applicability.get("release_plan_changed") is not True
+            ):
+                continue
+
             # Conditional level resolution (skip for identity-only entries)
             if rule.conditional_level is not None:
                 resolved_level = resolve_level(rule, context, api_ctx)

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -253,3 +253,33 @@
   hint: >-
     Merge the auto-created sync PR or trigger the release automation
     workflow manually (workflow_dispatch) to update code/common/ files.
+
+# P-022: check-release-plan-exclusivity
+# release-plan.yaml changes must be in their own PR — any co-changed
+# files are reported so that any new validation errors stay clearly
+# attributable to the release-plan change rather than masked by
+# unrelated code changes in the same PR.
+- id: P-022
+  engine: python
+  engine_rule: check-release-plan-exclusivity
+  applicability:
+    release_plan_changed: true
+  conditional_level:
+    default: error
+  hint: >-
+    Split this PR: keep release-plan.yaml changes in a dedicated PR,
+    and move the other listed files to a separate PR.
+
+# P-023: check-declared-dependency-tags-exist
+# When a dependency declaration (commonalities_release or icm_release)
+# advances in this PR, verify the declared tag exists in the source
+# repository.  Confirmed missing → error; API lookup failure → warn.
+# When the declaration is unchanged in the diff, the check is skipped
+# (pre-existing state is not this PR's responsibility).
+- id: P-023
+  engine: python
+  engine_rule: check-declared-dependency-tags-exist
+  applicability:
+    release_plan_changed: true
+  conditional_level:
+    default: error

--- a/validation/tests/test_context_builder.py
+++ b/validation/tests/test_context_builder.py
@@ -239,6 +239,11 @@ class TestValidationContextToDict:
             "commonalities_version", "icm_release",
             "base_ref", "is_release_review_pr", "release_plan_changed",
             "pr_number", "apis", "workflow_run_url", "tooling_ref",
+            # Release-plan validation context (Step 6b outputs)
+            "commonalities_release_changed", "icm_release_changed",
+            "release_plan_check_only",
+            "commonalities_tag_exists", "icm_tag_exists",
+            "non_release_plan_files_changed",
         }
         assert set(d.keys()) == expected_keys
 

--- a/validation/tests/test_orchestrator.py
+++ b/validation/tests/test_orchestrator.py
@@ -101,6 +101,12 @@ def _make_context(**overrides):
         "apis": (),
         "workflow_run_url": "https://github.com/example/runs/1",
         "tooling_ref": "abc123",
+        "release_plan_check_only": False,
+        "commonalities_release_changed": False,
+        "icm_release_changed": False,
+        "commonalities_tag_exists": None,
+        "icm_tag_exists": None,
+        "non_release_plan_files_changed": (),
     }
     defaults.update(overrides)
     ctx = MagicMock()
@@ -337,6 +343,57 @@ class TestRunEngines:
 
         assert "error:" in statuses["yamllint"]
         assert "finding(s)" in statuses["spectral"]
+
+    @patch("validation.orchestrator.run_gherkin_engine")
+    @patch("validation.orchestrator.run_python_engine")
+    @patch("validation.orchestrator.run_spectral_engine")
+    @patch("validation.orchestrator.run_yamllint_engine")
+    def test_release_plan_check_only_skips_spectral_and_gherkin(
+        self, mock_yamllint, mock_spectral, mock_python, mock_gherkin, paths
+    ):
+        """On a Commonalities advance (release_plan_check_only=True):
+        yamllint + Python still run; Spectral and gherkin are skipped
+        with explicit status messages.
+        """
+        mock_yamllint.return_value = []
+        mock_python.return_value = []
+        context = _make_context(release_plan_check_only=True)
+
+        findings, statuses = run_engines(
+            Path("/repo"), paths, context,
+            test_files=[Path("some.feature")],
+        )
+
+        assert mock_yamllint.called
+        assert mock_python.called
+        assert not mock_spectral.called
+        assert not mock_gherkin.called
+        assert "release-plan-check-only" in statuses["spectral"]
+        assert "release-plan-check-only" in statuses["gherkin"]
+
+    @patch("validation.orchestrator.run_gherkin_engine")
+    @patch("validation.orchestrator.run_python_engine")
+    @patch("validation.orchestrator.run_spectral_engine")
+    @patch("validation.orchestrator.run_yamllint_engine")
+    def test_release_plan_check_only_false_runs_all_engines(
+        self, mock_yamllint, mock_spectral, mock_python, mock_gherkin, paths
+    ):
+        """Default context (release_plan_check_only=False) runs all engines."""
+        mock_yamllint.return_value = []
+        mock_spectral.return_value = []
+        mock_python.return_value = []
+        mock_gherkin.return_value = []
+        context = _make_context(release_plan_check_only=False)
+
+        findings, statuses = run_engines(
+            Path("/repo"), paths, context,
+            test_files=[Path("some.feature")],
+        )
+
+        assert mock_yamllint.called
+        assert mock_spectral.called
+        assert mock_python.called
+        assert mock_gherkin.called
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -32,6 +32,8 @@ def _make_context(
     commonalities_release: str | None = "r4.1",
     is_release_review_pr: bool = False,
     apis: tuple[ApiContext, ...] = (),
+    release_plan_changed: bool | None = None,
+    release_plan_check_only: bool = False,
 ) -> ValidationContext:
     return ValidationContext(
         repository="TestRepo",
@@ -45,11 +47,12 @@ def _make_context(
         icm_release=None,
         base_ref=None,
         is_release_review_pr=is_release_review_pr,
-        release_plan_changed=None,
+        release_plan_changed=release_plan_changed,
         pr_number=None,
         apis=apis,
         workflow_run_url="",
         tooling_ref="",
+        release_plan_check_only=release_plan_check_only,
     )
 
 
@@ -281,6 +284,74 @@ class TestRunPostFilter:
         result = run_post_filter(findings, ctx, tmp_path)
         assert result.findings == []
         assert result.result == "pass"
+
+    def test_release_plan_check_only_keeps_release_plan_gated_rules(
+        self, tmp_path: Path
+    ):
+        """On a Commonalities advance, rules gated on release_plan_changed=true pass through."""
+        _write_rules(tmp_path, [
+            _minimal_rule(
+                engine_rule="some-rule",
+                applicability={"release_plan_changed": True},
+            )
+        ])
+        ctx = _make_context(
+            release_plan_changed=True,
+            release_plan_check_only=True,
+        )
+        findings = [_make_finding()]
+        result = run_post_filter(findings, ctx, tmp_path)
+        assert len(result.findings) == 1
+
+    def test_release_plan_check_only_drops_rules_without_release_plan_gate(
+        self, tmp_path: Path
+    ):
+        """On a Commonalities advance, rules without release_plan_changed applicability are dropped."""
+        _write_rules(tmp_path, [
+            _minimal_rule(engine_rule="some-rule")  # no applicability
+        ])
+        ctx = _make_context(
+            release_plan_changed=True,
+            release_plan_check_only=True,
+        )
+        findings = [_make_finding()]
+        result = run_post_filter(findings, ctx, tmp_path)
+        assert result.findings == []
+
+    def test_release_plan_check_only_drops_false_gated_rules(
+        self, tmp_path: Path
+    ):
+        """Rules gated on release_plan_changed=false would already fail the
+        applicability check (release_plan_changed is true under
+        release_plan_check_only).  Verifies the gate doesn't accidentally
+        keep them.
+        """
+        _write_rules(tmp_path, [
+            _minimal_rule(
+                engine_rule="some-rule",
+                applicability={"release_plan_changed": False},
+            )
+        ])
+        ctx = _make_context(
+            release_plan_changed=True,
+            release_plan_check_only=True,
+        )
+        findings = [_make_finding()]
+        result = run_post_filter(findings, ctx, tmp_path)
+        assert result.findings == []
+
+    def test_release_plan_check_only_false_does_not_filter(
+        self, tmp_path: Path
+    ):
+        """When release_plan_check_only is false (normal PR), rules without
+        a release_plan_changed applicability should run normally."""
+        _write_rules(tmp_path, [
+            _minimal_rule(engine_rule="some-rule")
+        ])
+        ctx = _make_context(release_plan_check_only=False)
+        findings = [_make_finding()]
+        result = run_post_filter(findings, ctx, tmp_path)
+        assert len(result.findings) == 1
 
     def test_level_muted_removes_finding(self, tmp_path: Path):
         """Level resolved to 'muted' removes the finding."""

--- a/validation/tests/test_python_checks_release_plan.py
+++ b/validation/tests/test_python_checks_release_plan.py
@@ -13,7 +13,9 @@ from validation.engines.python_checks.release_plan_checks import (
     _check_file_existence,
     _check_release_type_consistency,
     _check_track_consistency,
+    check_declared_dependency_tags_exist,
     check_orphan_api_definitions,
+    check_release_plan_exclusivity,
     check_release_plan_semantics,
 )
 
@@ -312,3 +314,229 @@ class TestCheckOrphanApiDefinitions:
         (api_dir / "README.md").touch()
         findings = check_orphan_api_definitions(tmp_path, _make_context())
         assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# TestCheckReleasePlanExclusivity (P-022)
+# ---------------------------------------------------------------------------
+
+
+def _context_with_other_files(*files: str) -> ValidationContext:
+    """Build a context with a populated non_release_plan_files_changed."""
+    base = _make_context()
+    return ValidationContext(
+        repository=base.repository,
+        branch_type=base.branch_type,
+        trigger_type=base.trigger_type,
+        profile=base.profile,
+        stage=base.stage,
+        target_release_type=base.target_release_type,
+        commonalities_release=base.commonalities_release,
+        commonalities_version=base.commonalities_version,
+        icm_release=base.icm_release,
+        base_ref=base.base_ref,
+        is_release_review_pr=base.is_release_review_pr,
+        release_plan_changed=True,
+        pr_number=base.pr_number,
+        apis=base.apis,
+        workflow_run_url=base.workflow_run_url,
+        tooling_ref=base.tooling_ref,
+        non_release_plan_files_changed=tuple(files),
+    )
+
+
+class TestCheckReleasePlanExclusivity:
+    def test_no_other_files(self, tmp_path: Path):
+        context = _context_with_other_files()
+        assert check_release_plan_exclusivity(tmp_path, context) == []
+
+    def test_single_other_file(self, tmp_path: Path):
+        context = _context_with_other_files("code/API_definitions/qod.yaml")
+        findings = check_release_plan_exclusivity(tmp_path, context)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert findings[0]["engine_rule"] == "check-release-plan-exclusivity"
+        assert findings[0]["path"] == "release-plan.yaml"
+        assert "code/API_definitions/qod.yaml" in findings[0]["message"]
+        assert "1 other file" in findings[0]["message"]
+
+    def test_multiple_other_files(self, tmp_path: Path):
+        files = [
+            "code/API_definitions/qod.yaml",
+            "code/Test_definitions/qod.feature",
+            "CHANGELOG.md",
+        ]
+        context = _context_with_other_files(*files)
+        findings = check_release_plan_exclusivity(tmp_path, context)
+        assert len(findings) == 1
+        assert "3 other file" in findings[0]["message"]
+        for f in files:
+            assert f in findings[0]["message"]
+
+    def test_preview_truncation_over_ten_files(self, tmp_path: Path):
+        files = [f"file-{i}.yaml" for i in range(15)]
+        context = _context_with_other_files(*files)
+        findings = check_release_plan_exclusivity(tmp_path, context)
+        assert len(findings) == 1
+        msg = findings[0]["message"]
+        # First 10 files listed, remaining count summarised
+        for f in files[:10]:
+            assert f in msg
+        assert "and 5 more" in msg
+
+    def test_default_context_has_no_other_files(self, tmp_path: Path):
+        # Ensures _make_context() default does not trigger the rule.
+        assert check_release_plan_exclusivity(tmp_path, _make_context()) == []
+
+
+# ---------------------------------------------------------------------------
+# TestCheckDeclaredDependencyTagsExist (P-023)
+# ---------------------------------------------------------------------------
+
+
+def _context_with_dependency_changes(
+    *,
+    commonalities_release_changed: bool = False,
+    icm_release_changed: bool = False,
+    commonalities_tag_exists: bool | None = None,
+    icm_tag_exists: bool | None = None,
+) -> ValidationContext:
+    base = _make_context()
+    return ValidationContext(
+        repository=base.repository,
+        branch_type=base.branch_type,
+        trigger_type=base.trigger_type,
+        profile=base.profile,
+        stage=base.stage,
+        target_release_type=base.target_release_type,
+        commonalities_release=base.commonalities_release,
+        commonalities_version=base.commonalities_version,
+        icm_release=base.icm_release,
+        base_ref=base.base_ref,
+        is_release_review_pr=base.is_release_review_pr,
+        release_plan_changed=True,
+        pr_number=base.pr_number,
+        apis=base.apis,
+        workflow_run_url=base.workflow_run_url,
+        tooling_ref=base.tooling_ref,
+        commonalities_release_changed=commonalities_release_changed,
+        icm_release_changed=icm_release_changed,
+        commonalities_tag_exists=commonalities_tag_exists,
+        icm_tag_exists=icm_tag_exists,
+    )
+
+
+def _write_release_plan_with_dependencies(
+    tmp_path: Path,
+    commonalities: str | None = "r4.2",
+    icm: str | None = "r2.3",
+) -> None:
+    plan = _make_plan()
+    deps: dict = {}
+    if commonalities is not None:
+        deps["commonalities_release"] = commonalities
+    if icm is not None:
+        # Schema field name (not the shorter context attribute 'icm_release').
+        deps["identity_consent_management_release"] = icm
+    plan["dependencies"] = deps
+    _write_release_plan(tmp_path, plan)
+
+
+class TestCheckDeclaredDependencyTagsExist:
+    def test_no_release_plan(self, tmp_path: Path):
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            commonalities_tag_exists=False,
+        )
+        assert check_declared_dependency_tags_exist(tmp_path, context) == []
+
+    def test_no_dependency_changed(self, tmp_path: Path):
+        _write_release_plan_with_dependencies(tmp_path)
+        # Default context: no *_release_changed flags set
+        assert check_declared_dependency_tags_exist(tmp_path, _make_context()) == []
+
+    def test_commonalities_changed_tag_exists(self, tmp_path: Path):
+        _write_release_plan_with_dependencies(tmp_path)
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            commonalities_tag_exists=True,
+        )
+        assert check_declared_dependency_tags_exist(tmp_path, context) == []
+
+    def test_commonalities_changed_tag_missing(self, tmp_path: Path):
+        _write_release_plan_with_dependencies(tmp_path, commonalities="r9.9")
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            commonalities_tag_exists=False,
+        )
+        findings = check_declared_dependency_tags_exist(tmp_path, context)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert findings[0]["engine_rule"] == "check-declared-dependency-tags-exist"
+        assert "r9.9" in findings[0]["message"]
+        assert "camaraproject/Commonalities" in findings[0]["message"]
+
+    def test_commonalities_changed_lookup_failed(self, tmp_path: Path):
+        _write_release_plan_with_dependencies(tmp_path, commonalities="r4.2")
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            commonalities_tag_exists=None,
+        )
+        findings = check_declared_dependency_tags_exist(tmp_path, context)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert "r4.2" in findings[0]["message"]
+        assert "Could not verify" in findings[0]["message"]
+
+    def test_commonalities_changed_declaration_removed(self, tmp_path: Path):
+        # Dependency declaration was advanced to null — not P-023's
+        # concern (P-009 / schema handles this).
+        _write_release_plan_with_dependencies(tmp_path, commonalities=None)
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            commonalities_tag_exists=None,
+        )
+        assert check_declared_dependency_tags_exist(tmp_path, context) == []
+
+    def test_icm_changed_tag_missing(self, tmp_path: Path):
+        _write_release_plan_with_dependencies(tmp_path, icm="r9.9")
+        context = _context_with_dependency_changes(
+            icm_release_changed=True,
+            icm_tag_exists=False,
+        )
+        findings = check_declared_dependency_tags_exist(tmp_path, context)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert "r9.9" in findings[0]["message"]
+        assert "camaraproject/IdentityAndConsentManagement" in findings[0]["message"]
+
+    def test_both_changed_both_missing(self, tmp_path: Path):
+        _write_release_plan_with_dependencies(
+            tmp_path, commonalities="r9.9", icm="r9.9"
+        )
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            commonalities_tag_exists=False,
+            icm_release_changed=True,
+            icm_tag_exists=False,
+        )
+        findings = check_declared_dependency_tags_exist(tmp_path, context)
+        assert len(findings) == 2
+        messages = "\n".join(f["message"] for f in findings)
+        assert "commonalities_release" in messages
+        assert "icm_release" in messages
+
+    def test_icm_changed_commonalities_unchanged(self, tmp_path: Path):
+        # ICM-only advance: commonalities_release unchanged, icm_release changed.
+        # Only ICM tag checked.
+        _write_release_plan_with_dependencies(
+            tmp_path, commonalities="r4.2", icm="r9.9"
+        )
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=False,
+            icm_release_changed=True,
+            icm_tag_exists=False,
+        )
+        findings = check_declared_dependency_tags_exist(tmp_path, context)
+        assert len(findings) == 1
+        assert "icm_release" in findings[0]["message"]

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 21
+        assert counts["python"] == 23
         assert counts["spectral"] == 84
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -306,8 +306,8 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 14, (
-            f"Expected 14 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 15, (
+            f"Expected 15 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds release-plan-focused validation and suppresses misleading findings on Commonalities-advance PRs:

- **P-022 `check-release-plan-exclusivity`** — flags any non-release-plan files co-changed with `release-plan.yaml`, listing them so the codeowner can split the PR. Closes a signal gap that the legacy v0 `pr_validation.yml` covered but v1 `validation.yml` did not.
- **P-023 `check-declared-dependency-tags-exist`** — on any PR that advances `dependencies.commonalities_release` or `dependencies.identity_consent_management_release`, verifies the declared tag exists via the GitHub API. Confirmed 404 → error; API lookup failure → warn (does not block on infra flakes). Skipped when the declaration is unchanged in the diff.
- **`release_plan_check_only` engine suppression** — when a Commonalities advance is detected, the orchestrator skips Spectral and gherkin engines. The post-filter keeps only Python rules gated on `applicability.release_plan_changed: true`. This avoids producing findings against stale `code/common/*` content under the new ruleset — the codeowner cannot act on those in the bump PR. ICM-only advances do not trigger engine suppression (no common files to sync).

Both new rules share existing machinery: `applicability.release_plan_changed: true`. No new rule-metadata field was introduced.

Workflow additions in `.github/workflows/validation.yml`:
- Step 6 extended to emit `non_release_plan_files_changed` (JSON list, used by P-022).
- New Step 6b diffs base vs head `release-plan.yaml`, computes per-dependency `*_release_changed` flags, looks up declared tag existence via the GitHub API, and sets `release_plan_check_only`.

New inputs in `shared-actions/run-validation/action.yml` plumb these values through to the Python orchestrator via `VALIDATION_*` env vars.

#### Which issue(s) this PR fixes:

Fixes #206

Part of the validation framework v1 umbrella: camaraproject/ReleaseManagement#448.

#### Special notes for reviewers:

- 881 tests pass (15 new for P-022/P-023, 4 new post-filter, 2 new orchestrator engine-skip).
- `.github/workflows/**` and orchestrator code changed — per the established manual E2E gate, the `v1-rc` tag should only advance after a full release cycle on `camaraproject/ReleaseTest` verifies the new branch logic end-to-end.
- No changes to rule metadata for rules outside P-009/P-022/P-023. No existing rule behavior changes.

#### Changelog input

```
 release-note

Validation framework: added P-022 (release-plan exclusivity) and P-023 (declared dependency tag existence) rules. On Commonalities dependency advance PRs, Spectral and gherkin engines are suppressed and only release-plan rules run, avoiding misleading findings against stale common content.

```

#### Additional documentation

```
docs

N/A for this PR.

```