### PR TITLE
fix(canary): check last bot reply + attribute the slash-command comment

### DIFF
--- a/release_automation/regression/expected-comments.yaml
+++ b/release_automation/regression/expected-comments.yaml
@@ -1,0 +1,18 @@
+# Expected leading title of the final bot comment on the Release Issue
+# when each slash command completes on the green path.
+#
+# This is a test assertion, not a captured artifact. When the RA workflow
+# changes the template used for a given command, edit this file alongside
+# the workflow change.
+#
+# Titles are taken from the first line of
+#   release_automation/templates/bot_messages/<template>.md
+# and truncated at the first dynamic portion (after the static prefix).
+# A comment matches if its first non-blank line starts with the prefix.
+#
+# Source templates:
+#   snapshot_created.md   -> "**✅ Snapshot created — State: `snapshot-active`**"
+#   snapshot_discarded.md -> "**🗑️ Snapshot discarded — State: `planned`**"
+
+create-snapshot: "**✅ Snapshot created"
+discard-snapshot: "**🗑️ Snapshot discarded"

--- a/release_automation/scripts/regression_runner.py
+++ b/release_automation/scripts/regression_runner.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 import time
@@ -47,6 +48,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    print("Error: pyyaml package is required. Install with: pip install pyyaml")
+    sys.exit(2)
 
 # Package-relative imports so unit tests can patch at the right boundary.
 # The release_automation/ package is already on sys.path when invoked via
