### PR TITLE
fix(canary): skip HTML-comment identity marker when extracting title

### DIFF
--- a/release_automation/scripts/regression_runner.py
+++ b/release_automation/scripts/regression_runner.py
@@ -41,6 +41,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -423,17 +424,29 @@ def load_expected_comment_titles(path: Path | None = None) -> dict[str, str]:
     return data
 
 
-def _first_nonblank_line(body: str) -> str:
-    """Return the first non-blank line of *body*, stripped of trailing space."""
+_HTML_COMMENT_RE = re.compile(r"^\s*<!--.*?-->\s*$")
+
+
+def _first_visible_line(body: str) -> str:
+    """Return the first non-blank, non-HTML-comment line of *body*.
+
+    The RA bot's post-bot-comment action prepends an HTML-comment marker
+    (e.g. `<!-- release-bot:r1.2 -->`) to every reply for programmatic
+    identity. That marker isn't user-visible and isn't the title; skip it
+    when locating the title line.
+    """
     for line in body.splitlines():
-        if line.strip():
-            return line.rstrip()
+        stripped = line.strip()
+        if not stripped or _HTML_COMMENT_RE.match(line):
+            continue
+        return line.rstrip()
     return ""
 
 
 def _match_comment_title(body: str, expected_prefix: str) -> bool:
-    """True iff the first non-blank line of *body* starts with *expected_prefix*."""
-    return _first_nonblank_line(body).startswith(expected_prefix)
+    """True iff the first visible (non-blank, non-HTML-comment) line of *body*
+    starts with *expected_prefix*."""
+    return _first_visible_line(body).startswith(expected_prefix)
 
 
 def fetch_last_bot_comment(
@@ -711,7 +724,7 @@ def _fire_command_phase(
         )
         return report, run_id
 
-    actual_title = _first_nonblank_line(last_comment.get("body") or "")
+    actual_title = _first_visible_line(last_comment.get("body") or "")
     if _match_comment_title(last_comment.get("body") or "", expected_title):
         report.passed = True
         report.detail = f"bot reply matches expected — `{actual_title}`"

--- a/release_automation/tests/test_regression_runner.py
+++ b/release_automation/tests/test_regression_runner.py
@@ -20,7 +20,7 @@ from release_automation.scripts.regression_runner import (
     PhaseReport,
     _build_command_body,
     _canary_run_url,
-    _first_nonblank_line,
+    _first_visible_line,
     _iso_to_dt,
     _match_comment_title,
     fetch_last_bot_comment,
@@ -742,9 +742,45 @@ class TestMatchCommentTitle:
         body = "\n\n**🗑️ Snapshot discarded — State: `planned`**\nmore"
         assert _match_comment_title(body, "**🗑️ Snapshot discarded")
 
+    def test_skips_html_comment_marker(self):
+        # The RA bot's post-bot-comment action prepends an HTML-comment
+        # identity marker (one per release tag) to every reply. The title
+        # is on the next non-marker line.
+        body = (
+            "<!-- release-bot:r1.2 -->\n"
+            "**✅ Snapshot created — State: `snapshot-active`**\n"
+            "Release PR: #96"
+        )
+        assert _match_comment_title(body, "**✅ Snapshot created")
+        assert _first_visible_line(body).startswith("**✅ Snapshot created")
+
+    def test_skips_multiple_html_markers_with_blank_lines(self):
+        # Belt-and-braces: marker + blank + marker + title should still work.
+        body = (
+            "<!-- release-bot:r1.2 -->\n\n"
+            "<!-- some other marker -->\n"
+            "**🗑️ Snapshot discarded — State: `planned`**\n"
+        )
+        assert _match_comment_title(body, "**🗑️ Snapshot discarded")
+
+    def test_html_comment_inline_with_content_is_not_skipped(self):
+        # If a line has BOTH an HTML comment and visible content, it
+        # shouldn't be treated as a pure marker — the title regex is
+        # anchored at the line boundaries.
+        body = "<!-- marker --> **✅ Snapshot created**"
+        # The line contains more than just a comment, so it's kept as the
+        # title line (and the match fails because the prefix expects the
+        # title to start the line).
+        assert not _match_comment_title(body, "**✅ Snapshot created")
+
     def test_empty_body(self):
         assert not _match_comment_title("", "**✅ Snapshot created")
-        assert _first_nonblank_line("") == ""
+        assert _first_visible_line("") == ""
+
+    def test_only_html_markers_returns_empty(self):
+        body = "<!-- release-bot:r1.2 -->\n\n<!-- another -->\n"
+        assert _first_visible_line(body) == ""
+        assert not _match_comment_title(body, "**✅ Snapshot created")
 
 
 # ---------------------------------------------------------------------------
@@ -898,11 +934,13 @@ class TestPhaseFireCreateSnapshotPolished:
             "release_automation.scripts.regression_runner.time.sleep",
             lambda *_a, **_k: None,
         )
+        # Shape matches real RA bot output: identity marker on line 1,
+        # title on line 2 (exercises the HTML-comment skip).
         comments = [
             _comment(
                 "2026-04-23T05:00:30Z",
                 "github-actions[bot]",
-                "**✅ Snapshot created — State: `snapshot-active`**\nRelease PR: #94",
+                "<!-- release-bot:r1.2 -->\n**✅ Snapshot created — State: `snapshot-active`**\nRelease PR: #94",
             ),
         ]
         caller_run = {


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The RA bot's `post-bot-comment` action prepends an identity marker of the form `<!-- release-bot:<release-tag> -->` as line 1 of every reply (programmatic lookup key). The canary's `_first_nonblank_line` + `_match_comment_title` grabbed that marker as the "title" and failed to match the visible `**✅ Snapshot created …` line beneath it.

Observed on run [24821023555](https://github.com/camaraproject/tooling/actions/runs/24821023555) (post-[tooling#218](https://github.com/camaraproject/tooling/pull/218) merge). The round-trip actually executed green on ReleaseTest — snapshot `r1.2-7c6a6e8` was created, PR [#96](https://github.com/camaraproject/ReleaseTest/pull/96) opened — but the canary misclassified the result as fire-phase FAIL.

Rename `_first_nonblank_line` → `_first_visible_line` and skip lines that are pure HTML comments (anchored `^\s*<!--.*?-->\s*$`). Lines that mix content with an inline comment are **not** skipped.

#### Which issue(s) this PR fixes:

Fixes #

Related to camaraproject/ReleaseManagement#379.

#### Special notes for reviewers:

73/73 tests pass. New coverage: single marker + title, multiple markers + blank lines, inline-comment line (not skipped), empty body, and marker-only body.

Post-merge I'll manually `/discard-snapshot` on ReleaseTest#93 to clear the stale `snapshot-active` left from the last canary attempt, then dispatch the canary to confirm the round-trip scores as 5/5 green.

#### Changelog input

```
 release-note
 none (canary bug fix; no behavior change to the RA workflow itself)
```

#### Additional documentation

This section can be blank.

```
docs
```