### PR TITLE
fix(ra): clamp slash-command args to the first line of the body

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -109,30 +109,40 @@ jobs:
               // Parse slash commands. Each pattern anchors at start and
               // requires either whitespace or end-of-string after the
               // command so /create-snapshotextra does not match /create-snapshot.
+              //
+              // commandArgs is clamped to what follows on the SAME line as
+              // the command. Anything after the first newline is treated
+              // as free-form context and ignored. No command consumes more
+              // than a single-token reason or a '--confirm <tag>' flag, so
+              // this also blocks shell-injection via backticks in multi-line
+              // bodies when command_args flows into downstream shell steps
+              // (e.g. post-result's Resolve Reason).
+              const firstLine = body.split(/\r?\n/, 1)[0];
+
               if (/^\/create-snapshot(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'create-snapshot';
-                commandArgs = body.replace(/^\/create-snapshot/, '').trim();
+                commandArgs = '';  // no arguments accepted
                 shouldContinue = 'true';
               } else if (/^\/discard-snapshot(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'discard-snapshot';
-                commandArgs = body.replace(/^\/discard-snapshot/, '').trim();
+                commandArgs = firstLine.replace(/^\/discard-snapshot/, '').trim();
                 shouldContinue = 'true';
               } else if (/^\/delete-draft(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'delete-draft';
-                commandArgs = body.replace(/^\/delete-draft/, '').trim();
+                commandArgs = firstLine.replace(/^\/delete-draft/, '').trim();
                 shouldContinue = 'true';
               } else if (/^\/sync-issue(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'sync-issue';
-                commandArgs = body.replace(/^\/sync-issue/, '').trim();
+                commandArgs = '';  // no arguments accepted
                 shouldContinue = 'true';
               } else if (/^\/publish-release(?:\s|$)/.test(body)) {
                 triggerType = 'slash_command';
                 command = 'publish-release';
-                commandArgs = body.replace(/^\/publish-release/, '').trim();
+                commandArgs = firstLine.replace(/^\/publish-release/, '').trim();
                 // Parse --confirm <tag> argument
                 const confirmMatch = commandArgs.match(/--confirm\s+(\S+)/);
                 confirmTag = confirmMatch ? confirmMatch[1] : '';


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

No RA slash command consumes more than a single-token reason or a `--confirm <tag>` flag, but the parser captured the **entire comment body** after the command — multi-line and all — as `command_args`. That value flows into `post-result`'s `Resolve Reason` step, which double-quotes it into a bash script. Double-quoted bash still performs command substitution on backticks, so a body containing `` `text` `` (e.g. the canary's attribution with `` `camaraproject/tooling` `` and `` `/discard-snapshot` ``) turned into a shell-injection that exited 127 and failed the whole run. Discovered by the Release Automation Regression canary (run [24820328229](https://github.com/camaraproject/ReleaseTest/actions/runs/24820328229)).

Clamp `commandArgs` to what follows the command on the **same line**; treat anything after the first newline as free-form context and discard.

- `/create-snapshot` and `/sync-issue`: take no arguments → empty string.
- `/discard-snapshot` and `/delete-draft`: single-line reason preserved (existing UX).
- `/publish-release`: continues to extract `--confirm <tag>`.

Side benefit: commenters can now append multi-line explanation below the command without it landing in the bot's "Reason:" field or in workflow logs.

#### Which issue(s) this PR fixes:

Fixes #

Related to camaraproject/ReleaseManagement#379.

#### Special notes for reviewers:

Verified the new parser with six test cases (bare, multi-line create, single-line discard-with-reason, multi-line discard, publish-confirm, publish-with-trailing-notes) — all produce the expected `command`, `commandArgs`, and `confirmTag` values.

Post-merge the canary should round-trip green again (canary's attribution body is now safe).

#### Changelog input

```
 release-note
 none (RA workflow fix; clamps slash-command args to the first line)
```

#### Additional documentation

This section can be blank.

```
docs
```