@@ -57,7 +64,6 @@ if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
 from config import (  # noqa: E402
-    LABEL_RELEASE_MGMT_BOT,
     RELEASE_REVIEW_BRANCH_PREFIX,
     SNAPSHOT_BRANCH_PREFIX,
     STATE_PLANNED,
@@ -368,6 +374,143 @@ def release_review_pr_for_issue(repo: str, issue_number: int) -> int | None:
 
 
 # ---------------------------------------------------------------------------
+# Expected comment-title config + bot-comment lookup
+# ---------------------------------------------------------------------------
+
+
+# Bot logins that post replies during RA workflow runs. The validation App
+# token posts via GITHUB_TOKEN inside the workflow (github-actions[bot]) for
+# most replies; the RA app mints its own token for some paths.
+_RA_BOT_LOGINS = frozenset({
+    "github-actions[bot]",
+    "camara-release-automation[bot]",
+})
+
+
+def _expected_comments_path() -> Path:
+    """Path to the expected-comment-titles config file in this worktree."""
+    return _HERE.parent / "regression" / "expected-comments.yaml"
+
+
+def load_expected_comment_titles(path: Path | None = None) -> dict[str, str]:
+    """Load the per-command expected final-bot-comment title prefixes.
+
+    The config is human-edited alongside RA workflow template changes. Format:
+        create-snapshot: "**✅ Snapshot created"
+        discard-snapshot: "**🗑️ Snapshot discarded"
+    """
+    config_path = path or _expected_comments_path()
+    if not config_path.exists():
+        raise InfrastructureError(
+            f"expected-comments config not found at {config_path}"
+        )
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise InfrastructureError(
+            f"{config_path}: YAML parse error: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise InfrastructureError(
+            f"{config_path}: expected a YAML mapping at the root"
+        )
+    for key, val in data.items():
+        if not isinstance(key, str) or not isinstance(val, str):
+            raise InfrastructureError(
+                f"{config_path}: all keys and values must be strings "
+                f"(offender: {key!r}={val!r})"
+            )
+    return data
+
+
+def _first_nonblank_line(body: str) -> str:
+    """Return the first non-blank line of *body*, stripped of trailing space."""
+    for line in body.splitlines():
+        if line.strip():
+            return line.rstrip()
+    return ""
+
+
+def _match_comment_title(body: str, expected_prefix: str) -> bool:
+    """True iff the first non-blank line of *body* starts with *expected_prefix*."""
+    return _first_nonblank_line(body).startswith(expected_prefix)
+
+
+def fetch_last_bot_comment(
+    repo: str, issue_number: int, since: datetime,
+) -> dict[str, Any] | None:
+    """Return the newest RA-bot-authored comment on *issue_number* since *since*.
+
+    Scans comments via the `gh api` issues/comments endpoint. Filters
+    client-side to authors in `_RA_BOT_LOGINS` whose `created_at` >= *since*.
+    Returns the comment dict (with `body`, `created_at`, `user.login`, `html_url`)
+    or None if no matching comment is found.
+    """
+    data = gh(
+        [
+            "api", f"repos/{repo}/issues/{issue_number}/comments",
+            "--paginate",
+            "--jq", "[.[] | {body, created_at, user: {login: .user.login}, html_url}]",
+        ],
+        parse_json=True,
+    )
+    candidates: list[dict[str, Any]] = []
+    for item in data:
+        user = (item.get("user") or {}).get("login")
+        if user not in _RA_BOT_LOGINS:
+            continue
+        try:
+            created = _iso_to_dt(item["created_at"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        if created >= since:
+            candidates.append(item)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda c: c["created_at"], reverse=True)
+    return candidates[0]
+
+
+# ---------------------------------------------------------------------------
+# Command-comment attribution
+# ---------------------------------------------------------------------------
+
+
+def _canary_run_url() -> str | None:
+    """Compose this workflow run's URL from the Actions-provided env vars.
+
+    Returns None when any required var is missing (e.g. running locally).
+    """
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if server and repo and run_id:
+        return f"{server}/{repo}/actions/runs/{run_id}"
+    return None
+
+
+def _build_command_body(command: str, purpose: str) -> str:
+    """Build a slash-command comment body carrying canary attribution.
+
+    The first line is the bare slash command (so the caller's `if:` filter
+    and the reusable workflow's word-boundary parser both accept it). A blank
+    line and an attribution paragraph follow.
+    """
+    run_url = _canary_run_url()
+    if run_url:
+        attribution = (
+            f"Posted by the Release Automation Regression canary in "
+            f"`camaraproject/tooling` (run: {run_url})."
+        )
+    else:
+        attribution = (
+            "Posted by the Release Automation Regression canary in "
+            "`camaraproject/tooling`."
+        )
+    return f"{command}\n\n{attribution} {purpose}".rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
 # Fire + run discovery
 # ---------------------------------------------------------------------------
 
@@ -476,34 +619,61 @@ def phase_pre_check(repo: str, issue_number: int) -> PhaseReport:
     return report
 
 
-def phase_fire_create_snapshot(
+_CREATE_SNAPSHOT_PURPOSE = (
+    "This is an automated CI smoke test. A `/discard-snapshot` will follow "
+    "to restore state; no release will be published."
+)
+
+_DISCARD_SNAPSHOT_PURPOSE = (
+    "Completing the CI smoke test round-trip started above."
+)
+
+
+def _fire_command_phase(
     repo: str,
     issue_number: int,
     *,
+    command: str,
+    purpose: str,
+    expected_title: str,
     poll_timeout: int,
     dry_run: bool,
 ) -> tuple[PhaseReport, str | None]:
-    """Phase 2 — post /create-snapshot, discover the caller run, poll it.
+    """Post a slash command, poll the triggered run, check the final bot reply.
 
-    Returns (report, run_id). run_id is None on dry-run or failure.
+    Fire phase passes iff:
+    1. The comment was posted + a caller run was discovered;
+    2. The caller run reached `completed` with `conclusion == 'success'`;
+    3. A bot comment appeared on the Release Issue after we posted, and its
+       first non-blank line starts with `expected_title`.
+
+    Rejection (e.g. cache-stale, permission-denied) surfaces as the caller
+    bot posting `command_rejected` as its final reply — case (3) fails with
+    the actual title in the detail. Internal failures (snapshot_failed,
+    internal_error templates) fail the same way.
+
+    Returns (report, run_id). run_id is None on dry-run or early fail.
     """
-    report = PhaseReport(name="fire /create-snapshot")
+    report = PhaseReport(name=f"fire {command}")
     if dry_run:
         report.passed = True
-        report.detail = f"DRY-RUN: would post /create-snapshot on {repo}#{issue_number}"
+        report.detail = (
+            f"DRY-RUN: would post attributed `{command}` on {repo}#{issue_number}"
+        )
         return report, None
 
+    body = _build_command_body(command, purpose)
     marker = datetime.now(timezone.utc).replace(microsecond=0)
     try:
-        post_issue_comment(repo, issue_number, "/create-snapshot")
-        logger.info("posted /create-snapshot on %s#%s; polling for run", repo, issue_number)
+        post_issue_comment(repo, issue_number, body)
+        logger.info("posted %s on %s#%s; polling for caller run", command, repo, issue_number)
         run = find_recent_caller_run(
             repo,
             workflow_file=_RA_CALLER_WORKFLOW,
             since=marker,
         )
     except InfrastructureError as exc:
-        report.detail = f"could not fire /create-snapshot: {exc}"
+        report.detail = f"could not fire {command}: {exc}"
         return report, None
 
     run_id = str(run["databaseId"])
@@ -518,15 +688,63 @@ def phase_fire_create_snapshot(
         return report, run_id
 
     report.run_conclusion = conclusion
-    if conclusion == "success":
+    if conclusion != "success":
+        report.detail = (
+            f"caller run concluded {conclusion!r} — RA workflow failed "
+            f"(skipping comment check)"
+        )
+        return report, run_id
+
+    # Caller concluded success. That alone doesn't mean the command ran
+    # (rejection skips downstream jobs but still concludes success). Check
+    # the RA bot's final reply on the issue to disambiguate.
+    try:
+        last_comment = fetch_last_bot_comment(repo, issue_number, marker)
+    except InfrastructureError as exc:
+        report.detail = f"could not read bot reply: {exc}"
+        return report, run_id
+
+    if last_comment is None:
+        report.detail = (
+            "no bot reply received on the Release Issue since firing "
+            f"{command}; see caller run"
+        )
+        return report, run_id
+
+    actual_title = _first_nonblank_line(last_comment.get("body") or "")
+    if _match_comment_title(last_comment.get("body") or "", expected_title):
         report.passed = True
-        report.detail = f"run completed with conclusion={conclusion!r}"
+        report.detail = f"bot reply matches expected — `{actual_title}`"
     else:
         report.detail = (
-            f"run concluded {conclusion!r} (expected 'success') — "
-            f"see run for details"
+            f"bot reply does not match expected: got `{actual_title}`, "
+            f"expected prefix `{expected_title}`"
+        )
+        report.extras.append(
+            f"comment: {last_comment.get('html_url', '<no url>')}"
         )
     return report, run_id
+
+
+def phase_fire_create_snapshot(
+    repo: str,
+    issue_number: int,
+    *,
+    poll_timeout: int,
+    dry_run: bool,
+    expected_titles: dict[str, str] | None = None,
+) -> tuple[PhaseReport, str | None]:
+    """Phase 2 — post /create-snapshot, discover the caller run, poll, check reply."""
+    titles = expected_titles or load_expected_comment_titles()
+    expected = titles.get("create-snapshot", "")
+    return _fire_command_phase(
+        repo, issue_number,
+        command="/create-snapshot",
+        purpose=_CREATE_SNAPSHOT_PURPOSE,
+        expected_title=expected,
+        poll_timeout=poll_timeout,
+        dry_run=dry_run,
+    )
 
 
 def phase_verify_post_create(repo: str, issue_number: int) -> tuple[PhaseReport, str | None]:
@@ -591,48 +809,19 @@ def phase_fire_discard_snapshot(
     *,
     poll_timeout: int,
     dry_run: bool,
+    expected_titles: dict[str, str] | None = None,
 ) -> tuple[PhaseReport, str | None]:
-    """Phase 4 — post /discard-snapshot, discover the caller run, poll it."""
-    report = PhaseReport(name="fire /discard-snapshot")
-    if dry_run:
-        report.passed = True
-        report.detail = f"DRY-RUN: would post /discard-snapshot on {repo}#{issue_number}"
-        return report, None
-
-    marker = datetime.now(timezone.utc).replace(microsecond=0)
-    try:
-        post_issue_comment(repo, issue_number, "/discard-snapshot")
-        logger.info("posted /discard-snapshot on %s#%s; polling for run", repo, issue_number)
-        run = find_recent_caller_run(
-            repo,
-            workflow_file=_RA_CALLER_WORKFLOW,
-            since=marker,
-        )
-    except InfrastructureError as exc:
-        report.detail = f"could not fire /discard-snapshot: {exc}"
-        return report, None
-
-    run_id = str(run["databaseId"])
-    report.run_url = run.get("url")
-
-    try:
-        conclusion = poll_run(
-            repo, run_id, interval=15, timeout=poll_timeout
-        )
-    except InfrastructureError as exc:
-        report.detail = f"run {run_id} polling error: {exc}"
-        return report, run_id
-
-    report.run_conclusion = conclusion
-    if conclusion == "success":
-        report.passed = True
-        report.detail = f"run completed with conclusion={conclusion!r}"
-    else:
-        report.detail = (
-            f"run concluded {conclusion!r} (expected 'success') — "
-            f"see run for details"
-        )
-    return report, run_id
+    """Phase 4 — post /discard-snapshot, discover the caller run, poll, check reply."""
+    titles = expected_titles or load_expected_comment_titles()
+    expected = titles.get("discard-snapshot", "")
+    return _fire_command_phase(
+        repo, issue_number,
+        command="/discard-snapshot",
+        purpose=_DISCARD_SNAPSHOT_PURPOSE,
+        expected_title=expected,
+        poll_timeout=poll_timeout,
+        dry_run=dry_run,
+    )
 
 
 def phase_verify_post_discard(

--- a/release_automation/tests/test_regression_runner.py
+++ b/release_automation/tests/test_regression_runner.py
@@ -18,10 +18,17 @@ import pytest
 from release_automation.scripts.regression_runner import (
     InfrastructureError,
     PhaseReport,
+    _build_command_body,
+    _canary_run_url,
+    _first_nonblank_line,
     _iso_to_dt,
+    _match_comment_title,
+    fetch_last_bot_comment,
     find_recent_caller_run,
     find_release_issue,
     get_release_issue_state,
+    load_expected_comment_titles,
+    phase_fire_create_snapshot,
     phase_pre_check,
     phase_verify_post_create,
     phase_verify_post_discard,
@@ -680,3 +687,397 @@ class TestFindReleaseIssue:
             return_value=issues,
         ):
             assert find_release_issue("o/r") == 93
+
+
+# ---------------------------------------------------------------------------
+# load_expected_comment_titles + _match_comment_title
+# ---------------------------------------------------------------------------
+
+
+class TestLoadExpectedCommentTitles:
+    def test_loads_committed_config(self):
+        # Smoke-test against the real file in the repo — covers both
+        # "file exists" and "both commands present". If the workflow
+        # changes the template titles, this test starts failing and
+        # flags that the config must be updated too.
+        titles = load_expected_comment_titles()
+        assert "create-snapshot" in titles
+        assert "discard-snapshot" in titles
+        assert titles["create-snapshot"].startswith("**")
+        assert titles["discard-snapshot"].startswith("**")
+
+    def test_missing_file_raises(self, tmp_path):
+        missing = tmp_path / "does-not-exist.yaml"
+        with pytest.raises(InfrastructureError, match="not found"):
+            load_expected_comment_titles(missing)
+
+    def test_root_must_be_mapping(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("- not-a-mapping\n", encoding="utf-8")
+        with pytest.raises(InfrastructureError, match="mapping"):
+            load_expected_comment_titles(bad)
+
+    def test_values_must_be_strings(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("create-snapshot: 42\n", encoding="utf-8")
+        with pytest.raises(InfrastructureError, match="strings"):
+            load_expected_comment_titles(bad)
+
+
+class TestMatchCommentTitle:
+    def test_exact_prefix_match(self):
+        body = "**✅ Snapshot created — State: `snapshot-active`**\nmore text"
+        assert _match_comment_title(body, "**✅ Snapshot created")
+
+    def test_prefix_with_dynamic_tail(self):
+        body = "**✅ Snapshot created — State: `snapshot-active`**\n..."
+        # The prefix matches; the rest of the line is dynamic.
+        assert _match_comment_title(body, "**✅ Snapshot created")
+
+    def test_non_match(self):
+        body = "**❌ Command rejected: `/create-snapshot` — State: `planned`**"
+        assert not _match_comment_title(body, "**✅ Snapshot created")
+
+    def test_skips_leading_blank_lines(self):
+        body = "\n\n**🗑️ Snapshot discarded — State: `planned`**\nmore"
+        assert _match_comment_title(body, "**🗑️ Snapshot discarded")
+
+    def test_empty_body(self):
+        assert not _match_comment_title("", "**✅ Snapshot created")
+        assert _first_nonblank_line("") == ""
+
+
+# ---------------------------------------------------------------------------
+# fetch_last_bot_comment
+# ---------------------------------------------------------------------------
+
+
+def _comment(at: str, login: str, body: str = "", html_url: str = "https://x/c") -> dict:
+    return {
+        "body": body,
+        "created_at": at,
+        "user": {"login": login},
+        "html_url": html_url,
+    }
+
+
+class TestFetchLastBotComment:
+    def test_returns_newest_bot_comment(self):
+        since = datetime(2026, 4, 23, 10, 0, 0, tzinfo=timezone.utc)
+        comments = [
+            _comment("2026-04-23T10:00:30Z", "github-actions[bot]", "first"),
+            _comment("2026-04-23T10:01:00Z", "camara-release-automation[bot]", "second"),
+            _comment("2026-04-23T10:00:45Z", "hdamker", "human comment ignored"),
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=comments,
+        ):
+            result = fetch_last_bot_comment("o/r", 90, since)
+        assert result is not None
+        assert result["user"]["login"] == "camara-release-automation[bot]"
+        assert result["body"] == "second"
+
+    def test_ignores_comments_before_since(self):
+        since = datetime(2026, 4, 23, 10, 0, 0, tzinfo=timezone.utc)
+        comments = [
+            _comment("2026-04-23T09:59:00Z", "github-actions[bot]", "too old"),
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=comments,
+        ):
+            result = fetch_last_bot_comment("o/r", 90, since)
+        assert result is None
+
+    def test_returns_none_when_only_human_comments(self):
+        since = datetime(2026, 4, 23, 10, 0, 0, tzinfo=timezone.utc)
+        comments = [
+            _comment("2026-04-23T10:05:00Z", "hdamker", "human"),
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=comments,
+        ):
+            result = fetch_last_bot_comment("o/r", 90, since)
+        assert result is None
+
+    def test_handles_malformed_timestamps(self):
+        since = datetime(2026, 4, 23, 10, 0, 0, tzinfo=timezone.utc)
+        comments = [
+            _comment("not-a-timestamp", "github-actions[bot]", "broken"),
+            _comment("2026-04-23T10:05:00Z", "github-actions[bot]", "good"),
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=comments,
+        ):
+            result = fetch_last_bot_comment("o/r", 90, since)
+        assert result is not None
+        assert result["body"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# _build_command_body + _canary_run_url
+# ---------------------------------------------------------------------------
+
+
+class TestCanaryRunURL:
+    def test_composes_url_when_all_env_present(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "camaraproject/tooling")
+        monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+        assert _canary_run_url() == "https://github.com/camaraproject/tooling/actions/runs/12345"
+
+    def test_none_when_any_missing(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+        monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+        monkeypatch.setenv("GITHUB_RUN_ID", "1")
+        assert _canary_run_url() is None
+
+
+class TestBuildCommandBody:
+    def test_starts_with_command_and_blank_line(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+        body = _build_command_body("/create-snapshot", "Smoke test.")
+        lines = body.split("\n")
+        assert lines[0] == "/create-snapshot"
+        assert lines[1] == ""
+        # The caller's startsWith check requires the first line to be exactly
+        # the command; the second line must be blank or whitespace so the
+        # reusable workflow's regex `/^\/cmd(?:\s|$)/` also matches.
+        assert body.startswith("/create-snapshot\n")
+
+    def test_attribution_includes_run_url_when_in_ci(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "camaraproject/tooling")
+        monkeypatch.setenv("GITHUB_RUN_ID", "99")
+        body = _build_command_body("/create-snapshot", "Smoke test.")
+        assert "(run: https://github.com/camaraproject/tooling/actions/runs/99)" in body
+        assert "Release Automation Regression canary" in body
+
+    def test_attribution_without_run_url_outside_ci(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+        body = _build_command_body("/create-snapshot", "Smoke test.")
+        assert "run:" not in body  # URL clause omitted
+        assert "Release Automation Regression canary" in body
+        assert "Smoke test." in body
+
+
+# ---------------------------------------------------------------------------
+# phase_fire_create_snapshot — failure classes after the polish
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED = {
+    "create-snapshot": "**✅ Snapshot created",
+    "discard-snapshot": "**🗑️ Snapshot discarded",
+}
+
+
+def _gh_router(responses):
+    """Dispatch `gh(args, ...)` calls to responses keyed by a substring pattern."""
+    def router(args, parse_json=False):  # noqa: ARG001
+        joined = " ".join(args)
+        for pattern, value in responses:
+            if pattern in joined:
+                if callable(value):
+                    return value(joined)
+                return value
+        raise AssertionError(f"no mock configured for: {joined}")
+    return router
+
+
+class TestPhaseFireCreateSnapshotPolished:
+    def test_pass_on_matching_bot_reply(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+        # Deterministic: skip polling delays and caller-run discovery delay.
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.time.sleep",
+            lambda *_a, **_k: None,
+        )
+        comments = [
+            _comment(
+                "2026-04-23T05:00:30Z",
+                "github-actions[bot]",
+                "**✅ Snapshot created — State: `snapshot-active`**\nRelease PR: #94",
+            ),
+        ]
+        caller_run = {
+            "databaseId": 999,
+            "createdAt": "2026-04-23T05:00:10Z",
+            "status": "completed",
+            "conclusion": "success",
+            "url": "https://x/run/999",
+        }
+        responses = [
+            ("issue comment", ""),  # post_issue_comment
+            ("run list", [caller_run]),  # find_recent_caller_run
+            ("run view", {"status": "completed", "conclusion": "success"}),  # poll_run
+            ("issues/90/comments", comments),  # fetch_last_bot_comment
+        ]
+        # find_recent_caller_run uses an internal loop; force its `since`
+        # to be in the past so any created_at compares pass.
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.datetime",
+            _FixedDatetime("2026-04-23T04:59:00Z"),
+        )
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=_gh_router(responses),
+        ):
+            report, run_id = phase_fire_create_snapshot(
+                "camaraproject/ReleaseTest", 90,
+                poll_timeout=10, dry_run=False,
+                expected_titles=_EXPECTED,
+            )
+        assert report.passed is True
+        assert "Snapshot created" in report.detail
+        assert run_id == "999"
+
+    def test_fail_on_rejection_reply(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.time.sleep",
+            lambda *_a, **_k: None,
+        )
+        comments = [
+            _comment(
+                "2026-04-23T05:00:30Z",
+                "github-actions[bot]",
+                "**❌ Command rejected: `/create-snapshot` — State: `planned`**\nYour current permission: none",
+            ),
+        ]
+        caller_run = {
+            "databaseId": 999,
+            "createdAt": "2026-04-23T05:00:10Z",
+            "status": "completed",
+            "conclusion": "success",
+            "url": "https://x/run/999",
+        }
+        responses = [
+            ("issue comment", ""),
+            ("run list", [caller_run]),
+            ("run view", {"status": "completed", "conclusion": "success"}),
+            ("issues/90/comments", comments),
+        ]
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.datetime",
+            _FixedDatetime("2026-04-23T04:59:00Z"),
+        )
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=_gh_router(responses),
+        ):
+            report, run_id = phase_fire_create_snapshot(
+                "camaraproject/ReleaseTest", 90,
+                poll_timeout=10, dry_run=False,
+                expected_titles=_EXPECTED,
+            )
+        assert report.passed is False
+        assert "Command rejected" in report.detail
+        assert run_id == "999"
+        # Extras carry the comment URL for operator diagnosis.
+        assert any("https://x/c" in extra for extra in report.extras)
+
+    def test_fail_when_caller_run_failed(self, monkeypatch):
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.time.sleep",
+            lambda *_a, **_k: None,
+        )
+        caller_run = {
+            "databaseId": 999,
+            "createdAt": "2026-04-23T05:00:10Z",
+            "status": "completed",
+            "conclusion": "failure",
+            "url": "https://x/run/999",
+        }
+        responses = [
+            ("issue comment", ""),
+            ("run list", [caller_run]),
+            ("run view", {"status": "completed", "conclusion": "failure"}),
+        ]
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.datetime",
+            _FixedDatetime("2026-04-23T04:59:00Z"),
+        )
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=_gh_router(responses),
+        ):
+            report, _ = phase_fire_create_snapshot(
+                "camaraproject/ReleaseTest", 90,
+                poll_timeout=10, dry_run=False,
+                expected_titles=_EXPECTED,
+            )
+        assert report.passed is False
+        assert "failure" in report.detail
+        assert "RA workflow failed" in report.detail
+
+    def test_fail_when_no_bot_reply(self, monkeypatch):
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.time.sleep",
+            lambda *_a, **_k: None,
+        )
+        caller_run = {
+            "databaseId": 999,
+            "createdAt": "2026-04-23T05:00:10Z",
+            "status": "completed",
+            "conclusion": "success",
+            "url": "https://x/run/999",
+        }
+        responses = [
+            ("issue comment", ""),
+            ("run list", [caller_run]),
+            ("run view", {"status": "completed", "conclusion": "success"}),
+            ("issues/90/comments", []),  # no comments at all
+        ]
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.datetime",
+            _FixedDatetime("2026-04-23T04:59:00Z"),
+        )
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=_gh_router(responses),
+        ):
+            report, _ = phase_fire_create_snapshot(
+                "camaraproject/ReleaseTest", 90,
+                poll_timeout=10, dry_run=False,
+                expected_titles=_EXPECTED,
+            )
+        assert report.passed is False
+        assert "no bot reply" in report.detail
+
+    def test_dry_run_skips_everything(self):
+        report, run_id = phase_fire_create_snapshot(
+            "camaraproject/ReleaseTest", 90,
+            poll_timeout=10, dry_run=True,
+            expected_titles=_EXPECTED,
+        )
+        assert report.passed is True
+        assert "DRY-RUN" in report.detail
+        assert run_id is None
+
+
+class _FixedDatetime:
+    """Freeze `datetime.now(...)` to a specific UTC moment; everything else passes through.
+
+    Used to make the fire-phase's UTC marker deterministic in tests so the
+    run-discovery and comment-lookup filters compare against a known point.
+    """
+
+    def __init__(self, iso: str):
+        self._now = datetime.strptime(iso, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+
+    def now(self, tz=None):
+        return self._now if tz is None else self._now.astimezone(tz)
+
+    def strptime(self, *args, **kwargs):
+        return datetime.strptime(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(datetime, name)


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Two polish items surfaced by the first green canary run ([tooling#214](https://github.com/camaraproject/tooling/pull/214)):

**1. Fire-phase criterion was too loose.** The caller run concludes `success` even when `validate-command` rejects and skips downstream jobs — observed on run [24801994238](https://github.com/camaraproject/tooling/actions/runs/24801994238) where 3 phases PASSed despite rejection. After `poll_run`, the fire-phase now reads the RA bot's final reply on the Release Issue since the fire marker and compares its first line against an expected title prefix per command. Expected prefixes live in `release_automation/regression/expected-comments.yaml` — hand-edited when the RA bot templates change (test-assertion discipline, not a captured artifact). Rejection (`command_rejected`), internal failure (`snapshot_failed`, `internal_error`), and warning paths (`common_sync_failed`) all produce different titles, so one check catches them all. Caller non-success short-circuits before the comment check.

**2. Slash-command comments on ReleaseTest were bare.** Operators had no way to tell the canary's `/create-snapshot` and `/discard-snapshot` posts from manual commands. Both now carry canary attribution + the triggering workflow run URL (composed from Actions env vars; URL clause omitted gracefully outside CI). The first line is still the bare slash command, so both the caller's `if:` filter and the reusable workflow's word-boundary parser accept it.

#### Which issue(s) this PR fixes:

Fixes #

Related to camaraproject/ReleaseManagement#379.

#### Special notes for reviewers:

23 new unit tests (69/69 pass total). pyflakes clean.

Rejection-path end-to-end check after merge: bump `release-plan.yaml` `dependencies.commonalities_release` on ReleaseTest from `r4.1` → `r4.2` (cache-stale → rejected), dispatch the canary, expect fire-phase FAIL "expected '✅ Snapshot created', got '❌ Command rejected …'", revert.

#### Changelog input

```
 release-note
 none (CI polish for the RA regression canary)
```

#### Additional documentation

This section can be blank.

```
docs
```