### PR TITLE
fix(ra): RA canary integration — caller filter + validate-command allowlist + canary summary

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -760,28 +760,41 @@ jobs:
             console.log('Checking user permission...');
             let userPermission;
 
-            try {
-              const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                username: user
-              });
+            // Trusted CI bot identities. App bots don't register as collaborators,
+            // so getCollaboratorPermissionLevel returns 'none' for them; the write
+            // intent is established by the App installation on the target repo.
+            // Currently used by the Release Automation Regression canary in
+            // camaraproject/tooling, which posts slash commands as
+            // camara-validation[bot].
+            const TRUSTED_BOT_USERS = new Set(['camara-validation[bot]']);
 
-              userPermission = permission.permission;
-              console.log(`User permission: ${userPermission}`);
+            if (TRUSTED_BOT_USERS.has(user)) {
+              userPermission = 'write';
+              console.log(`User ${user} is a trusted CI bot; treating as write`);
+            } else {
+              try {
+                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: user
+                });
 
-              const hasPermission = ['admin', 'maintain', 'write'].includes(userPermission);
-
-              if (!hasPermission) {
+                userPermission = permission.permission;
+                console.log(`User permission: ${userPermission}`);
+              } catch (error) {
+                console.log(`Permission check failed: ${error.message}`);
+                // If we can't check permission, deny by default
                 core.setOutput('allowed', 'false');
-                core.setOutput('error_message', `You must have write access or higher to run release commands. Your current permission: ${userPermission}`);
+                core.setOutput('error_message', `Failed to verify permissions: ${error.message}`);
                 return;
               }
-            } catch (error) {
-              console.log(`Permission check failed: ${error.message}`);
-              // If we can't check permission, deny by default
+            }
+
+            const hasPermission = ['admin', 'maintain', 'write'].includes(userPermission);
+
+            if (!hasPermission) {
               core.setOutput('allowed', 'false');
-              core.setOutput('error_message', `Failed to verify permissions: ${error.message}`);
+              core.setOutput('error_message', `You must have write access or higher to run release commands. Your current permission: ${userPermission}`);
               return;
             }
 

--- a/release_automation/scripts/regression_runner.py
+++ b/release_automation/scripts/regression_runner.py
@@ -635,9 +635,10 @@ def render_markdown(reports: list[PhaseReport], repo: str, issue_number: int) ->
     """Render a phase-by-phase PASS/FAIL summary as markdown."""
     passed = sum(1 for r in reports if r.passed)
     total = len(reports)
+    verdict = "PASS" if passed == total and total > 0 else "FAIL"
     lines: list[str] = []
     lines.append(
-        f"## Release Automation Regression — {passed}/{total} phases PASS"
+        f"## Release Automation Regression — {verdict}: {passed} of {total} phases passed"
     )
     lines.append("")
     lines.append(f"- target repo: `{repo}`")
@@ -789,7 +790,7 @@ def main(argv: list[str] | None = None) -> int:
     passed = sum(1 for r in reports if r.passed)
     total = len(reports)
     print(
-        f"{'PASS' if all_passed else 'FAIL'}: {passed}/{total} phases",
+        f"{'PASS' if all_passed else 'FAIL'}: {passed} of {total} phases passed",
         file=sys.stderr,
     )
 

--- a/release_automation/tests/test_regression_runner.py
+++ b/release_automation/tests/test_regression_runner.py
@@ -539,10 +539,9 @@ class TestRenderMarkdown:
             ),
         ]
         out = render_markdown(reports, "o/r", 90)
-        assert "2/2 phases PASS" in out
+        assert "PASS: 2 of 2 phases passed" in out
         assert "`o/r`" in out
         assert "#90" in out
-        assert "PASS" in out
         assert "https://x/1" in out
         # Successful phases with a run_url still emit a detail section.
         assert "conclusion: `success`" in out
@@ -552,9 +551,18 @@ class TestRenderMarkdown:
             PhaseReport(name="pre-check", passed=False, detail="state=planned"),
         ]
         out = render_markdown(reports, "o/r", 90)
