### PR TITLE
feat(ci): add Release Automation Regression canary + rename VF canary

### DIFF
--- a/.github/workflows/release-automation-regression.yml
+++ b/.github/workflows/release-automation-regression.yml
@@ -1,0 +1,94 @@
+# CAMARA Release Automation — Regression (canary)
+#
+# Sibling to validation-regression.yml. Exercises the release-automation-reusable.yml
+# workflow on camaraproject/ReleaseTest via a /create-snapshot + /discard-snapshot
+# round-trip, catching runtime bugs in the RA workflow and shared actions
+# that the Validation Regression canary cannot reach.
+#
+# Round-trip only — never merges the Release Review PR, never creates a
+# draft build, never calls /publish-release. No real tags or releases
+# are produced. Full manual E2E remains the gate for publish-side changes
+# before @v1-rc moves.
+#
+# Cross-repo access is provided by a short-lived camara-validation
+# GitHub App installation token scoped to camaraproject/ReleaseTest.
+# Permissions used: issues:write (post slash-command comment),
+# actions:write (poll caller runs), pull_requests:write (verify Release
+# Review PR presence). The App has no contents:write — and none is needed.
+# The default GITHUB_TOKEN is only used for the initial checkout.
+
+name: Release Automation Regression
+
+on:
+  push:
+    branches: [validation-framework]
+    paths:
+      - '.github/workflows/release-automation-reusable.yml'
+      - '.github/workflows/release-automation-regression.yml'
+      - 'release_automation/**'
+      - 'shared-actions/**'
+      - 'tooling_lib/**'
+  workflow_dispatch:
+
+concurrency:
+  group: release-automation-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  regression:
+    name: RA regression canary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install runner dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pyyaml
+
+      - name: Mint validation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VALIDATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VALIDATION_APP_PRIVATE_KEY }}
+          owner: camaraproject
+          repositories: ReleaseTest
+
+      - name: Run RA regression runner
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python3 release_automation/scripts/regression_runner.py \
+            --repo camaraproject/ReleaseTest \
+            --release-issue 90 \
+            --summary-file release-automation-regression-summary.md
+
+      - name: Publish summary
+        if: always()
+        run: |
+          if [ -f release-automation-regression-summary.md ]; then
+            cat release-automation-regression-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::release-automation-regression-summary.md not produced (runner likely failed before writing)"
+          fi
+
+      - name: Upload summary artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-automation-regression-summary
+          path: release-automation-regression-summary.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/validation-regression.yml
+++ b/.github/workflows/validation-regression.yml
@@ -1,4 +1,4 @@
-# CAMARA Validation Framework — Regression Runner (canary)
+# CAMARA Validation Framework — Validation Regression (canary)
 #
 # Auto-dispatches validation/scripts/regression_runner.py against
 # camaraproject/ReleaseTest on every push to validation-framework, so
@@ -16,7 +16,7 @@
 #
 # See validation/docs/regression-testing.md for the full picture.
 
-name: Regression Runner
+name: Validation Regression
 
 on:
   push:
@@ -26,11 +26,11 @@ on:
       - 'shared-actions/**'
       - 'tooling_lib/**'
       - '.github/workflows/validation.yml'
-      - '.github/workflows/regression-runner.yml'
+      - '.github/workflows/validation-regression.yml'
   workflow_dispatch:
 
 concurrency:
-  group: regression-runner-${{ github.ref }}
+  group: validation-regression-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -72,22 +72,22 @@ jobs:
           python3 validation/scripts/regression_runner.py \
             --repo camaraproject/ReleaseTest \
             --branch-filter 'regression/*' \
-            --summary-file regression-summary.md
+            --summary-file validation-regression-summary.md
 
       - name: Publish summary
         if: always()
         run: |
-          if [ -f regression-summary.md ]; then
-            cat regression-summary.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -f validation-regression-summary.md ]; then
+            cat validation-regression-summary.md >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "::warning::regression-summary.md not produced (runner likely failed before writing)"
+            echo "::warning::validation-regression-summary.md not produced (runner likely failed before writing)"
           fi
 
       - name: Upload summary artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: regression-runner-summary
-          path: regression-summary.md
+          name: validation-regression-summary
+          path: validation-regression-summary.md
           if-no-files-found: warn
           retention-days: 30

