### PR TITLE
fix(canary): auto-discover the Release Issue on the target repo

### DIFF
--- a/.github/workflows/release-automation-regression.yml
+++ b/.github/workflows/release-automation-regression.yml
@@ -72,7 +72,6 @@ jobs:
         run: |
           python3 release_automation/scripts/regression_runner.py \
             --repo camaraproject/ReleaseTest \
-            --release-issue 90 \
             --summary-file release-automation-regression-summary.md
 
       - name: Publish summary

--- a/release_automation/scripts/regression_runner.py
+++ b/release_automation/scripts/regression_runner.py
@@ -11,11 +11,19 @@ runner at validation/scripts/regression_runner.py.
 
 Usage:
     python3 regression_runner.py --repo camaraproject/ReleaseTest \\
-        --release-issue 90 \\
         [--summary-file release-automation-regression-summary.md]
 
+    # Override discovery (useful when iterating locally):
+    python3 regression_runner.py --repo camaraproject/ReleaseTest --release-issue 93
+
     # Dry-run (no comments posted, no runs polled):
-    python3 regression_runner.py --repo ... --release-issue 90 --dry-run
+    python3 regression_runner.py --repo camaraproject/ReleaseTest --dry-run
+
+The Release Issue is auto-discovered on --repo via the 'release-issue' label
+and the workflow-owned body marker. Release Issues cycle per release — each
+publish closes the current one and opens a fresh issue for the next cycle —
+so a hardcoded number would break after the first cycle. Pass --release-issue
+only to override discovery (local testing, or recovering from a split state).
 
 Exit codes:
     0  all phases PASS
@@ -66,6 +74,13 @@ logger = logging.getLogger("ra_regression_runner")
 # Python modules. If the workflow changes the prefix, update this line.
 # Source of truth: .github/workflows/release-automation-reusable.yml
 _STATE_LABEL_PREFIX = "release-state:"
+
+# Release Issue discovery markers — matched by find_release_issue().
+# Both the label and the body marker must be present; the combination
+# distinguishes the workflow-owned Release Issue from any other issue
+# a maintainer might tag as 'release-issue'.
+_RELEASE_ISSUE_LABEL = "release-issue"
+_RELEASE_ISSUE_BODY_MARKER = "<!-- release-automation:workflow-owned -->"
 
 # Caller workflow filename on the target test repo. Each release-plan
 # repo copies this caller from the shared template.
@@ -180,6 +195,50 @@ def poll_run(
 # ---------------------------------------------------------------------------
 # Issue / branch / PR readers
 # ---------------------------------------------------------------------------
+
+
+def find_release_issue(repo: str) -> int:
+    """Discover the single workflow-owned Release Issue on *repo*.
+
+    Release Issues cycle per release (closed on publish, a fresh one opened
+    for the next cycle), so the canary must discover the current one rather
+    than relying on a static number. A match requires both:
+
+    - the `release-issue` label (server-side filter), and
+    - the workflow-owned body marker (client-side check).
+
+    Returns the issue number. Raises InfrastructureError if zero matches
+    (no active release cycle on the target repo) or more than one match
+    (corrupted state that automation must not silently collapse).
+    """
+    data = gh(
+        [
+            "api", f"repos/{repo}/issues",
+            "-X", "GET",
+            "-f", "state=open",
+            "-f", f"labels={_RELEASE_ISSUE_LABEL}",
+            "--paginate",
+            "--jq", "[.[] | select(.pull_request == null) | {number, body}]",
+        ],
+        parse_json=True,
+    )
+    matching = [
+        item["number"]
+        for item in data
+        if _RELEASE_ISSUE_BODY_MARKER in (item.get("body") or "")
+    ]
+    if len(matching) == 0:
+        raise InfrastructureError(
+            f"{repo}: no open Release Issue found "
+            f"(need label '{_RELEASE_ISSUE_LABEL}' AND body marker "
+            f"'{_RELEASE_ISSUE_BODY_MARKER}')"
+        )
+    if len(matching) > 1:
+        nums = ", ".join(f"#{n}" for n in sorted(matching))
+        raise InfrastructureError(
+            f"{repo}: multiple open Release Issues found: {nums}"
+        )
+    return matching[0]
 
 
 def read_state_label(labels: list[dict[str, Any]]) -> str | None:
@@ -686,8 +745,9 @@ def _build_argparser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--release-issue",
         type=int,
-        required=True,
-        help="issue number of the persistent Release Issue on --repo",
+        help="issue number of the current Release Issue on --repo; "
+             "if omitted, auto-discovered via label + body marker "
+             "(the normal path — Release Issues cycle per release)",
     )
     parser.add_argument(
         "--summary-file",
@@ -772,8 +832,15 @@ def main(argv: list[str] | None = None) -> int:
     _setup_logging(args.verbose)
 
     try:
+        issue_number = args.release_issue
+        if issue_number is None:
+            issue_number = find_release_issue(args.repo)
+            logger.info(
+                "discovered Release Issue: #%d on %s", issue_number, args.repo
+            )
+
         reports = run_phases(
-            args.repo, args.release_issue,
+            args.repo, issue_number,
             poll_timeout=args.poll_timeout,
             dry_run=args.dry_run,
         )
@@ -781,7 +848,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"INFRA: {exc}", file=sys.stderr)
         return 2
 