-        assert "0/1 phases PASS" in out
-        assert "FAIL" in out
+        assert "FAIL: 0 of 1 phases passed" in out
         assert "state=planned" in out
+
+    def test_partial_pass_header_says_fail(self):
+        reports = [
+            PhaseReport(name="pre-check", passed=True, detail="ok"),
+            PhaseReport(name="verify", passed=False, detail="state unchanged"),
+        ]
+        out = render_markdown(reports, "o/r", 90)
+        # 1/2 is not overall PASS — header must say FAIL, not leave it ambiguous.
+        assert "FAIL: 1 of 2 phases passed" in out
+        assert "PASS: " not in out.split("\n")[0]
 
     def test_pipe_escape_in_detail(self):
         reports = [

--- a/release_automation/workflows/release-automation-caller.yml
+++ b/release_automation/workflows/release-automation-caller.yml
@@ -68,7 +68,7 @@ permissions:
 jobs:
   release-automation:
     # Skip if:
-    # - issue_comment from a Bot (release automation bot comments, not human commands)
+    # - issue_comment from the RA bot itself (its own replies, to prevent self-triggering)
     # - issue_comment but not a release command or not on a release issue
     # - issues event but not a release issue
     # - pull_request but not merged or not to a snapshot branch
@@ -76,7 +76,7 @@ jobs:
       (github.event_name == 'push') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
-       github.event.comment.user.type != 'Bot' &&
+       github.event.comment.user.login != 'camara-release-automation[bot]' &&
        contains(github.event.issue.labels.*.name, 'release-issue') &&
        (startsWith(github.event.comment.body, '/create-snapshot') ||
         startsWith(github.event.comment.body, '/discard-snapshot') ||


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Three fixes surfaced by wiring up the Release Automation Regression canary ([tooling#214](https://github.com/camaraproject/tooling/pull/214)). The canary posts `/create-snapshot` + `/discard-snapshot` on ReleaseTest as `camara-validation[bot]`; each fix addresses one gate it hit.

**1. Caller `if:` filter was too broad.** `comment.user.type != 'Bot'` blocked all bot comments — including non-RA bots legitimately firing slash commands from CI. Narrow the filter in `release_automation/workflows/release-automation-caller.yml` to `comment.user.login != 'camara-release-automation[bot]'`. The RA bot's own replies still can't self-trigger (which would starve the serial concurrency queue); other bot identities pass through to the slash-command gate. Mirrors [ReleaseTest#92](https://github.com/camaraproject/ReleaseTest/pull/92); propagates to API repos via the reconciliation campaign once `@v1-rc` advances.

**2. `validate-command` rejected the canary's slash commands.** App bots don't register as collaborators, so `getCollaboratorPermissionLevel` returns `permission: 'none'` for them. Allowlist `camara-validation[bot]` in `validate-command` so its commands reach the RA workflow. Defense in depth unchanged: `/publish-release` still requires CODEOWNERS (bots don't match), and the caller filter from fix 1 still blocks the RA bot from self-triggering.

**3. Canary summary was ambiguous.** Markdown header `3/5 phases PASS` didn't surface the overall FAIL; stderr `FAIL: 3/5 phases` could read as "3 failed". Both now read `<VERDICT>: N of M phases passed`.

#### Which issue(s) this PR fixes:

Fixes #

Related to camaraproject/ReleaseManagement#379.

#### Special notes for reviewers:

Observed on run [tooling#24801994238](https://github.com/camaraproject/tooling/actions/runs/24801994238) (after ReleaseTest#92 merged): caller passed `camara-validation[bot]` through, but `validate-command` rejected with "permission: none" and set `allowed=false`; downstream jobs conditionally skipped; run still concluded `success` — which is why fire-phases misreported PASS. Verify phases caught state-didn't-change correctly. Tightening fire-phase detection (so rejection attributes to the fire phase, not verify) is a small follow-up.

#### Changelog input

```
 release-note
 none (CI fix for the RA regression canary)
```

#### Additional documentation

This section can be blank.

```
docs
```