--- a/release_automation/scripts/regression_runner.py
+++ b/release_automation/scripts/regression_runner.py
@@ -1,0 +1,813 @@
+#!/usr/bin/env python3
+"""
+CAMARA Release Automation — Regression Runner
+
+Exercises the release-automation-reusable.yml workflow on a persistent
+test repository (default: camaraproject/ReleaseTest) via a round-trip
+/create-snapshot + /discard-snapshot pair. Catches the bug class that
+the validation regression canary cannot reach — runtime bugs in the RA
+workflow and its shared actions. See the sibling validation regression
+runner at validation/scripts/regression_runner.py.
+
+Usage:
+    python3 regression_runner.py --repo camaraproject/ReleaseTest \\
+        --release-issue 90 \\
+        [--summary-file release-automation-regression-summary.md]
+
+    # Dry-run (no comments posted, no runs polled):
+    python3 regression_runner.py --repo ... --release-issue 90 --dry-run
+
+Exit codes:
+    0  all phases PASS
+    1  verification failure (run concluded non-success or post-state mismatch)
+    2  infrastructure failure (gh error, timeout, state unsafe to proceed)
+
+No real releases, tags, or draft builds are produced. The round-trip only
+covers commands that are reversible — merging the Release Review PR or
+invoking /publish-release is explicitly out of scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Package-relative imports so unit tests can patch at the right boundary.
+# The release_automation/ package is already on sys.path when invoked via
+# python3 release_automation/scripts/regression_runner.py (pytest uses
+# repo root and the package's __init__.py).
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from config import (  # noqa: E402
+    LABEL_RELEASE_MGMT_BOT,
+    RELEASE_REVIEW_BRANCH_PREFIX,
+    SNAPSHOT_BRANCH_PREFIX,
+    STATE_PLANNED,
+    STATE_SNAPSHOT_ACTIVE,
+)
+
+
+logger = logging.getLogger("ra_regression_runner")
+
+
+# Label prefix used by release-automation-reusable.yml for issue state.
+# Deliberately hardcoded here rather than added to config.py — the value
+# is defined by the reusable workflow's state-update step, not by the
+# Python modules. If the workflow changes the prefix, update this line.
+# Source of truth: .github/workflows/release-automation-reusable.yml
+_STATE_LABEL_PREFIX = "release-state:"
+
+# Caller workflow filename on the target test repo. Each release-plan
+# repo copies this caller from the shared template.
+_RA_CALLER_WORKFLOW = "release-automation.yml"
+
+
+# ---------------------------------------------------------------------------
+# Errors + phase report
+# ---------------------------------------------------------------------------
+
+
+class InfrastructureError(RuntimeError):
+    """Raised for gh errors, missing preconditions, or timeouts.
+
+    Distinct from a verification failure (which is a regression in RA, not
+    infrastructure). Infrastructure errors map to exit code 2; verification
+    failures map to exit 1.
+    """
+
+
+@dataclass
+class PhaseReport:
+    """Per-phase PASS/FAIL record with human-readable detail."""
+
+    name: str
+    passed: bool = False
+    detail: str = ""
+    run_url: str | None = None
+    run_conclusion: str | None = None
+    extras: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# GitHub I/O helpers (duplicated from validation/scripts/regression_runner.py)
+# ---------------------------------------------------------------------------
+
+
+def gh(args: list[str], *, parse_json: bool = False) -> Any:
+    """Run `gh <args>` and return stdout (optionally JSON-parsed).
+
+    Raises InfrastructureError on non-zero exit. Stderr is captured and
+    included in the exception message for diagnosis.
+    """
+    cmd = ["gh", *args]
+    logger.debug("gh call: %s", " ".join(cmd))
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True
+        )
+    except FileNotFoundError as exc:
+        raise InfrastructureError(
+            "gh CLI not found — install https://cli.github.com and run `gh auth login`"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise InfrastructureError(
+            f"gh {' '.join(args)}: exit {exc.returncode}\n"
+            f"stderr: {exc.stderr.strip()}"
+        ) from exc
+    if parse_json:
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise InfrastructureError(
+                f"gh {' '.join(args)}: could not parse stdout as JSON: {exc}"
+            ) from exc
+    return result.stdout
+
+
+def _iso_to_dt(stamp: str) -> datetime:
+    """Parse a GitHub ISO-8601 timestamp (UTC) to a timezone-aware datetime."""
+    return datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+
+
+def poll_run(
+    repo: str,
+    run_id: str,
+    *,
+    interval: int,
+    timeout: int,
+) -> str:
+    """Wait until *run_id* completes; return its conclusion string.
+
+    Raises InfrastructureError on timeout. Conclusion may be "success",
+    "failure", "cancelled", "neutral", "skipped", etc. — caller decides
+    what to treat as verification failure vs infrastructure failure.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        data = gh(
+            [
+                "run", "view", run_id,
+                "--repo", repo,
+                "--json", "status,conclusion",
+            ],
+            parse_json=True,
+        )
+        status = data.get("status")
+        conclusion = data.get("conclusion") or ""
+        logger.debug("run %s status=%s conclusion=%s", run_id, status, conclusion)
+        if status == "completed":
+            return conclusion
+        if time.monotonic() >= deadline:
+            raise InfrastructureError(
+                f"run {run_id} did not complete within {timeout}s "
+                f"(last status={status})"
+            )
+        time.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# Issue / branch / PR readers
+# ---------------------------------------------------------------------------
+
+
+def read_state_label(labels: list[dict[str, Any]]) -> str | None:
+    """Extract the release-state:* value from a list of label objects.
+
+    Returns the state string (e.g. "planned", "snapshot-active") or None
+    if no release-state:* label is present. Raises InfrastructureError if
+    more than one release-state:* label is found — that indicates workflow
+    corruption and must not be silently collapsed.
+    """
+    found: list[str] = []
+    for label in labels:
+        name = label.get("name") if isinstance(label, dict) else None
+        if isinstance(name, str) and name.startswith(_STATE_LABEL_PREFIX):
+            found.append(name[len(_STATE_LABEL_PREFIX):])
+    if len(found) > 1:
+        raise InfrastructureError(
+            f"Release Issue carries multiple {_STATE_LABEL_PREFIX}* labels: "
+            f"{sorted(found)}"
+        )
+    return found[0] if found else None
+
+
+def get_release_issue_state(repo: str, issue_number: int) -> str | None:
+    """Read the release-state:* label value on the given issue."""
+    data = gh(
+        [
+            "api", f"repos/{repo}/issues/{issue_number}",
+            "--jq", "{labels: .labels, state: .state}",
+        ],
+        parse_json=True,
+    )
+    if data.get("state") != "open":
+        raise InfrastructureError(
+            f"{repo}#{issue_number}: issue is not open (state={data.get('state')!r})"
+        )
+    return read_state_label(data.get("labels", []))
+
+
+def snapshot_id_from_branch(branch_name: str) -> str:
+    """Extract snapshot id from a release-snapshot/ or release-review/ branch name.
+
+    Example:
+        'release-snapshot/r1.2-abc1234' -> 'r1.2-abc1234'
+        'release-review/r1.2-abc1234' -> 'r1.2-abc1234'
+        'release-review/r1.2-abc1234-preserved' -> 'r1.2-abc1234'
+    """
+    for prefix in (SNAPSHOT_BRANCH_PREFIX, RELEASE_REVIEW_BRANCH_PREFIX):
+        if branch_name.startswith(prefix):
+            tail = branch_name[len(prefix):]
+            if tail.endswith("-preserved"):
+                tail = tail[: -len("-preserved")]
+            return tail
+    raise InfrastructureError(
+        f"not a snapshot/review branch name: {branch_name!r}"
+    )
+
+
+def find_snapshot_branch(repo: str) -> str | None:
+    """Return the name of the single active release-snapshot/* branch, or None.
+
+    Raises InfrastructureError if more than one snapshot branch exists —
+    that indicates prior-run corruption and must not be silently collapsed.
+    """
+    data = gh(
+        [
+            "api", f"repos/{repo}/branches",
+            "--paginate",
+            "--jq", ".[].name",
+        ]
+    )
+    names = [
+        line.strip()
+        for line in data.splitlines()
+        if line.strip().startswith(SNAPSHOT_BRANCH_PREFIX)
+    ]
+    if len(names) > 1:
+        raise InfrastructureError(
+            f"{repo}: multiple active snapshot branches: {names}"
+        )
+    return names[0] if names else None
+
+
+def branch_exists(repo: str, branch_name: str) -> bool:
+    """Return True iff *branch_name* currently exists on *repo*."""
+    try:
+        gh(
+            [
+                "api", f"repos/{repo}/branches/{branch_name}",
+                "--jq", ".name",
+            ]
+        )
+        return True
+    except InfrastructureError as exc:
+        # `gh api` returns non-zero with "HTTP 404" in stderr for missing
+        # branches. Any other error re-raises.
+        if "HTTP 404" in str(exc) or "Not Found" in str(exc):
+            return False
+        raise
+
+
+def release_review_pr_for_issue(repo: str, issue_number: int) -> int | None:
+    """Return the PR number of the Release Review PR referencing *issue_number*, or None.
+
+    The Release Review PR is the one whose head branch matches
+    release-review/* AND whose body references #<issue_number>. Since the
+    head-branch invariant is sufficient on a round-trip-tested repo, we
+    search on head branch only.
+    """
+    data = gh(
+        [
+            "pr", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--json", "number,headRefName,title",
+            "--limit", "20",
+        ],
+        parse_json=True,
+    )
+    for pr in data:
+        head = pr.get("headRefName", "")
+        if head.startswith(RELEASE_REVIEW_BRANCH_PREFIX) and not head.endswith(
+            "-preserved"
+        ):
+            return pr.get("number")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fire + run discovery
+# ---------------------------------------------------------------------------
+
+
+def post_issue_comment(repo: str, issue_number: int, body: str) -> None:
+    """Post *body* as a new comment on *issue_number* in *repo*."""
+    gh(
+        [
+            "issue", "comment", str(issue_number),
+            "--repo", repo,
+            "--body", body,
+        ]
+    )
+
+
+def find_recent_caller_run(
+    repo: str,
+    *,
+    workflow_file: str,
+    since: datetime,
+    attempts: int = 15,
+    interval: float = 2.0,
+) -> dict[str, Any]:
+    """Poll `gh run list` for an issue_comment-triggered run newer than *since*.
+
+    Returns the run dict (with databaseId, createdAt, url, status, conclusion)
+    once one is observed. Raises InfrastructureError on timeout.
+    """
+    for _ in range(attempts):
+        time.sleep(interval)
+        runs = gh(
+            [
+                "run", "list",
+                "--repo", repo,
+                "--workflow", workflow_file,
+                "--event", "issue_comment",
+                "--json", "databaseId,createdAt,status,conclusion,url",
+                "--limit", "10",
+            ],
+            parse_json=True,
+        )
+        candidates: list[dict[str, Any]] = []
+        for run in runs:
+            try:
+                created = _iso_to_dt(run["createdAt"])
+            except (KeyError, ValueError):
+                continue
+            if created >= since:
+                candidates.append(run)
+        if candidates:
+            # Newest first — take the one with the latest createdAt.
+            candidates.sort(key=lambda r: r["createdAt"], reverse=True)
+            run = candidates[0]
+            logger.info(
+                "found caller run id=%s (%s)",
+                run.get("databaseId"), run.get("url"),
+            )
+            return run
+    raise InfrastructureError(
+        f"{repo}: no {workflow_file} issue_comment run appeared within "
+        f"{attempts * interval:.0f}s since {since.isoformat()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phases
+# ---------------------------------------------------------------------------
+
+
+def phase_pre_check(repo: str, issue_number: int) -> PhaseReport:
+    """Phase 1 — confirm the target issue is in release-state:planned.
+
+    Fail-loudly if it is not. Any other state risks stomping on a real
+    release cycle (or a prior smoke run that left state dirty); recovery
+    is a manual /discard-snapshot by an operator.
+    """
+    report = PhaseReport(name="pre-check")
+    try:
+        state = get_release_issue_state(repo, issue_number)
+    except InfrastructureError as exc:
+        report.detail = f"could not read state: {exc}"
+        return report
+
+    if state is None:
+        report.detail = (
+            f"{repo}#{issue_number} has no {_STATE_LABEL_PREFIX}* label — "
+            f"unsafe to proceed"
+        )
+        return report
+
+    if state != STATE_PLANNED:
+        hint = ""
+        if state == STATE_SNAPSHOT_ACTIVE:
+            hint = (
+                " — a prior run may have left state dirty; manual "
+                "`/discard-snapshot` on the Release Issue is required to "
+                "recover before the next run"
+            )
+        report.detail = (
+            f"state is {state!r}, expected {STATE_PLANNED!r}{hint}"
+        )
+        return report
+
+    report.passed = True
+    report.detail = f"state={state!r} on {repo}#{issue_number}"
+    return report
+
+
+def phase_fire_create_snapshot(
+    repo: str,
+    issue_number: int,
+    *,
+    poll_timeout: int,
+    dry_run: bool,
+) -> tuple[PhaseReport, str | None]:
+    """Phase 2 — post /create-snapshot, discover the caller run, poll it.
+
+    Returns (report, run_id). run_id is None on dry-run or failure.
+    """
+    report = PhaseReport(name="fire /create-snapshot")
+    if dry_run:
+        report.passed = True
+        report.detail = f"DRY-RUN: would post /create-snapshot on {repo}#{issue_number}"
+        return report, None
+
+    marker = datetime.now(timezone.utc).replace(microsecond=0)
+    try:
+        post_issue_comment(repo, issue_number, "/create-snapshot")
+        logger.info("posted /create-snapshot on %s#%s; polling for run", repo, issue_number)
+        run = find_recent_caller_run(
+            repo,
+            workflow_file=_RA_CALLER_WORKFLOW,
+            since=marker,
+        )
+    except InfrastructureError as exc:
+        report.detail = f"could not fire /create-snapshot: {exc}"
+        return report, None
+
+    run_id = str(run["databaseId"])
+    report.run_url = run.get("url")
+
+    try:
+        conclusion = poll_run(
+            repo, run_id, interval=15, timeout=poll_timeout
+        )
+    except InfrastructureError as exc:
+        report.detail = f"run {run_id} polling error: {exc}"
+        return report, run_id
+
+    report.run_conclusion = conclusion
+    if conclusion == "success":
+        report.passed = True
+        report.detail = f"run completed with conclusion={conclusion!r}"
+    else:
+        report.detail = (
+            f"run concluded {conclusion!r} (expected 'success') — "
+            f"see run for details"
+        )
+    return report, run_id
+
+
+def phase_verify_post_create(repo: str, issue_number: int) -> tuple[PhaseReport, str | None]:
+    """Phase 3 — confirm the world looks like a successful /create-snapshot.
+
+    Requirements:
+    - issue state label == snapshot-active
+    - exactly one release-snapshot/* branch exists
+    - a Release Review PR exists (head branch starts with release-review/)
+
+    Returns (report, snapshot_id) — snapshot_id is needed by verify-post-discard
+    to confirm the rename to -preserved.
+    """
+    report = PhaseReport(name="verify post-create")
+    try:
+        state = get_release_issue_state(repo, issue_number)
+    except InfrastructureError as exc:
+        report.detail = f"could not read state: {exc}"
+        return report, None
+
+    checks: list[tuple[bool, str]] = []
+
+    state_ok = state == STATE_SNAPSHOT_ACTIVE
+    checks.append(
+        (state_ok, f"state={state!r} {'==' if state_ok else '!='} snapshot-active")
+    )
+
+    try:
+        snapshot_branch = find_snapshot_branch(repo)
+    except InfrastructureError as exc:
+        report.detail = f"snapshot branch lookup failed: {exc}"
+        return report, None
+    checks.append(
+        (snapshot_branch is not None, f"snapshot branch={snapshot_branch!r}")
+    )
+
+    try:
+        pr_number = release_review_pr_for_issue(repo, issue_number)
+    except InfrastructureError as exc:
+        report.detail = f"PR lookup failed: {exc}"
+        return report, None
+    checks.append(
+        (pr_number is not None, f"release review PR=#{pr_number}" if pr_number else "no release review PR")
+    )
+
+    report.extras = [msg for _, msg in checks]
+    report.passed = all(ok for ok, _ in checks)
+    report.detail = "; ".join(msg for _, msg in checks)
+
+    snapshot_id: str | None = None
+    if snapshot_branch:
+        try:
+            snapshot_id = snapshot_id_from_branch(snapshot_branch)
+        except InfrastructureError:
+            snapshot_id = None
+    return report, snapshot_id
+
+
+def phase_fire_discard_snapshot(
+    repo: str,
+    issue_number: int,
+    *,
+    poll_timeout: int,
+    dry_run: bool,
+) -> tuple[PhaseReport, str | None]:
+    """Phase 4 — post /discard-snapshot, discover the caller run, poll it."""
+    report = PhaseReport(name="fire /discard-snapshot")
+    if dry_run:
+        report.passed = True
+        report.detail = f"DRY-RUN: would post /discard-snapshot on {repo}#{issue_number}"
+        return report, None
+
+    marker = datetime.now(timezone.utc).replace(microsecond=0)
+    try:
+        post_issue_comment(repo, issue_number, "/discard-snapshot")
+        logger.info("posted /discard-snapshot on %s#%s; polling for run", repo, issue_number)
+        run = find_recent_caller_run(
+            repo,
+            workflow_file=_RA_CALLER_WORKFLOW,
+            since=marker,
+        )
+    except InfrastructureError as exc:
+        report.detail = f"could not fire /discard-snapshot: {exc}"
+        return report, None
+
+    run_id = str(run["databaseId"])
+    report.run_url = run.get("url")
+
+    try:
+        conclusion = poll_run(
+            repo, run_id, interval=15, timeout=poll_timeout
+        )
+    except InfrastructureError as exc:
+        report.detail = f"run {run_id} polling error: {exc}"
+        return report, run_id
+
+    report.run_conclusion = conclusion
+    if conclusion == "success":
+        report.passed = True
+        report.detail = f"run completed with conclusion={conclusion!r}"
+    else:
+        report.detail = (
+            f"run concluded {conclusion!r} (expected 'success') — "
+            f"see run for details"
+        )
+    return report, run_id
+
+
+def phase_verify_post_discard(
+    repo: str, issue_number: int, snapshot_id: str | None
+) -> PhaseReport:
+    """Phase 5 — confirm the world looks like a successful /discard-snapshot.
+
+    Requirements:
+    - issue state label == planned
+    - the prior release-snapshot/<snapshot_id> branch is gone
+    - a release-review/<snapshot_id>-preserved branch exists
+    """
+    report = PhaseReport(name="verify post-discard")
+    try:
+        state = get_release_issue_state(repo, issue_number)
+    except InfrastructureError as exc:
+        report.detail = f"could not read state: {exc}"
+        return report
+
+    checks: list[tuple[bool, str]] = []
+
+    state_ok = state == STATE_PLANNED
+    checks.append(
+        (state_ok, f"state={state!r} {'==' if state_ok else '!='} planned")
+    )
+
+    if snapshot_id:
+        snap_branch = f"{SNAPSHOT_BRANCH_PREFIX}{snapshot_id}"
+        preserved_branch = f"{RELEASE_REVIEW_BRANCH_PREFIX}{snapshot_id}-preserved"
+        try:
+            snap_still = branch_exists(repo, snap_branch)
+            preserved = branch_exists(repo, preserved_branch)
+        except InfrastructureError as exc:
+            report.detail = f"branch existence check failed: {exc}"
+            return report
+        checks.append(
+            (not snap_still, f"snapshot branch {snap_branch!r} {'still exists' if snap_still else 'gone'}")
+        )
+        checks.append(
+            (preserved, f"preserved branch {preserved_branch!r} {'present' if preserved else 'missing'}")
+        )
+    else:
+        checks.append(
+            (False, "snapshot_id not captured in phase 3 — skipping branch checks")
+        )
+
+    report.extras = [msg for _, msg in checks]
+    report.passed = all(ok for ok, _ in checks)
+    report.detail = "; ".join(msg for _, msg in checks)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(reports: list[PhaseReport], repo: str, issue_number: int) -> str:
+    """Render a phase-by-phase PASS/FAIL summary as markdown."""
+    passed = sum(1 for r in reports if r.passed)
+    total = len(reports)
+    lines: list[str] = []
+    lines.append(
+        f"## Release Automation Regression — {passed}/{total} phases PASS"
+    )
+    lines.append("")
+    lines.append(f"- target repo: `{repo}`")
+    lines.append(f"- release issue: #{issue_number}")
+    lines.append("")
+    lines.append("| Phase | Result | Detail |")
+    lines.append("|---|---|---|")
+    for report in reports:
+        status = "PASS" if report.passed else "FAIL"
+        detail = report.detail.replace("|", "\\|") if report.detail else "-"
+        lines.append(f"| {report.name} | {status} | {detail} |")
+
+    # Per-phase detail (run URLs, extras)
+    for report in reports:
+        if report.run_url is None and not report.extras:
+            continue
+        lines.append("")
+        lines.append(f"### {report.name}")
+        if report.run_url:
+            lines.append(f"- run: {report.run_url}")
+        if report.run_conclusion:
+            lines.append(f"- conclusion: `{report.run_conclusion}`")
+        for extra in report.extras:
+            lines.append(f"- {extra}")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="regression_runner.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="owner/repo of the test repository (e.g. camaraproject/ReleaseTest)",
+    )
+    parser.add_argument(
+        "--release-issue",
+        type=int,
+        required=True,
+        help="issue number of the persistent Release Issue on --repo",
+    )
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        help="write a markdown summary report to this path",
+    )
+    parser.add_argument(
+        "--poll-timeout",
+        type=int,
+        default=600,
+        help="max seconds to wait for each caller run to complete (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="do not post comments or poll runs; only exercise the pre-check",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="verbose logging",
+    )
+    return parser
+
+
+def _setup_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-5s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def run_phases(
+    repo: str,
+    issue_number: int,
+    *,
+    poll_timeout: int,
+    dry_run: bool,
+) -> list[PhaseReport]:
+    """Orchestrate all phases. Stop at the first fatal-to-continue failure."""
+    reports: list[PhaseReport] = []
+
+    pre = phase_pre_check(repo, issue_number)
+    reports.append(pre)
+    if not pre.passed:
+        return reports
+
+    create_report, _create_run_id = phase_fire_create_snapshot(
+        repo, issue_number,
+        poll_timeout=poll_timeout, dry_run=dry_run,
+    )
+    reports.append(create_report)
+    if dry_run:
+        logger.info("dry-run: skipping post-create verify, discard, post-discard verify")
+        return reports
+    if not create_report.passed:
+        # A failed /create-snapshot should not be followed by /discard-snapshot:
+        # if /create-snapshot failed before changing state, discard is invalid;
+        # if /create-snapshot failed after changing state, an operator needs
+        # to investigate before automation mutates further.
+        return reports
+
+    verify_create, snapshot_id = phase_verify_post_create(repo, issue_number)
+    reports.append(verify_create)
+
+    discard_report, _discard_run_id = phase_fire_discard_snapshot(
+        repo, issue_number,
+        poll_timeout=poll_timeout, dry_run=dry_run,
+    )
+    reports.append(discard_report)
+    if not discard_report.passed:
+        return reports
+
+    verify_discard = phase_verify_post_discard(repo, issue_number, snapshot_id)
+    reports.append(verify_discard)
+    return reports
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_argparser().parse_args(argv)
+    _setup_logging(args.verbose)
+
+    try:
+        reports = run_phases(
+            args.repo, args.release_issue,
+            poll_timeout=args.poll_timeout,
+            dry_run=args.dry_run,
+        )
+    except InfrastructureError as exc:
+        print(f"INFRA: {exc}", file=sys.stderr)
+        return 2
+
+    markdown = render_markdown(reports, args.repo, args.release_issue)
+    print(markdown)
+    if args.summary_file:
+        args.summary_file.write_text(markdown, encoding="utf-8")
+
+    all_passed = all(r.passed for r in reports)
+    passed = sum(1 for r in reports if r.passed)
+    total = len(reports)
+    print(
+        f"{'PASS' if all_passed else 'FAIL'}: {passed}/{total} phases",
+        file=sys.stderr,
+    )
+
+    # Distinguish infrastructure exit (2) from verification exit (1).
+    # Infrastructure exit is surfaced earlier via the InfrastructureError
+    # path above. If we got here but not all phases passed, it's either
+    # a verification failure (conclusion != success or state mismatch)
+    # OR an infrastructure problem captured inside a phase's detail (the
+    # phase put a "could not ..." message into report.detail). We treat
+    # the former as exit 1 and the latter as exit 2 by looking at the
+    # first failing phase's detail for the sentinel prefix "could not".
+    if all_passed:
+        return 0
+    for report in reports:
+        if not report.passed and report.detail.startswith("could not "):
+            return 2
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/release_automation/tests/test_regression_runner.py
+++ b/release_automation/tests/test_regression_runner.py
@@ -1,0 +1,583 @@
+"""
+Unit tests for the Release Automation regression runner.
+
+Pure-logic coverage only — network and subprocess calls are mocked at the
+`gh()` boundary. These tests verify state-label parsing, run-discovery
+filtering, markdown rendering, phase decision matrix, and branch-name
+parsing. Integration behaviour is covered by CI staging (see
+private-dev-docs/validation-framework/prompts/prompt-project-session.md).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from release_automation.scripts.regression_runner import (
+    InfrastructureError,
+    PhaseReport,
+    _iso_to_dt,
+    find_recent_caller_run,
+    get_release_issue_state,
+    phase_pre_check,
+    phase_verify_post_create,
+    phase_verify_post_discard,
+    read_state_label,
+    render_markdown,
+    snapshot_id_from_branch,
+)
+
+
+# ---------------------------------------------------------------------------
+# read_state_label
+# ---------------------------------------------------------------------------
+
+
+class TestReadStateLabel:
+    def test_returns_planned(self):
+        labels = [
+            {"name": "release-issue"},
+            {"name": "release-state:planned"},
+        ]
+        assert read_state_label(labels) == "planned"
+
+    def test_returns_snapshot_active(self):
+        labels = [{"name": "release-state:snapshot-active"}]
+        assert read_state_label(labels) == "snapshot-active"
+
+    def test_returns_none_when_no_state_label(self):
+        labels = [{"name": "release-issue"}, {"name": "bug"}]
+        assert read_state_label(labels) is None
+
+    def test_returns_none_for_empty_list(self):
+        assert read_state_label([]) is None
+
+    def test_raises_on_multiple_state_labels(self):
+        labels = [
+            {"name": "release-state:planned"},
+            {"name": "release-state:snapshot-active"},
+        ]
+        with pytest.raises(InfrastructureError, match="multiple"):
+            read_state_label(labels)
+
+    def test_ignores_non_dict_entries(self):
+        labels = [None, "weird", {"name": "release-state:planned"}]
+        assert read_state_label(labels) == "planned"
+
+    def test_ignores_non_string_name(self):
+        labels = [{"name": 42}, {"name": "release-state:planned"}]
+        assert read_state_label(labels) == "planned"
+
+    def test_ignores_labels_without_name_key(self):
+        labels = [{"color": "red"}, {"name": "release-state:planned"}]
+        assert read_state_label(labels) == "planned"
+
+
+# ---------------------------------------------------------------------------
+# snapshot_id_from_branch
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotIdFromBranch:
+    def test_snapshot_branch(self):
+        assert snapshot_id_from_branch("release-snapshot/r1.2-abc1234") == "r1.2-abc1234"
+
+    def test_release_review_branch(self):
+        assert snapshot_id_from_branch("release-review/r1.2-abc1234") == "r1.2-abc1234"
+
+    def test_preserved_branch(self):
+        assert (
+            snapshot_id_from_branch("release-review/r1.2-abc1234-preserved")
+            == "r1.2-abc1234"
+        )
+
+    def test_rejects_unrelated_branch(self):
+        with pytest.raises(InfrastructureError, match="not a snapshot/review branch"):
+            snapshot_id_from_branch("main")
+
+    def test_rejects_feature_branch(self):
+        with pytest.raises(InfrastructureError):
+            snapshot_id_from_branch("feat/something")
+
+
+# ---------------------------------------------------------------------------
+# _iso_to_dt
+# ---------------------------------------------------------------------------
+
+
+class TestIsoToDt:
+    def test_parses_utc_timestamp(self):
+        result = _iso_to_dt("2026-04-22T15:30:00Z")
+        assert result == datetime(2026, 4, 22, 15, 30, 0, tzinfo=timezone.utc)
+        assert result.tzinfo is timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# phase_pre_check — decision matrix
+# ---------------------------------------------------------------------------
+
+
+def _mock_issue_labels(labels: list[dict[str, str]], state: str = "open"):
+    """Helper that returns a dict mimicking `gh api issues/<N>` output."""
+    return {"labels": labels, "state": state}
+
+
+class TestPhasePreCheck:
+    def test_pass_when_state_planned(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels([{"name": "release-state:planned"}]),
+        ):
+            report = phase_pre_check("camaraproject/ReleaseTest", 90)
+        assert report.passed is True
+        assert "planned" in report.detail
+
+    def test_fail_when_snapshot_active(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels(
+                [{"name": "release-state:snapshot-active"}]
+            ),
+        ):
+            report = phase_pre_check("camaraproject/ReleaseTest", 90)
+        assert report.passed is False
+        assert "snapshot-active" in report.detail
+        # The snapshot-active branch emits the manual-recovery hint.
+        assert "/discard-snapshot" in report.detail
+
+    def test_fail_when_draft_ready(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels(
+                [{"name": "release-state:draft-ready"}]
+            ),
+        ):
+            report = phase_pre_check("camaraproject/ReleaseTest", 90)
+        assert report.passed is False
+        assert "draft-ready" in report.detail
+        # Non-snapshot-active states do NOT get the discard hint (it would be wrong).
+        assert "/discard-snapshot" not in report.detail
+
+    def test_fail_when_published(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels(
+                [{"name": "release-state:published"}]
+            ),
+        ):
+            report = phase_pre_check("camaraproject/ReleaseTest", 90)
+        assert report.passed is False
+
+    def test_fail_when_no_state_label(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels([{"name": "other"}]),
+        ):
+            report = phase_pre_check("camaraproject/ReleaseTest", 90)
+        assert report.passed is False
+        assert "no release-state:" in report.detail
+
+    def test_fail_when_issue_closed(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels(
+                [{"name": "release-state:planned"}], state="closed",
+            ),
+        ):
+            report = phase_pre_check("camaraproject/ReleaseTest", 90)
+        assert report.passed is False
+        assert "could not read state" in report.detail
+        # Infrastructure-style message — has the "could not" sentinel that
+        # drives exit-code 2 classification in main().
+        assert report.detail.startswith("could not ")
+
+
+# ---------------------------------------------------------------------------
+# get_release_issue_state (integration through gh mock)
+# ---------------------------------------------------------------------------
+
+
+class TestGetReleaseIssueState:
+    def test_extracts_state(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels([{"name": "release-state:planned"}]),
+        ):
+            assert get_release_issue_state("o/r", 1) == "planned"
+
+    def test_returns_none_when_absent(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels([]),
+        ):
+            assert get_release_issue_state("o/r", 1) is None
+
+    def test_raises_when_not_open(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=_mock_issue_labels([], state="closed"),
+        ):
+            with pytest.raises(InfrastructureError, match="not open"):
+                get_release_issue_state("o/r", 1)
+
+
+# ---------------------------------------------------------------------------
+# find_recent_caller_run — event filter + newest-after-marker selection
+# ---------------------------------------------------------------------------
+
+
+class TestFindRecentCallerRun:
+    def test_picks_newest_after_marker(self):
+        marker = datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc)
+        runs = [
+            {
+                "databaseId": 1,
+                "createdAt": "2026-04-22T09:59:00Z",
+                "status": "completed",
+                "conclusion": "success",
+                "url": "https://x/1",
+            },
+            {
+                "databaseId": 2,
+                "createdAt": "2026-04-22T10:01:00Z",
+                "status": "in_progress",
+                "conclusion": None,
+                "url": "https://x/2",
+            },
+            {
+                "databaseId": 3,
+                "createdAt": "2026-04-22T10:02:00Z",
+                "status": "queued",
+                "conclusion": None,
+                "url": "https://x/3",
+            },
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=runs,
+        ):
+            run = find_recent_caller_run(
+                "o/r",
+                workflow_file="release-automation.yml",
+                since=marker,
+                attempts=1,
+                interval=0.0,
+            )
+        # Newest (after marker) is run 3.
+        assert run["databaseId"] == 3
+
+    def test_ignores_runs_before_marker(self):
+        marker = datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc)
+        runs = [
+            {
+                "databaseId": 1,
+                "createdAt": "2026-04-22T09:00:00Z",
+                "status": "completed",
+                "conclusion": "success",
+                "url": "https://x/1",
+            },
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=runs,
+        ):
+            with pytest.raises(InfrastructureError, match="no .* run appeared"):
+                find_recent_caller_run(
+                    "o/r",
+                    workflow_file="release-automation.yml",
+                    since=marker,
+                    attempts=1,
+                    interval=0.0,
+                )
+
+    def test_ignores_malformed_timestamps(self):
+        marker = datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc)
+        runs = [
+            {
+                "databaseId": 1,
+                "createdAt": "not-a-timestamp",
+                "status": "queued",
+                "conclusion": None,
+                "url": "https://x/1",
+            },
+            {
+                "databaseId": 2,
+                "createdAt": "2026-04-22T10:05:00Z",
+                "status": "queued",
+                "conclusion": None,
+                "url": "https://x/2",
+            },
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=runs,
+        ):
+            run = find_recent_caller_run(
+                "o/r",
+                workflow_file="release-automation.yml",
+                since=marker,
+                attempts=1,
+                interval=0.0,
+            )
+        assert run["databaseId"] == 2
+
+
+# ---------------------------------------------------------------------------
+# phase_verify_post_create
+# ---------------------------------------------------------------------------
+
+
+def _make_gh_router(responses):
+    """Dispatch gh(args) calls to successive responses keyed by first arg pattern.
+
+    Each response is (match_prefix, return_value). The router is called
+    with the full args list and returns the first matching response.
+    """
+    def router(args, parse_json=False):  # noqa: ARG001
+        for pattern, value in responses:
+            if pattern in " ".join(args):
+                return value
+        raise AssertionError(f"no mock configured for: {args}")
+    return router
+
+
+class TestPhaseVerifyPostCreate:
+    def test_pass_when_all_three_checks_ok(self):
+        issue_response = {
+            "labels": [{"name": "release-state:snapshot-active"}],
+            "state": "open",
+        }
+        branches_response = (
+            "main\nrelease-snapshot/r1.2-abc1234\nrelease-review/r1.2-abc1234\n"
+        )
+        pr_list_response = [
+            {
+                "number": 101,
+                "headRefName": "release-review/r1.2-abc1234",
+                "title": "Release Review: ...",
+            }
+        ]
+        responses = [
+            ("issues/90", issue_response),
+            ("/branches --paginate", branches_response),
+            ("pr list", pr_list_response),
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=_make_gh_router(responses),
+        ):
+            report, snapshot_id = phase_verify_post_create(
+                "camaraproject/ReleaseTest", 90
+            )
+        assert report.passed is True
+        assert snapshot_id == "r1.2-abc1234"
+        assert report.extras  # should carry the per-check messages
+
+    def test_fail_when_state_still_planned(self):
+        issue_response = {
+            "labels": [{"name": "release-state:planned"}],
+            "state": "open",
+        }
+        branches_response = "main\n"
+        pr_list_response: list[dict] = []
+        responses = [
+            ("issues/90", issue_response),
+            ("/branches --paginate", branches_response),
+            ("pr list", pr_list_response),
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=_make_gh_router(responses),
+        ):
+            report, snapshot_id = phase_verify_post_create(
+                "camaraproject/ReleaseTest", 90
+            )
+        assert report.passed is False
+        assert snapshot_id is None
+
+    def test_fail_when_multiple_snapshot_branches(self):
+        issue_response = {
+            "labels": [{"name": "release-state:snapshot-active"}],
+            "state": "open",
+        }
+        branches_response = (
+            "release-snapshot/r1.2-abc1234\nrelease-snapshot/r1.2-def5678\n"
+        )
+        responses = [
+            ("issues/90", issue_response),
+            ("/branches --paginate", branches_response),
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=_make_gh_router(responses),
+        ):
+            report, snapshot_id = phase_verify_post_create(
+                "camaraproject/ReleaseTest", 90
+            )
+        # Should surface an infra-style failure (caught by find_snapshot_branch).
+        assert report.passed is False
+        assert snapshot_id is None
+        assert report.detail.startswith("could not ") or "multiple" in report.detail
+
+
+# ---------------------------------------------------------------------------
+# phase_verify_post_discard
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseVerifyPostDiscard:
+    def test_pass_when_state_planned_and_preserved_exists(self):
+        issue_response = {
+            "labels": [{"name": "release-state:planned"}],
+            "state": "open",
+        }
+        # branch_exists calls: first the snapshot (should 404), then the preserved (should exist)
+        def gh_mock(args, parse_json=False):  # noqa: ARG001
+            joined = " ".join(args)
+            if "issues/90" in joined:
+                return issue_response
+            if "branches/release-snapshot/r1.2-abc1234" in joined:
+                raise InfrastructureError("HTTP 404: Not Found")
+            if "branches/release-review/r1.2-abc1234-preserved" in joined:
+                return ".name is release-review/r1.2-abc1234-preserved"
+            raise AssertionError(f"unmocked: {args}")
+
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=gh_mock,
+        ):
+            report = phase_verify_post_discard(
+                "camaraproject/ReleaseTest", 90, snapshot_id="r1.2-abc1234",
+            )
+        assert report.passed is True
+
+    def test_fail_when_snapshot_branch_still_exists(self):
+        issue_response = {
+            "labels": [{"name": "release-state:planned"}],
+            "state": "open",
+        }
+
+        def gh_mock(args, parse_json=False):  # noqa: ARG001
+            joined = " ".join(args)
+            if "issues/90" in joined:
+                return issue_response
+            if "branches/release-snapshot/r1.2-abc1234" in joined:
+                return "release-snapshot/r1.2-abc1234"  # still present
+            if "branches/release-review/r1.2-abc1234-preserved" in joined:
+                return "release-review/r1.2-abc1234-preserved"
+            raise AssertionError(f"unmocked: {args}")
+
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=gh_mock,
+        ):
+            report = phase_verify_post_discard(
+                "camaraproject/ReleaseTest", 90, snapshot_id="r1.2-abc1234",
+            )
+        assert report.passed is False
+        assert "still exists" in report.detail
+
+    def test_fail_when_preserved_branch_missing(self):
+        issue_response = {
+            "labels": [{"name": "release-state:planned"}],
+            "state": "open",
+        }
+
+        def gh_mock(args, parse_json=False):  # noqa: ARG001
+            joined = " ".join(args)
+            if "issues/90" in joined:
+                return issue_response
+            if "branches/release-snapshot/r1.2-abc1234" in joined:
+                raise InfrastructureError("HTTP 404: Not Found")
+            if "branches/release-review/r1.2-abc1234-preserved" in joined:
+                raise InfrastructureError("HTTP 404: Not Found")
+            raise AssertionError(f"unmocked: {args}")
+
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=gh_mock,
+        ):
+            report = phase_verify_post_discard(
+                "camaraproject/ReleaseTest", 90, snapshot_id="r1.2-abc1234",
+            )
+        assert report.passed is False
+        assert "missing" in report.detail
+
+    def test_skips_branch_checks_when_snapshot_id_missing(self):
+        issue_response = {
+            "labels": [{"name": "release-state:planned"}],
+            "state": "open",
+        }
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=issue_response,
+        ):
+            report = phase_verify_post_discard(
+                "camaraproject/ReleaseTest", 90, snapshot_id=None,
+            )
+        assert report.passed is False
+        assert "not captured" in report.detail
+
+
+# ---------------------------------------------------------------------------
+# render_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMarkdown:
+    def test_all_pass_header(self):
+        reports = [
+            PhaseReport(name="pre-check", passed=True, detail="ok"),
+            PhaseReport(
+                name="fire /create-snapshot",
+                passed=True,
+                detail="run completed",
+                run_url="https://x/1",
+                run_conclusion="success",
+            ),
+        ]
+        out = render_markdown(reports, "o/r", 90)
+        assert "2/2 phases PASS" in out
+        assert "`o/r`" in out
+        assert "#90" in out
+        assert "PASS" in out
+        assert "https://x/1" in out
+        # Successful phases with a run_url still emit a detail section.
+        assert "conclusion: `success`" in out
+
+    def test_fail_shows_per_phase(self):
+        reports = [
+            PhaseReport(name="pre-check", passed=False, detail="state=planned"),
+        ]
+        out = render_markdown(reports, "o/r", 90)
+        assert "0/1 phases PASS" in out
+        assert "FAIL" in out
+        assert "state=planned" in out
+
+    def test_pipe_escape_in_detail(self):
+        reports = [
+            PhaseReport(name="x", passed=True, detail="a | b | c"),
+        ]
+        out = render_markdown(reports, "o/r", 90)
+        # Pipes in detail are escaped so the markdown table doesn't split them.
+        assert r"a \| b \| c" in out
+
+    def test_empty_detail_renders_dash(self):
+        reports = [PhaseReport(name="x", passed=True, detail="")]
+        out = render_markdown(reports, "o/r", 90)
+        assert "| x | PASS | - |" in out
+
+    def test_extras_render_as_bullets(self):
+        reports = [
+            PhaseReport(
+                name="verify post-create",
+                passed=True,
+                detail="all ok",
+                extras=["state=snapshot-active", "pr=#101"],
+            ),
+        ]
+        out = render_markdown(reports, "o/r", 90)
+        assert "- state=snapshot-active" in out
+        assert "- pr=#101" in out

--- a/validation/docs/regression-testing.md
+++ b/validation/docs/regression-testing.md
@@ -189,7 +189,7 @@ points at.
 The regression runner fires automatically on every push to
 `validation-framework` that touches `validation/**`, `shared-actions/**`,
 or the workflow itself. The workflow lives at
-[.github/workflows/regression-runner.yml](../../.github/workflows/regression-runner.yml)
+[.github/workflows/validation-regression.yml](../../.github/workflows/validation-regression.yml)
 on this same branch (so it only exists where it matters and does not
 run on `main`). Manual dispatch is available via the Actions UI for
 fix-then-verify cycles.
@@ -201,7 +201,7 @@ persisted PAT.
 
 Results surface in three places: (1) the workflow's own pass/fail
 status in the Actions tab on `camaraproject/tooling`, (2) the markdown
-summary on the run's summary page, and (3) the `regression-runner-summary`
+summary on the run's summary page, and (3) the `validation-regression-summary`
 artifact attached to each run (30-day retention).
 
 ### Verify all canary branches


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds a second regression canary on `validation-framework` covering the Release Automation surface. The existing canary only exercises `camara-validation.yml` — runtime bugs in `release-automation-reusable.yml` can sit dormant for days (recent examples: #197, #198, both 3 days dormant).

The new **Release Automation Regression** workflow fires a `/create-snapshot` + `/discard-snapshot` round-trip on `camaraproject/ReleaseTest` whenever a push to `validation-framework` touches RA-surface paths (`release-automation-reusable.yml`, `release_automation/**`, `shared-actions/**`, `tooling_lib/**`). Both #197 and #198 would have been caught pre-merge.

Round-trip only — merging the Release Review PR and `/publish-release` remain out of scope; full manual E2E still gates `@v1-rc` moves.

For symmetry the existing VF canary is renamed:

- `regression-runner.yml` → `validation-regression.yml`
- New: `release-automation-regression.yml`

Uses the existing `camara-validation` App token, same permission profile as the renamed sibling.

#### Which issue(s) this PR fixes:

Fixes #

Related to camaraproject/ReleaseManagement#379 — adds CI regression coverage to improve RA rollout reliability.

#### Special notes for reviewers:

- Round-trip produces no real tags/releases/drafts; leaves a `release-review/<id>-preserved` branch behind per normal `/discard-snapshot` semantics.
- Pre-check fail-loudly: if ReleaseTest state isn't `release-state:planned`, the runner exits 2 without mutating anything — avoids stomping on a manual cycle.
- Rename impact: the old `regression-runner.yml` path 404s; artifact name changes `regression-runner-summary` → `validation-regression-summary`.
- 38 new unit tests; 630 existing `release_automation/tests/` tests pass; 24 existing VF tests pass post-rename.

#### Changelog input

```
 release-note
 none (internal CI infrastructure)
```

#### Additional documentation

This section can be blank.

```
docs
```