-    markdown = render_markdown(reports, args.repo, args.release_issue)
+    markdown = render_markdown(reports, args.repo, issue_number)
     print(markdown)
     if args.summary_file:
         args.summary_file.write_text(markdown, encoding="utf-8")

--- a/release_automation/tests/test_regression_runner.py
+++ b/release_automation/tests/test_regression_runner.py
@@ -20,6 +20,7 @@ from release_automation.scripts.regression_runner import (
     PhaseReport,
     _iso_to_dt,
     find_recent_caller_run,
+    find_release_issue,
     get_release_issue_state,
     phase_pre_check,
     phase_verify_post_create,
@@ -589,3 +590,93 @@ class TestRenderMarkdown:
         out = render_markdown(reports, "o/r", 90)
         assert "- state=snapshot-active" in out
         assert "- pr=#101" in out
+
+
+# ---------------------------------------------------------------------------
+# find_release_issue
+# ---------------------------------------------------------------------------
+
+
+MARKER = "<!-- release-automation:workflow-owned -->"
+
+
+class TestFindReleaseIssue:
+    def test_single_match(self):
+        issues = [
+            {"number": 93, "body": f"{MARKER}\n\nsome body text"},
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=issues,
+        ):
+            assert find_release_issue("o/r") == 93
+
+    def test_zero_matches_raises(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=[],
+        ):
+            with pytest.raises(InfrastructureError, match="no open Release Issue"):
+                find_release_issue("o/r")
+
+    def test_multiple_matches_raises(self):
+        issues = [
+            {"number": 90, "body": f"{MARKER}\n\nold cycle"},
+            {"number": 93, "body": f"{MARKER}\n\nnew cycle"},
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=issues,
+        ):
+            with pytest.raises(InfrastructureError, match="multiple open Release Issues.*#90.*#93"):
+                find_release_issue("o/r")
+
+    def test_labeled_but_no_marker_is_excluded(self):
+        # gh API filters by label server-side, but a maintainer could
+        # hand-label an issue without the workflow-owned body marker.
+        # That's not a workflow-owned issue; it must not match.
+        issues = [
+            {"number": 42, "body": "This is a hand-labeled release issue, not the workflow's."},
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=issues,
+        ):
+            with pytest.raises(InfrastructureError, match="no open Release Issue"):
+                find_release_issue("o/r")
+
+    def test_marker_case_sensitivity(self):
+        # The marker must match exactly — substring check on the body.
+        issues = [
+            {"number": 42, "body": "<!-- Release-Automation:Workflow-Owned -->"},  # wrong case
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=issues,
+        ):
+            with pytest.raises(InfrastructureError, match="no open Release Issue"):
+                find_release_issue("o/r")
+
+    def test_null_body_is_tolerated(self):
+        # GitHub occasionally returns null for empty bodies; don't crash.
+        issues = [
+            {"number": 42, "body": None},
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=issues,
+        ):
+            with pytest.raises(InfrastructureError, match="no open Release Issue"):
+                find_release_issue("o/r")
+
+    def test_marker_anywhere_in_body_matches(self):
+        # Marker may appear after other content (future-proofing if the
+        # template ever reorders).
+        issues = [
+            {"number": 93, "body": f"First line\n\nSecond line\n\n{MARKER}\n"},
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=issues,
+        ):
+            assert find_release_issue("o/r") == 93


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The Release Automation Regression canary added in [tooling#214](https://github.com/camaraproject/tooling/pull/214) hardcoded Release Issue `#90` on ReleaseTest. Release Issues cycle per release — each publish closes the current one and opens a fresh issue for the next cycle — so a hardcoded number breaks after the first cycle. Surfaced when ReleaseTest #90 closed mid-debugging and #93 took its place: the next organic canary run failed pre-check with `issue is not open (state='closed')`.

Make `--release-issue` optional; when omitted, discover the single open issue carrying both the `release-issue` label AND the `<!-- release-automation:workflow-owned -->` body marker. Zero or multiple matches raise `InfrastructureError` (same fail-loudly philosophy as pre-check). Drop `--release-issue 90` from `release-automation-regression.yml`. Keep the CLI flag for local override or split-state recovery.

Live dry-run against ReleaseTest confirmed discovery now finds `#93` automatically.

#### Which issue(s) this PR fixes:

Fixes #

Related to camaraproject/ReleaseManagement#379.

#### Special notes for reviewers:

7 new unit tests covering zero / one / multiple matches, labeled-without-marker (hand-labeled issues excluded), case-sensitivity, null body, and marker-anywhere-in-body. 46/46 total tests pass.

#### Changelog input

```
 release-note
 none (CI fix for the RA regression canary)
```

#### Additional documentation

This section can be blank.

```
docs
```