### PR TITLE
Three small pre-E2E fixes: sync PR body, feature-line wip handling, scenario URL version check

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -106,31 +106,33 @@ jobs:
                 return;
               }
 
-              // Parse slash commands
-              if (body.startsWith('/create-snapshot')) {
+              // Parse slash commands. Each pattern anchors at start and
+              // requires either whitespace or end-of-string after the
+              // command so /create-snapshotextra does not match /create-snapshot.
+              if (/^\/create-snapshot(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'create-snapshot';
-                commandArgs = body.replace('/create-snapshot', '').trim();
+                commandArgs = body.replace(/^\/create-snapshot/, '').trim();
                 shouldContinue = 'true';
-              } else if (body.startsWith('/discard-snapshot')) {
+              } else if (/^\/discard-snapshot(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'discard-snapshot';
-                commandArgs = body.replace('/discard-snapshot', '').trim();
+                commandArgs = body.replace(/^\/discard-snapshot/, '').trim();
                 shouldContinue = 'true';
-              } else if (body.startsWith('/delete-draft')) {
+              } else if (/^\/delete-draft(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'delete-draft';
-                commandArgs = body.replace('/delete-draft', '').trim();
+                commandArgs = body.replace(/^\/delete-draft/, '').trim();
                 shouldContinue = 'true';
-              } else if (body.startsWith('/sync-issue')) {
+              } else if (/^\/sync-issue(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'sync-issue';
-                commandArgs = body.replace('/sync-issue', '').trim();
+                commandArgs = body.replace(/^\/sync-issue/, '').trim();
                 shouldContinue = 'true';
-              } else if (body.startsWith('/publish-release')) {
+              } else if (/^\/publish-release(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'publish-release';
-                commandArgs = body.replace('/publish-release', '').trim();
+                commandArgs = body.replace(/^\/publish-release/, '').trim();
                 // Parse --confirm <tag> argument
                 const confirmMatch = commandArgs.match(/--confirm\s+(\S+)/);
                 confirmTag = confirmMatch ? confirmMatch[1] : '';
@@ -1686,16 +1688,22 @@ jobs:
           git commit -m "chore: post-release sync for ${RELEASE_TAG}"
           git push origin "$SYNC_BRANCH"
 
-          # Create PR — capture failure as sync_status=failed
-          if PR_URL=$(gh pr create \
-            --title "Release Automation: Post-release sync (${RELEASE_TAG})" \
-            --body "Automated post-release sync PR for ${RELEASE_TAG}.
+          # Create PR — capture failure as sync_status=failed.
+          # Body assembled via heredoc so the markdown has no
+          # YAML-run-block indent leaking into the rendered PR description.
+          PR_BODY=$(cat <<EOF
+          Automated post-release sync PR for ${RELEASE_TAG}.
 
           This PR updates:
           - README.md Release Information section (copied from release tag)
           - CHANGELOG for the release cycle
 
-          Created by release automation workflow." \
+          Created by release automation workflow.
+          EOF
+          )
+          if PR_URL=$(gh pr create \
+            --title "Release Automation: Post-release sync (${RELEASE_TAG})" \
+            --body "$PR_BODY" \
             --head "$SYNC_BRANCH" \
             --base main); then
 
@@ -2263,10 +2271,10 @@ jobs:
             git commit -m "chore: sync common files from Commonalities ${COMMONALITIES_RELEASE}"
             git push origin "$SYNC_BRANCH"
 
-            # Create PR
-            PR_URL=$(gh pr create \
-              --title "Sync common files from Commonalities ${COMMONALITIES_RELEASE}" \
-              --body "Automated sync of \`code/common/\` files from \`camaraproject/Commonalities\` at release tag \`${COMMONALITIES_RELEASE}\`.
+            # Create PR. Body assembled via heredoc so markdown has no
+            # YAML-run-block indent leaking into the rendered PR description.
+            PR_BODY=$(cat <<EOF
+          Automated sync of \`code/common/\` files from \`camaraproject/Commonalities\` at release tag \`${COMMONALITIES_RELEASE}\`.
 
           This PR was created by release automation because the cached Commonalities files were out of sync with the declared dependency in \`release-plan.yaml\`.
 
@@ -2274,7 +2282,12 @@ jobs:
           - Updated files in \`code/common/\` to match Commonalities ${COMMONALITIES_RELEASE}
           - Added/updated \`.sync-manifest.yaml\` with file integrity hashes
 
-          **Action required:** Review and merge this PR. The \`/create-snapshot\` command will be blocked until common files are in sync." \
+          **Action required:** Review and merge this PR. The \`/create-snapshot\` command will be blocked until common files are in sync.
+          EOF
+          )
+            PR_URL=$(gh pr create \
+              --title "Sync common files from Commonalities ${COMMONALITIES_RELEASE}" \
+              --body "$PR_BODY" \
               --head "$SYNC_BRANCH" \
               --base main) || {
               echo "::error::Failed to create sync PR"

--- a/release_automation/config/transformations.yaml
+++ b/release_automation/config/transformations.yaml
@@ -49,15 +49,18 @@ transformations:
     replacement: "/{url_version}"
 
   # T1b: Test definition API version in Feature line
-  # Replaces "vwip" with "v{api_version}" (e.g., "v1.1.0") in Feature declarations.
-  # Matches both the comma-separated form ("Feature: <name>, vwip - …") and the
-  # space-only form ("Feature: <name> vwip - …"); the space before "vwip" is the
-  # single common anchor across CAMARA test-file conventions.
+  # Replaces "wip" or "vwip" with "v{api_version}" (e.g., "v1.1.0") in
+  # Feature declarations. Matches both the comma-separated form
+  # ("Feature: <name>, vwip - …") and the space-only form
+  # ("Feature: <name> vwip - …"); the space before the version token
+  # is the single common anchor across CAMARA test-file conventions.
+  # The optional `v?` accepts bare `wip` as a style variation (parallel
+  # to `0.1.0` vs `v0.1.0` in info.version).
   - name: test_def_api_version
-    description: Replace vwip in test definition Feature line (comma- or space-separated)
+    description: Replace wip/vwip in test definition Feature line (comma- or space-separated)
     type: regex
     file_pattern: "code/Test_definitions/*.feature"
-    pattern: "(Feature: .*?) vwip\\b"
+    pattern: "(Feature: .*?) v?wip\\b"
     replacement: "\\g<1> v{api_version}"
 
   # T3: Commonalities reference in x-camara-commonalities

--- a/release_automation/tests/test_mechanical_transformer.py
+++ b/release_automation/tests/test_mechanical_transformer.py
@@ -370,10 +370,10 @@ class TestFeatureLineReplacement:
 
     T1B_RULE = TransformationRule(
         name="test_def_api_version",
-        description="Replace vwip in test definition Feature line",
+        description="Replace wip/vwip in test definition Feature line",
         type=TransformationType.REGEX,
         file_pattern="code/Test_definitions/*.feature",
-        pattern=r"(Feature: .*?) vwip\b",
+        pattern=r"(Feature: .*?) v?wip\b",
         replacement=r"\g<1> v{api_version}",
     )
 
@@ -429,12 +429,43 @@ class TestFeatureLineReplacement:
         assert content == original
 
     def test_no_vwip_unchanged(self, transformer, context):
-        """A Feature line with no `vwip` anywhere is a no-op."""
+        """A Feature line with no `wip` or `vwip` anywhere is a no-op."""
         original = "Feature: CAMARA Quality On Demand - Operation createSession\n"
         result, content, feature_path = self._run(transformer, context, original)
         assert result.success
         assert feature_path not in result.files_modified
         assert content == original
+
+    def test_bare_wip_comma_form(self, transformer, context):
+        """Bare `wip` (no leading v) on a comma-separated Feature line.
+
+        Observed on Simple Edge Discovery — treated as a style variation
+        parallel to `0.1.0` vs `v0.1.0` in info.version.
+        """
+        result, content, feature_path = self._run(
+            transformer,
+            context,
+            "Feature: CAMARA Simple Edge Discovery, wip - Operation readClosestEdgeCloudZone\n",
+        )
+        assert result.success
+        assert feature_path in result.files_modified
+        assert content == (
+            "Feature: CAMARA Simple Edge Discovery, v3.2.0-rc.2 - "
+            "Operation readClosestEdgeCloudZone\n"
+        )
+
+    def test_bare_wip_space_form(self, transformer, context):
+        """Bare `wip` on a space-only Feature line."""
+        result, content, feature_path = self._run(
+            transformer,
+            context,
+            "Feature: CAMARA Quality On Demand wip - Operation createSession\n",
+        )
+        assert result.success
+        assert feature_path in result.files_modified
+        assert content == (
+            "Feature: CAMARA Quality On Demand v3.2.0-rc.2 - Operation createSession\n"
+        )
 
 
 class TestYamlPathTransformation:

--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -31,6 +31,7 @@ from .test_checks import (
     check_test_files_exist,
 )
 from .version_checks import (
+    check_feature_file_url_version,
     check_info_version_format,
     check_server_url_api_name,
     check_server_url_version,
@@ -47,6 +48,7 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-server-url-api-name", CheckScope.API, check_server_url_api_name),
     CheckDescriptor("check-test-files-exist", CheckScope.API, check_test_files_exist),
     CheckDescriptor("check-test-file-version", CheckScope.API, check_test_file_version),
+    CheckDescriptor("check-feature-file-url-version", CheckScope.API, check_feature_file_url_version),
     CheckDescriptor("check-commonalities-version", CheckScope.API, check_commonalities_version),
     CheckDescriptor("check-subscription-filename", CheckScope.API, check_subscription_filename),
     CheckDescriptor("check-event-type-format", CheckScope.API, check_event_type_format),

--- a/validation/engines/python_checks/test_checks.py
+++ b/validation/engines/python_checks/test_checks.py
@@ -106,14 +106,20 @@ def check_test_files_exist(
     ]
 
 
-# Regex to extract version from CAMARA Feature line.
-# Matches ", v{segment}" where segment runs until " - " or end of line.
-# On main: "vwip".  On release: "v2.2.0-alpha.5" (full semver with v).
+# Regex to extract version from CAMARA Feature line. Aligned with the T1b
+# transformation pattern in release_automation/config/transformations.yaml
+# so that any line T1b can transform is also recognized here. The leading
+# ``\s`` separator accepts both the comma-and-space form ("Feature: X, vwip")
+# and the space-only form ("Feature: X vwip"). The captured token is
+# ``wip`` / ``vwip`` (style variation on main/maintenance) or ``v{semver}``
+# (release branches).
 # Examples:
 #   "Feature: CAMARA QoD API, vwip - Operation deleteSession"       → "vwip"
+#   "Feature: CAMARA QoD API, wip - Operation deleteSession"        → "wip"
+#   "Feature: CAMARA QoD API vwip - Operation deleteSession"        → "vwip"
 #   "Feature: CAMARA QoD API, v2.2.0-alpha.5 - Operation create"    → "v2.2.0-alpha.5"
 #   "Feature: CAMARA QoD API, v1.0.0"                               → "v1.0.0"
-_FEATURE_VERSION_RE = re.compile(r",\s*(v\S+?)(?:\s+-\s| *$)")
+_FEATURE_VERSION_RE = re.compile(r"\s(v?wip|v\S+?)(?:\s+-\s|\s*$)")
 
 
 def _extract_feature_version(file_path: Path) -> Optional[str]:
@@ -181,18 +187,31 @@ def check_test_file_version(
         # No test files found — check_test_files_exist reports this.
         return []
 
+    # Compare with leading-v stripped so bare "wip" and "vwip" are treated
+    # as equivalent on main/maintenance (a style variation, parallel to
+    # "0.1.0" vs "v0.1.0" in info.version). Release branches always carry
+    # T1b's "v{api_version}" output, so the normalized comparison still
+    # enforces an exact match there.
+    expected_token = expected_segment.lower().removeprefix("v")
+
     findings: List[dict] = []
     for test_file in matching:
         actual_version = _extract_feature_version(test_file)
 
         if actual_version is None:
+            # No wip/vwip/v* token on the Feature line — T1b has nothing to
+            # replace and a release cut would carry the literal text into
+            # the snapshot. Emitted under a distinct rule ID (P-024) so its
+            # severity cannot be masked by P-007's conditional_level.
             findings.append(
                 make_finding(
-                    engine_rule="check-test-file-version",
+                    engine_rule="check-test-file-feature-line-untransformable",
                     level="error",
                     message=(
-                        f"Test file '{test_file.name}' has no version in its "
-                        f"Feature line (expected '{expected_segment}')"
+                        f"Test file '{test_file.name}' Feature line has no "
+                        f"'wip', 'vwip', or 'v{{version}}' token — nothing "
+                        f"for snapshot transformation to replace "
+                        f"(expected '{expected_segment}')"
                     ),
                     path=f"{_TEST_DIR}/{test_file.name}",
                     line=1,
@@ -201,7 +220,8 @@ def check_test_file_version(
             )
             continue
 
-        if actual_version.lower() != expected_segment.lower():
+        actual_token = actual_version.lower().removeprefix("v")
+        if actual_token != expected_token:
             findings.append(
                 make_finding(
                     engine_rule="check-test-file-version",

--- a/validation/engines/python_checks/version_checks.py
+++ b/validation/engines/python_checks/version_checks.py
@@ -13,6 +13,9 @@ from typing import List, Optional
 from validation.context import ValidationContext
 
 from ._types import load_yaml_safe, make_finding
+from .test_checks import _stem_matches_api
+
+_TEST_DIR = "code/Test_definitions"
 
 # Matches a semantic version (optionally with pre-release label).
 # Examples: "1.0.0", "0.2.0-alpha.2", "1.0.0-rc.1"
@@ -30,6 +33,19 @@ _URL_VERSION_RE = re.compile(r"/(?P<version>v[a-z0-9.]+)/?$", re.IGNORECASE)
 # Extracts the api-name segment from a server URL (segment before version).
 # e.g. "{apiRoot}/quality-on-demand/v1" -> "quality-on-demand"
 _URL_API_NAME_RE = re.compile(r"/(?P<api_name>[^/]+)/v[a-z0-9.]+/?$", re.IGNORECASE)
+
+# Matches a CAMARA-shaped version segment inside a scenario-step URL path:
+# an api-name segment (lowercase letters/digits/hyphens) followed by
+# either ``v{segment}`` or bare ``wip`` as the next segment. Used by P-025
+# to locate the version-bearing portion of a URL anywhere in a feature-
+# file line (not just at the end of the URL).
+# e.g. ``/quality-on-demand/vwip/sessions`` -> captured segment ``vwip``
+#      ``/qod/v1/sessions``                 -> captured ``v1``
+#      ``/device-status/wip/status``        -> captured ``wip``
+_STEP_URL_VERSION_RE = re.compile(
+    r"/[a-z0-9\-]+/(v[a-z0-9.]+|wip)(?=/|\s|$)",
+    re.IGNORECASE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +242,90 @@ def check_server_url_version(
                     api_name=api.api_name,
                 )
             )
+
+    return findings
+
+
+def check_feature_file_url_version(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate server URL version segments in feature-file scenario steps.
+
+    P-004 (``check_server_url_version``) covers ``servers[].url`` in the API
+    YAML.  This check extends the same version-segment discipline to URL
+    paths inside ``code/Test_definitions/*.feature`` scenario steps.
+
+    Rationale: snapshot transformation T2b rewrites ``/vwip`` to the
+    target version path (``/{url_version}``), but the rewrite only matches
+    the strict ``/vwip`` form.  A bare ``/wip`` (or a wrong ``/v{...}``
+    segment) in a scenario step survives into the snapshot.  Unlike the
+    Feature-line ``wip`` vs ``vwip`` case in P-007 (which is a style
+    variation), a URL-path version segment has no style-variation escape
+    hatch — the leading ``v`` is required.
+
+    Always error.  The expected segment is derived from the API spec's
+    ``info.version`` via :func:`build_version_segment`, so the check
+    naturally handles main (``info.version == 'wip'`` -> ``vwip``),
+    release, and maintenance branches without branch-type code.
+    """
+    api = context.apis[0]
+    spec_path = repo_path / api.spec_file
+
+    spec = load_yaml_safe(spec_path)
+    if spec is None:
+        return []
+
+    info_version = str(spec.get("info", {}).get("version", "")).strip()
+    if not info_version:
+        return []  # Caught by check_info_version_format.
+
+    expected_segment = build_version_segment(info_version)
+    if expected_segment is None:
+        return []  # Caught by check_info_version_format.
+
+    test_dir = repo_path / _TEST_DIR
+    if not test_dir.is_dir():
+        return []
+
+    matching = [
+        f for f in test_dir.iterdir()
+        if f.is_file()
+        and f.suffix == ".feature"
+        and _stem_matches_api(f.stem, api.api_name)
+    ]
+    if not matching:
+        return []
+
+    findings: List[dict] = []
+    expected_lower = expected_segment.lower()
+
+    for feature_file in matching:
+        try:
+            with open(feature_file, encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        for line_number, line in enumerate(lines, start=1):
+            for match in _STEP_URL_VERSION_RE.finditer(line):
+                actual_segment = match.group(1)
+                if actual_segment.lower() == expected_lower:
+                    continue
+                findings.append(
+                    make_finding(
+                        engine_rule="check-feature-file-url-version",
+                        level="error",
+                        message=(
+                            f"Scenario-step URL version segment "
+                            f"'/{actual_segment}' does not match expected "
+                            f"'/{expected_segment}' (derived from "
+                            f"info.version '{info_version}')"
+                        ),
+                        path=f"{_TEST_DIR}/{feature_file.name}",
+                        line=line_number,
+                        api_name=api.api_name,
+                    )
+                )
 
     return findings
 

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -286,3 +286,18 @@
     release_plan_changed: true
   conditional_level:
     default: error
+
+# P-024: check-test-file-feature-line-untransformable
+# Fires when the Feature line of a test file has no `wip`, `vwip`, or
+# `v{version}` token — nothing for snapshot transformation T1b to
+# replace, so a release cut would carry the literal text into the
+# snapshot. Always error: distinct from P-007 (which covers the
+# "present but mismatched" case under conditional_level hint/warn).
+# P-007 and P-024 are mutually exclusive per the check's code path
+# (`continue` after the None branch prevents both from firing on the
+# same file).
+- id: P-024
+  engine: python
+  engine_rule: check-test-file-feature-line-untransformable
+  conditional_level:
+    default: error

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -301,3 +301,16 @@
   engine_rule: check-test-file-feature-line-untransformable
   conditional_level:
     default: error
+
+# P-025: check-feature-file-url-version
+# Validates that URL paths inside .feature scenario steps carry the
+# expected version segment derived from info.version. Sibling to P-004
+# (which covers servers[].url in API YAMLs). Unlike Feature-line `wip`
+# (covered by P-007), a URL path version has no style-variation escape
+# hatch: bare `/wip` is never valid because snapshot transformation
+# T2b rewrites only the strict `/vwip` form. Always error.
+- id: P-025
+  engine: python
+  engine_rule: check-feature-file-url-version
+  conditional_level:
+    default: error

--- a/validation/tests/test_python_checks_test.py
+++ b/validation/tests/test_python_checks_test.py
@@ -153,6 +153,26 @@ class TestCheckTestFileVersion:
         ctx = _make_context("qod", branch_type="main")
         assert check_test_file_version(tmp_path, ctx) == []
 
+    def test_main_bare_wip_passes(self, tmp_path: Path):
+        """Bare 'wip' (no leading v) is a style variation — accepted on main."""
+        test_dir = _make_test_dir(tmp_path)
+        self._write_feature(
+            test_dir / "qod.feature",
+            "Feature: CAMARA QoD API, wip - Operation createSession",
+        )
+        ctx = _make_context("qod", branch_type="main")
+        assert check_test_file_version(tmp_path, ctx) == []
+
+    def test_main_space_only_vwip_passes(self, tmp_path: Path):
+        """Space-only Feature line (no comma) is a legacy style — accepted."""
+        test_dir = _make_test_dir(tmp_path)
+        self._write_feature(
+            test_dir / "qod.feature",
+            "Feature: CAMARA QoD API vwip - Operation createSession",
+        )
+        ctx = _make_context("qod", branch_type="main")
+        assert check_test_file_version(tmp_path, ctx) == []
+
     def test_main_real_version_fails(self, tmp_path: Path):
         """On main, v1 is wrong even when target_api_version is 1.0.0."""
         test_dir = _make_test_dir(tmp_path)
@@ -163,6 +183,7 @@ class TestCheckTestFileVersion:
         ctx = _make_context("qod", version="1.0.0", branch_type="main")
         findings = check_test_file_version(tmp_path, ctx)
         assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-test-file-version"
         assert "v1" in findings[0]["message"]
         assert "vwip" in findings[0]["message"]
 
@@ -173,6 +194,15 @@ class TestCheckTestFileVersion:
         self._write_feature(
             test_dir / "qod.feature",
             "Feature: CAMARA QoD API, vwip - Operation createSession",
+        )
+        ctx = _make_context("qod", branch_type="maintenance")
+        assert check_test_file_version(tmp_path, ctx) == []
+
+    def test_maintenance_bare_wip_passes(self, tmp_path: Path):
+        test_dir = _make_test_dir(tmp_path)
+        self._write_feature(
+            test_dir / "qod.feature",
+            "Feature: CAMARA QoD API, wip - Operation createSession",
         )
         ctx = _make_context("qod", branch_type="maintenance")
         assert check_test_file_version(tmp_path, ctx) == []
@@ -244,6 +274,7 @@ class TestCheckTestFileVersion:
     # --- common edge cases ---
 
     def test_no_version_in_feature_line(self, tmp_path: Path):
+        """Feature line with no wip/vwip/v* token → untransformable (P-024)."""
         test_dir = _make_test_dir(tmp_path)
         self._write_feature(
             test_dir / "qod.feature",
@@ -252,7 +283,24 @@ class TestCheckTestFileVersion:
         ctx = _make_context("qod", branch_type="main")
         findings = check_test_file_version(tmp_path, ctx)
         assert len(findings) == 1
-        assert "no version" in findings[0]["message"]
+        assert findings[0]["engine_rule"] == (
+            "check-test-file-feature-line-untransformable"
+        )
+        assert findings[0]["level"] == "error"
+
+    def test_garbage_token_is_untransformable(self, tmp_path: Path):
+        """A non-version token like 'xyz' is untransformable, not a mismatch."""
+        test_dir = _make_test_dir(tmp_path)
+        self._write_feature(
+            test_dir / "qod.feature",
+            "Feature: CAMARA QoD API, xyz - Operation createSession",
+        )
+        ctx = _make_context("qod", branch_type="main")
+        findings = check_test_file_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == (
+            "check-test-file-feature-line-untransformable"
+        )
 
     def test_empty_file(self, tmp_path: Path):
         test_dir = _make_test_dir(tmp_path)
@@ -260,7 +308,9 @@ class TestCheckTestFileVersion:
         ctx = _make_context("qod", branch_type="main")
         findings = check_test_file_version(tmp_path, ctx)
         assert len(findings) == 1
-        assert "no version" in findings[0]["message"]
+        assert findings[0]["engine_rule"] == (
+            "check-test-file-feature-line-untransformable"
+        )
 
     def test_no_test_dir(self, tmp_path: Path):
         ctx = _make_context("qod")

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -10,6 +10,7 @@ import yaml
 from validation.context import ApiContext, ValidationContext
 from validation.engines.python_checks.version_checks import (
     build_version_segment,
+    check_feature_file_url_version,
     check_info_version_format,
     check_server_url_api_name,
     check_server_url_version,
@@ -346,3 +347,168 @@ class TestCheckServerUrlApiName:
         findings = check_server_url_api_name(tmp_path, ctx)
         assert len(findings) == 1
         assert "wrong-name" in findings[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# TestCheckFeatureFileUrlVersion  (P-025)
+# ---------------------------------------------------------------------------
+
+
+def _write_feature(tmp_path: Path, name: str, body: str) -> Path:
+    test_dir = tmp_path / "code" / "Test_definitions"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    feature_path = test_dir / name
+    feature_path.write_text(body)
+    return feature_path
+
+
+class TestCheckFeatureFileUrlVersion:
+    """Tests for check_feature_file_url_version — P-025.
+
+    On main, ``info.version == 'wip'`` -> expected ``vwip``.
+    On release, ``info.version`` is a semver -> expected derived via
+    :func:`build_version_segment` (e.g. ``1.0.0`` -> ``v1``).
+    """
+
+    def test_main_vwip_scenarios_pass(self, tmp_path: Path):
+        _write_spec(tmp_path, "qod", "wip")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, vwip\n"
+            "  Scenario: Create session\n"
+            "    When I send a POST to /quality-on-demand/vwip/sessions\n"
+            "    Then the status code is 201\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_main_bare_wip_in_url_is_error(self, tmp_path: Path):
+        """Bare /wip in a scenario step has no style-variation excuse."""
+        _write_spec(tmp_path, "qod", "wip")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, vwip\n"
+            "  Scenario: Create session\n"
+            "    When I send a POST to /quality-on-demand/wip/sessions\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        findings = check_feature_file_url_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-feature-file-url-version"
+        assert findings[0]["level"] == "error"
+        assert "/wip" in findings[0]["message"]
+        assert "/vwip" in findings[0]["message"]
+        assert findings[0]["line"] == 3
+
+    def test_main_wrong_version_segment_is_error(self, tmp_path: Path):
+        _write_spec(tmp_path, "qod", "wip")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, vwip\n"
+            "  When I send a POST to /quality-on-demand/v1/sessions\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        findings = check_feature_file_url_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "/v1" in findings[0]["message"]
+        assert "/vwip" in findings[0]["message"]
+
+    def test_release_matching_version_passes(self, tmp_path: Path):
+        _write_spec(tmp_path, "qod", "1.0.0")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, v1.0.0\n"
+            "  When I send a POST to /quality-on-demand/v1/sessions\n",
+        )
+        ctx = _make_context("qod", branch_type="release", version="1.0.0")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_release_wrong_version_is_error(self, tmp_path: Path):
+        """/vwip survives into a release snapshot only if T2b failed —
+        treat it as error relative to the release target version."""
+        _write_spec(tmp_path, "qod", "1.0.0")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, v1.0.0\n"
+            "  When I send a POST to /quality-on-demand/vwip/sessions\n",
+        )
+        ctx = _make_context("qod", branch_type="release", version="1.0.0")
+        findings = check_feature_file_url_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "/vwip" in findings[0]["message"]
+        assert "/v1" in findings[0]["message"]
+
+    def test_initial_version_minor_segment(self, tmp_path: Path):
+        """info.version 0.3.0 -> v0.3 (initial-maturity mapping)."""
+        _write_spec(tmp_path, "qod", "0.3.0")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, v0.3.0\n"
+            "  When I send a POST to /quality-on-demand/v0.3/sessions\n",
+        )
+        ctx = _make_context("qod", branch_type="release", version="0.3.0")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_feature_without_url_steps(self, tmp_path: Path):
+        _write_spec(tmp_path, "qod", "wip")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, vwip\n"
+            "  Scenario: plain prose only\n"
+            "    Given an authenticated user\n"
+            "    Then the service responds successfully\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_url_without_version_segment_skipped(self, tmp_path: Path):
+        """A URL with no version/wip segment is silently ignored — scope
+        is URL-version validation, not presence checking."""
+        _write_spec(tmp_path, "qod", "wip")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, vwip\n"
+            "  When I send a GET to /static/index.html\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_multiple_lines_collect_all_findings(self, tmp_path: Path):
+        _write_spec(tmp_path, "qod", "wip")
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, vwip\n"
+            "  When I send a POST to /quality-on-demand/v1/sessions\n"
+            "  And I send a GET to /quality-on-demand/wip/sessions/{id}\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        findings = check_feature_file_url_version(tmp_path, ctx)
+        assert len(findings) == 2
+        lines = {f["line"] for f in findings}
+        assert lines == {2, 3}
+
+    def test_spec_missing_returns_no_findings(self, tmp_path: Path):
+        """No spec file => silent skip (filename/presence checks report)."""
+        _write_feature(
+            tmp_path, "qod.feature",
+            "Feature: QoD, vwip\n"
+            "  When I send a POST to /quality-on-demand/wip/sessions\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_test_dir_missing_returns_no_findings(self, tmp_path: Path):
+        _write_spec(tmp_path, "qod", "wip")
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_no_matching_feature_file(self, tmp_path: Path):
+        """Feature file for a different API => skip (stem doesn't match)."""
+        _write_spec(tmp_path, "qod", "wip")
+        _write_feature(
+            tmp_path, "other-api.feature",
+            "Feature: Other, vwip\n"
+            "  When I send a POST to /other-api/wip/resource\n",
+        )
+        ctx = _make_context("qod", branch_type="main", version="wip")
+        assert check_feature_file_url_version(tmp_path, ctx) == []

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 24
+        assert counts["python"] == 25
         assert counts["spectral"] == 84
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 23
+        assert counts["python"] == 24
         assert counts["spectral"] == 84
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13


### PR DESCRIPTION
#### What type of PR is this?

correction, enhancement/feature

#### What this PR does / why we need it:

Three unrelated small fixes bundled so they share the upcoming manual
E2E cycle for the `@v1-rc` tag move.

**1. `release-automation-reusable.yml`** — sync PR bodies now built via
heredoc into `PR_BODY`, so YAML run-block indent no longer leaks into
rendered markdown. Slash-command detection switched from `startsWith()`
to anchored word-boundary regex so `/create-snapshotextra` can't match
`/create-snapshot`.

**2. Accept bare `wip` in Feature line; error on un-transformable form
(fixes #211)** — T1b pattern `vwip` → `v?wip`; P-007 parser aligned
with T1b (also covers space-only form `Feature: X vwip`). When the
Feature line has no `wip`/`vwip`/`v{version}` token at all, new rule
**P-024** (`default: error`) fires instead of P-007, so the severity
can't be masked by P-007's `conditional_level` (hint/warn). P-007 and
P-024 are mutually exclusive by code path.

**3. Validate URL version in scenario steps (fixes #212)** — new rule
**P-025** `check-feature-file-url-version`. API-scoped: derives expected
segment from `info.version` via `build_version_segment()` and scans each
matching `.feature` file. Sibling to P-004; no style-variation escape
hatch for bare `/wip`.

#### Which issue(s) this PR fixes:

Fixes #211
Fixes #212

#### Special notes for reviewers:

- Three separate commits; file sets disjoint except `python-rules.yaml`
  (different append positions).
- 1517 tests pass (1499 baseline + 18 new in commits 2/3). Rule-metadata
  integrity bumped from `counts["python"] == 23` to `25`.
- Commit 1 has no unit test — both paths run in the E2E cycle already
  required for this tag move.
- Existing regression fixtures should stay green: P-024 needs a Feature
  line with no version token at all; P-025 needs a scenario-step URL
  with a wrong version segment. Neither appears in current fixtures.

#### Changelog input

```
release-note
Accept bare `wip` as a style variation in test Feature lines; new P-024
errors on un-transformable Feature lines; new P-025 validates URL version
segments in feature-file scenario steps.
```

#### Additional documentation

```
docs
```