### PR TITLE
fix(validation): gate P-020 off Release Review PRs (fixes #199)

### DIFF
--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -218,12 +218,15 @@
 # `properties`. The $ref-only and `allOf: [{$ref: ...}]` forms have no
 # top-level `properties` and are not flagged.
 # Gated to Commonalities >=r4.2, where CAMARA_event_common.yaml exists.
+# Skipped on Release Review PRs, where inline CloudEvent is the expected
+# output of bundling rather than drift.
 - id: P-020
   engine: python
   engine_rule: check-cloudevent-via-ref
   applicability:
     api_pattern: [explicit-subscription, implicit-subscription]
     commonalities_release: ">=r4.2"
+    is_release_review_pr: false
   conditional_level:
     default: warn
   hint: >-


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

P-020 (`check-cloudevent-via-ref`) fires on bundled API definitions in Release Review PRs, where inline CloudEvent is the expected output of bundling rather than drift. Observed on ReleaseTest #88.

Adds `is_release_review_pr: false` to P-020's applicability block in `validation/rules/python-rules.yaml` so the post-filter skips the rule on Release Review PRs. No code change; uses the existing applicability-gating mechanism (same pattern as P-012, inverse sense).

Source-file drift detection on regular PRs is unaffected.

#### Which issue(s) this PR fixes:

Fixes #199

#### Special notes for reviewers:

Regression-runner uses `workflow_dispatch`, which sets `is_release_review_pr: false` — so regression-runner does not exercise this gate. Verification happens in the next manual full E2E on ReleaseTest (required anyway for #207 and #209 before the next `@v1-rc` move).

All 881 validation tests pass.

#### Changelog input

Not required — rule-metadata only; advisory-level behavior change.

#### Additional documentation

None.