### PR TITLE
fix: release-plan dep detection + enable SED at stage 'enabled'

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -181,114 +181,23 @@ jobs:
       # why the orchestrator suppresses the Spectral + gherkin engines.
       # ICM has no common files to sync, so an ICM advance does not
       # trigger engine suppression.
+      - name: Install pyyaml for dependency resolver
+        if: >-
+          github.event_name == 'pull_request'
+          && steps.detect-changes.outputs.release_plan_changed == 'true'
+        run: pip install --quiet pyyaml==6.0.3
+
       - name: Resolve dependency changes and declared tags
         id: detect-deps
         if: >-
           github.event_name == 'pull_request'
           && steps.detect-changes.outputs.release_plan_changed == 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { execSync } = require('child_process');
-            const fs = require('fs');
-            const path = require('path');
-            // js-yaml is bundled with actions/github-script v9+ and its
-            // dependencies; require by name.
-            const yaml = require('js-yaml');
-
-            function readYamlAtRef(ref, filePath) {
-              // Returns the parsed YAML at origin/<ref>:<filePath>, or
-              // {} when the file is absent at that ref.
-              try {
-                const raw = execSync(
-                  `git show origin/${ref}:${filePath}`,
-                  { stdio: ['ignore', 'pipe', 'pipe'] }
-                ).toString('utf8');
-                const parsed = yaml.load(raw);
-                return parsed && typeof parsed === 'object' ? parsed : {};
-              } catch (err) {
-                return {};
-              }
-            }
-
-            function readYamlAtPath(filePath) {
-              try {
-                const raw = fs.readFileSync(filePath, 'utf8');
-                const parsed = yaml.load(raw);
-                return parsed && typeof parsed === 'object' ? parsed : {};
-              } catch (err) {
-                return {};
-              }
-            }
-
-            function getDep(plan, field) {
-              const deps = (plan && plan.dependencies) || {};
-              return deps[field] || null;
-            }
-
-            const baseRef = context.payload.pull_request.base.ref;
-            const planPath = 'release-plan.yaml';
-            const basePlan = readYamlAtRef(baseRef, planPath);
-            const headPlan = readYamlAtPath(
-              path.join(process.env.GITHUB_WORKSPACE, planPath)
-            );
-
-            const DEPENDENCIES = [
-              {
-                field: 'commonalities_release',
-                sourceRepo: 'camaraproject/Commonalities',
-                changedOutput: 'commonalities_release_changed',
-                tagExistsOutput: 'commonalities_tag_exists',
-              },
-              {
-                field: 'identity_consent_management_release',
-                sourceRepo: 'camaraproject/IdentityAndConsentManagement',
-                changedOutput: 'icm_release_changed',
-                tagExistsOutput: 'icm_tag_exists',
-              },
-            ];
-
-            async function tagExists(owner, repo, tag) {
-              try {
-                await github.rest.git.getRef({
-                  owner, repo, ref: `tags/${tag}`,
-                });
-                return 'true';
-              } catch (err) {
-                if (err && err.status === 404) return 'false';
-                // 5xx, rate-limit, network, auth issues — let P-023
-                // surface a warn-level finding rather than blocking.
-                core.warning(
-                  `Tag lookup for ${owner}/${repo}@${tag} failed: ${err.message}`
-                );
-                return '';
-              }
-            }
-
-            let commonalitiesChanged = false;
-            for (const dep of DEPENDENCIES) {
-              const baseTag = getDep(basePlan, dep.field);
-              const headTag = getDep(headPlan, dep.field);
-              const changed = baseTag !== headTag;
-              core.setOutput(dep.changedOutput, changed ? 'true' : 'false');
-
-              if (changed && dep.field === 'commonalities_release') {
-                commonalitiesChanged = true;
-              }
-
-              if (changed && headTag) {
-                const [owner, repo] = dep.sourceRepo.split('/');
-                const exists = await tagExists(owner, repo, headTag);
-                core.setOutput(dep.tagExistsOutput, exists);
-              } else {
-                core.setOutput(dep.tagExistsOutput, '');
-              }
-            }
-
-            core.setOutput(
-              'release_plan_check_only',
-              commonalitiesChanged ? 'true' : 'false'
-            );
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .tooling/validation/scripts/resolve-release-plan-deps.py \
+            --base-ref "${{ github.base_ref }}" \
+            --workspace "${GITHUB_WORKSPACE}"
 
       # ── Step 7: Run validation (shared action) ─────────────────────
       #

--- a/validation/config/validation-config.yaml
+++ b/validation/config/validation-config.yaml
@@ -14,3 +14,5 @@ fork_owners:
 repositories:
   ReleaseTest:
     stage: enabled
+  SimpleEdgeDiscovery:
+    stage: enabled

--- a/validation/scripts/resolve-release-plan-deps.py
+++ b/validation/scripts/resolve-release-plan-deps.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+CAMARA Validation Framework — Release-Plan Dependency Resolver
+
+Diffs release-plan.yaml between the PR base ref and the checked-out head,
+detects which declared dependency tags changed, and probes the source repo
+for tag existence.  Emits GitHub Actions step outputs consumed by the
+run-validation shared action.
+
+Outputs (written to the file at $GITHUB_OUTPUT, or --github-output):
+
+    commonalities_release_changed   'true' | 'false'
+    icm_release_changed             'true' | 'false'
+    commonalities_tag_exists        'true' | 'false' | ''   (empty = skipped / lookup failed)
+    icm_tag_exists                  'true' | 'false' | ''
+    release_plan_check_only         'true' | 'false'
+
+`release_plan_check_only` is 'true' only when commonalities_release advanced:
+that is the dependency whose cached content (code/common/*) is stale under
+the new ruleset, so the orchestrator suppresses the Spectral + gherkin
+engines.  ICM has no common files to sync.
+
+External commands: `git show origin/<base_ref>:<path>` and `gh api
+/repos/<owner>/<repo>/git/ref/tags/<tag>`.  `gh` inherits GH_TOKEN /
+GITHUB_TOKEN from the calling workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "Error: pyyaml package is required. Install with: pip install pyyaml",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# ---------------------------------------------------------------------------
+# Dependency table
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Dependency:
+    field: str
+    source_repo: str  # "owner/repo"
+    changed_output: str
+    tag_exists_output: str
+
+
+DEPENDENCIES: tuple[Dependency, ...] = (
+    Dependency(
+        field="commonalities_release",
+        source_repo="camaraproject/Commonalities",
+        changed_output="commonalities_release_changed",
+        tag_exists_output="commonalities_tag_exists",
+    ),
+    Dependency(
+        field="identity_consent_management_release",
+        source_repo="camaraproject/IdentityAndConsentManagement",
+        changed_output="icm_release_changed",
+        tag_exists_output="icm_tag_exists",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+
+def _parse_plan(raw: str) -> dict[str, Any]:
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def read_plan_at_ref(base_ref: str, plan_path: str, *, git_bin: str = "git") -> dict[str, Any]:
+    """Load release-plan.yaml at `origin/<base_ref>`; return {} when missing."""
+    try:
+        result = subprocess.run(
+            [git_bin, "show", f"origin/{base_ref}:{plan_path}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {}
+    if result.returncode != 0:
+        return {}
+    return _parse_plan(result.stdout)
+
+
+def read_plan_at_path(plan_path: Path) -> dict[str, Any]:
+    """Load release-plan.yaml from the workspace; return {} when missing."""
+    try:
+        raw = plan_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    return _parse_plan(raw)
+
+
+def get_dep(plan: dict[str, Any], field: str) -> str | None:
+    deps = plan.get("dependencies") if isinstance(plan, dict) else None
+    if not isinstance(deps, dict):
+        return None
+    value = deps.get(field)
+    return value if isinstance(value, str) and value else None
+
+
+# ---------------------------------------------------------------------------
+# Tag lookup via gh
+# ---------------------------------------------------------------------------
+
+
+def tag_exists(owner: str, repo: str, tag: str, *, gh_bin: str = "gh") -> str:
+    """Return 'true' / 'false' / '' — tri-state existence flag.
+
+    'false' is only returned when the `gh` error is an authoritative 404.
+    Any other failure (5xx, rate limit, auth, network) returns '' so P-023
+    surfaces a warn-level finding rather than blocking validation.
+    """
+    try:
+        result = subprocess.run(
+            [
+                gh_bin,
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                f"/repos/{owner}/{repo}/git/ref/tags/{tag}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        emit_warning(f"Tag lookup for {owner}/{repo}@{tag} skipped: gh not found")
+        return ""
+
+    if result.returncode == 0:
+        return "true"
+
+    combined = f"{result.stdout}\n{result.stderr}"
+    if "HTTP 404" in combined or "Not Found" in combined:
+        return "false"
+
+    message = (result.stderr or result.stdout or "").strip().splitlines()
+    detail = message[-1] if message else f"exit code {result.returncode}"
+    emit_warning(f"Tag lookup for {owner}/{repo}@{tag} failed: {detail}")
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions output + warning helpers
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(outputs: dict[str, str], target: Path | None) -> None:
+    if target is None:
+        for key, value in outputs.items():
+            print(f"{key}={value}")
+        return
+    with target.open("a", encoding="utf-8") as fh:
+        for key, value in outputs.items():
+            fh.write(f"{key}={value}\n")
+
+
+def emit_warning(message: str) -> None:
+    print(f"::warning::{message}")
+
+
+# ---------------------------------------------------------------------------
+# Main resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve(
+    *,
+    base_ref: str,
+    plan_path: str,
+    workspace_plan: Path,
+    gh_bin: str = "gh",
+    git_bin: str = "git",
+) -> dict[str, str]:
+    base_plan = read_plan_at_ref(base_ref, plan_path, git_bin=git_bin)
+    head_plan = read_plan_at_path(workspace_plan)
+
+    outputs: dict[str, str] = {}
+    commonalities_changed = False
+
+    for dep in DEPENDENCIES:
+        base_tag = get_dep(base_plan, dep.field)
+        head_tag = get_dep(head_plan, dep.field)
+        changed = base_tag != head_tag
+        outputs[dep.changed_output] = "true" if changed else "false"
+
+        if changed and dep.field == "commonalities_release":
+            commonalities_changed = True
+
+        if changed and head_tag:
+            owner, repo = dep.source_repo.split("/", 1)
+            outputs[dep.tag_exists_output] = tag_exists(owner, repo, head_tag, gh_bin=gh_bin)
+        else:
+            outputs[dep.tag_exists_output] = ""
+
+    outputs["release_plan_check_only"] = "true" if commonalities_changed else "false"
+    return outputs
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True, help="PR base ref (e.g. 'main').")
+    parser.add_argument(
+        "--plan-path",
+        default="release-plan.yaml",
+        help="Path to release-plan.yaml relative to the repo root.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=os.environ.get("GITHUB_WORKSPACE", "."),
+        help="Path to the checked-out head workspace (default: $GITHUB_WORKSPACE).",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Path to the GITHUB_OUTPUT file (default: $GITHUB_OUTPUT).",
+    )
+    parser.add_argument("--gh-bin", default="gh", help=argparse.SUPPRESS)
+    parser.add_argument("--git-bin", default="git", help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    outputs = resolve(
+        base_ref=args.base_ref,
+        plan_path=args.plan_path,
+        workspace_plan=Path(args.workspace) / args.plan_path,
+        gh_bin=args.gh_bin,
+        git_bin=args.git_bin,
+    )
+
+    target = Path(args.github_output) if args.github_output else None
+    write_outputs(outputs, target)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/tests/test_resolve_release_plan_deps.py
+++ b/validation/tests/test_resolve_release_plan_deps.py
@@ -1,0 +1,388 @@
+"""Unit tests for validation.scripts.resolve-release-plan-deps.
+
+Covers plan parsing, diff semantics across the two declared dependencies,
+gh tag-lookup tri-state mapping (success / 404 / other), and
+GITHUB_OUTPUT file writing.  External commands (`git show`, `gh api`) are
+mocked by providing an alternative `gh_bin` / `git_bin` that points at a
+temp-directory shim script produced by the test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import stat
+import sys
+from pathlib import Path
+
+# validation/scripts/ is not a package — load the module directly.
+_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _ROOT / "validation" / "scripts" / "resolve-release-plan-deps.py"
+_spec = importlib.util.spec_from_file_location("resolve_release_plan_deps", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+resolve_release_plan_deps = importlib.util.module_from_spec(_spec)
+sys.modules["resolve_release_plan_deps"] = resolve_release_plan_deps
+_spec.loader.exec_module(resolve_release_plan_deps)
+
+
+get_dep = resolve_release_plan_deps.get_dep
+_parse_plan = resolve_release_plan_deps._parse_plan
+read_plan_at_path = resolve_release_plan_deps.read_plan_at_path
+read_plan_at_ref = resolve_release_plan_deps.read_plan_at_ref
+tag_exists = resolve_release_plan_deps.tag_exists
+resolve = resolve_release_plan_deps.resolve
+write_outputs = resolve_release_plan_deps.write_outputs
+
+
+# ---------------------------------------------------------------------------
+# Shim script factory — writes a tiny executable that echoes canned output
+# and exits with a canned return code.  Keeps tests hermetic without
+# needing to patch subprocess at the Python level.
+# ---------------------------------------------------------------------------
+
+
+def _make_shim(
+    tmp_path: Path,
+    name: str,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+) -> Path:
+    """Write an executable shim at tmp_path/<name> that prints fixed output.
+
+    Implemented in Python rather than bash to sidestep shell-quoting edge
+    cases with embedded newlines / quotes in the canned output.
+    """
+    script = tmp_path / name
+    lines = [
+        "#!/usr/bin/env python3",
+        "import sys",
+        f"sys.stdout.write({stdout!r})",
+        f"sys.stderr.write({stderr!r})",
+        f"sys.exit({exit_code})",
+        "",
+    ]
+    script.write_text("\n".join(lines), encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+# ---------------------------------------------------------------------------
+# get_dep / _parse_plan
+# ---------------------------------------------------------------------------
+
+
+class TestGetDep:
+    def test_returns_value_when_present(self):
+        plan = {"dependencies": {"commonalities_release": "r4.1"}}
+        assert get_dep(plan, "commonalities_release") == "r4.1"
+
+    def test_returns_none_when_field_absent(self):
+        plan = {"dependencies": {"other": "value"}}
+        assert get_dep(plan, "commonalities_release") is None
+
+    def test_returns_none_when_dependencies_absent(self):
+        assert get_dep({}, "commonalities_release") is None
+
+    def test_returns_none_when_dependencies_not_a_dict(self):
+        plan = {"dependencies": ["unexpected"]}
+        assert get_dep(plan, "commonalities_release") is None
+
+    def test_returns_none_when_value_empty_string(self):
+        plan = {"dependencies": {"commonalities_release": ""}}
+        assert get_dep(plan, "commonalities_release") is None
+
+    def test_returns_none_when_value_not_a_string(self):
+        plan = {"dependencies": {"commonalities_release": 4.1}}
+        assert get_dep(plan, "commonalities_release") is None
+
+
+class TestParsePlan:
+    def test_parses_valid_yaml(self):
+        assert _parse_plan("dependencies:\n  commonalities_release: r4.1\n") == {
+            "dependencies": {"commonalities_release": "r4.1"}
+        }
+
+    def test_returns_empty_on_invalid_yaml(self):
+        assert _parse_plan("dependencies: {\n  unterminated") == {}
+
+    def test_returns_empty_when_top_level_is_scalar(self):
+        assert _parse_plan("just-a-string") == {}
+
+    def test_returns_empty_on_empty_string(self):
+        assert _parse_plan("") == {}
+
+
+# ---------------------------------------------------------------------------
+# read_plan_at_path / read_plan_at_ref
+# ---------------------------------------------------------------------------
+
+
+class TestReadPlanAtPath:
+    def test_reads_existing_file(self, tmp_path):
+        plan_file = tmp_path / "release-plan.yaml"
+        plan_file.write_text("dependencies:\n  commonalities_release: r4.1\n")
+        assert read_plan_at_path(plan_file) == {
+            "dependencies": {"commonalities_release": "r4.1"}
+        }
+
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        assert read_plan_at_path(tmp_path / "absent.yaml") == {}
+
+
+class TestReadPlanAtRef:
+    def test_returns_plan_when_git_succeeds(self, tmp_path):
+        shim = _make_shim(
+            tmp_path,
+            "git",
+            stdout="dependencies:\n  commonalities_release: r4.1\n",
+            exit_code=0,
+        )
+        assert read_plan_at_ref("main", "release-plan.yaml", git_bin=str(shim)) == {
+            "dependencies": {"commonalities_release": "r4.1"}
+        }
+
+    def test_returns_empty_when_git_fails(self, tmp_path):
+        shim = _make_shim(
+            tmp_path,
+            "git",
+            stderr="fatal: Path 'release-plan.yaml' does not exist in 'origin/main'\n",
+            exit_code=128,
+        )
+        assert read_plan_at_ref("main", "release-plan.yaml", git_bin=str(shim)) == {}
+
+    def test_returns_empty_when_git_not_found(self):
+        assert read_plan_at_ref("main", "release-plan.yaml", git_bin="/no/such/bin") == {}
+
+
+# ---------------------------------------------------------------------------
+# tag_exists
+# ---------------------------------------------------------------------------
+
+
+class TestTagExists:
+    def test_returns_true_on_success(self, tmp_path):
+        shim = _make_shim(tmp_path, "gh", stdout='{"ref":"refs/tags/r4.1"}', exit_code=0)
+        assert (
+            tag_exists("camaraproject", "Commonalities", "r4.1", gh_bin=str(shim))
+            == "true"
+        )
+
+    def test_returns_false_on_http_404(self, tmp_path):
+        shim = _make_shim(
+            tmp_path,
+            "gh",
+            stderr="gh: Not Found (HTTP 404)\n",
+            exit_code=1,
+        )
+        assert (
+            tag_exists("camaraproject", "Commonalities", "r9.9", gh_bin=str(shim))
+            == "false"
+        )
+
+    def test_returns_empty_on_other_error(self, tmp_path, capsys):
+        shim = _make_shim(
+            tmp_path,
+            "gh",
+            stderr="gh: internal server error (HTTP 502)\n",
+            exit_code=1,
+        )
+        assert (
+            tag_exists("camaraproject", "Commonalities", "r4.1", gh_bin=str(shim))
+            == ""
+        )
+        out = capsys.readouterr().out
+        assert "::warning::Tag lookup for camaraproject/Commonalities@r4.1 failed" in out
+
+    def test_returns_empty_when_gh_missing(self, capsys):
+        assert (
+            tag_exists(
+                "camaraproject", "Commonalities", "r4.1", gh_bin="/no/such/bin"
+            )
+            == ""
+        )
+        out = capsys.readouterr().out
+        assert "::warning::Tag lookup" in out
+        assert "skipped: gh not found" in out
+
+
+# ---------------------------------------------------------------------------
+# resolve — end-to-end with shim binaries
+# ---------------------------------------------------------------------------
+
+
+def _write_plan(path: Path, commonalities: str | None, icm: str | None) -> None:
+    deps = {}
+    if commonalities is not None:
+        deps["commonalities_release"] = commonalities
+    if icm is not None:
+        deps["identity_consent_management_release"] = icm
+    body = "dependencies:\n" + "".join(f"  {k}: {v}\n" for k, v in deps.items())
+    path.write_text(body, encoding="utf-8")
+
+
+class TestResolve:
+    def test_no_changes(self, tmp_path):
+        """Same dep values on base and head → all changed flags false, all tag_exists empty."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        _write_plan(workspace / "release-plan.yaml", "r4.1", "r3.0")
+
+        git_shim = _make_shim(
+            tmp_path,
+            "git",
+            stdout="dependencies:\n  commonalities_release: r4.1\n  identity_consent_management_release: r3.0\n",
+            exit_code=0,
+        )
+        gh_shim = _make_shim(tmp_path, "gh", exit_code=0)  # should never be called
+
+        out = resolve(
+            base_ref="main",
+            plan_path="release-plan.yaml",
+            workspace_plan=workspace / "release-plan.yaml",
+            gh_bin=str(gh_shim),
+            git_bin=str(git_shim),
+        )
+
+        assert out == {
+            "commonalities_release_changed": "false",
+            "icm_release_changed": "false",
+            "commonalities_tag_exists": "",
+            "icm_tag_exists": "",
+            "release_plan_check_only": "false",
+        }
+
+    def test_commonalities_advanced_to_existing_tag(self, tmp_path):
+        """Commonalities bump only → check_only true, commonalities_tag_exists 'true'."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        _write_plan(workspace / "release-plan.yaml", "r4.2", "r3.0")
+
+        git_shim = _make_shim(
+            tmp_path,
+            "git",
+            stdout="dependencies:\n  commonalities_release: r4.1\n  identity_consent_management_release: r3.0\n",
+            exit_code=0,
+        )
+        gh_shim = _make_shim(tmp_path, "gh", stdout='{"ref":"refs/tags/r4.2"}', exit_code=0)
+
+        out = resolve(
+            base_ref="main",
+            plan_path="release-plan.yaml",
+            workspace_plan=workspace / "release-plan.yaml",
+            gh_bin=str(gh_shim),
+            git_bin=str(git_shim),
+        )
+
+        assert out["commonalities_release_changed"] == "true"
+        assert out["icm_release_changed"] == "false"
+        assert out["commonalities_tag_exists"] == "true"
+        assert out["icm_tag_exists"] == ""
+        assert out["release_plan_check_only"] == "true"
+
+    def test_icm_advanced_to_missing_tag(self, tmp_path):
+        """ICM bump to a tag that 404s → icm_tag_exists 'false', check_only remains false."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        _write_plan(workspace / "release-plan.yaml", "r4.1", "r9.9")
+
+        git_shim = _make_shim(
+            tmp_path,
+            "git",
+            stdout="dependencies:\n  commonalities_release: r4.1\n  identity_consent_management_release: r3.0\n",
+            exit_code=0,
+        )
+        gh_shim = _make_shim(
+            tmp_path,
+            "gh",
+            stderr="gh: Not Found (HTTP 404)\n",
+            exit_code=1,
+        )
+
+        out = resolve(
+            base_ref="main",
+            plan_path="release-plan.yaml",
+            workspace_plan=workspace / "release-plan.yaml",
+            gh_bin=str(gh_shim),
+            git_bin=str(git_shim),
+        )
+
+        assert out["commonalities_release_changed"] == "false"
+        assert out["icm_release_changed"] == "true"
+        assert out["commonalities_tag_exists"] == ""
+        assert out["icm_tag_exists"] == "false"
+        assert out["release_plan_check_only"] == "false"
+
+    def test_both_changed(self, tmp_path):
+        """Both dependencies advance — both tag lookups performed, check_only true."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        _write_plan(workspace / "release-plan.yaml", "r4.2", "r4.0")
+
+        git_shim = _make_shim(
+            tmp_path,
+            "git",
+            stdout="dependencies:\n  commonalities_release: r4.1\n  identity_consent_management_release: r3.0\n",
+            exit_code=0,
+        )
+        gh_shim = _make_shim(tmp_path, "gh", stdout='{"ref":"refs/tags/x"}', exit_code=0)
+
+        out = resolve(
+            base_ref="main",
+            plan_path="release-plan.yaml",
+            workspace_plan=workspace / "release-plan.yaml",
+            gh_bin=str(gh_shim),
+            git_bin=str(git_shim),
+        )
+
+        assert out["commonalities_release_changed"] == "true"
+        assert out["icm_release_changed"] == "true"
+        assert out["commonalities_tag_exists"] == "true"
+        assert out["icm_tag_exists"] == "true"
+        assert out["release_plan_check_only"] == "true"
+
+    def test_commonalities_removed_on_head(self, tmp_path):
+        """Head plan drops commonalities_release → changed true, no tag lookup → '' tag_exists."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        _write_plan(workspace / "release-plan.yaml", None, "r3.0")
+
+        git_shim = _make_shim(
+            tmp_path,
+            "git",
+            stdout="dependencies:\n  commonalities_release: r4.1\n  identity_consent_management_release: r3.0\n",
+            exit_code=0,
+        )
+        gh_shim = _make_shim(tmp_path, "gh", exit_code=0)
+
+        out = resolve(
+            base_ref="main",
+            plan_path="release-plan.yaml",
+            workspace_plan=workspace / "release-plan.yaml",
+            gh_bin=str(gh_shim),
+            git_bin=str(git_shim),
+        )
+
+        assert out["commonalities_release_changed"] == "true"
+        assert out["commonalities_tag_exists"] == ""  # no head tag to look up
+        assert out["release_plan_check_only"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# write_outputs
+# ---------------------------------------------------------------------------
+
+
+class TestWriteOutputs:
+    def test_appends_to_file(self, tmp_path):
+        target = tmp_path / "outputs"
+        target.write_text("existing=preserved\n", encoding="utf-8")
+        write_outputs({"a": "1", "b": "2"}, target)
+        content = target.read_text(encoding="utf-8")
+        assert "existing=preserved" in content
+        assert "a=1" in content
+        assert "b=2" in content
+
+    def test_prints_when_target_none(self, capsys):
+        write_outputs({"a": "1"}, None)
+        assert "a=1" in capsys.readouterr().out


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Two small changes on the `validation-framework` branch:

1. **fix(validation): resolve release-plan deps via python script**

   Step 6b of `.github/workflows/validation.yml` called `require('js-yaml')`
   inside an inline `actions/github-script` block. `js-yaml` is not bundled
   with `github-script` v9, so the first real PR to hit the step
   (SimpleEdgeDiscovery#161) crashed with `MODULE_NOT_FOUND`. The
   Validation Regression canary fires via `workflow_dispatch` and never
   exercises this pull-request-gated code path, so the bug was not caught
   on the `validation-framework` branch.

   Replace the inline JS with `validation/scripts/resolve-release-plan-deps.py`
   (pyyaml + `gh` CLI). The script preserves the same five step outputs
   (`commonalities_release_changed`, `icm_release_changed`,
   `commonalities_tag_exists`, `icm_tag_exists`, `release_plan_check_only`)
   and the tri-state tag-existence semantics (`true` / `false` / empty).
   26 unit tests cover plan parsing, diff, `gh` tri-state mapping, and
   `GITHUB_OUTPUT` file writing.

2. **chore(validation): enable SimpleEdgeDiscovery at stage 'enabled'**

   Adds an explicit per-repo override in `validation/config/validation-config.yaml`
   so SED's v1 validation runs on PRs (not just dispatch).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

- Targets `validation-framework` (not `main`). Changes land between the
  current `@v1-rc` tag at `2385fd36` and `HEAD`; production repos on
  `@v1-rc` are unaffected.
- Falls inside the existing manual full E2E requirement before the next
  `@v1-rc` tag move (workflow + script change).
- Pyyaml is pip-installed in a new prep step before Step 6b. The existing
  `run-validation` shared action pins `pyyaml==6.0.3`; this PR uses the
  same pin for consistency.

#### Changelog input

```
 release-note
No user-facing change; internal fix for the `validation-framework`
branch so release-plan-touching PRs can run the framework without a
MODULE_NOT_FOUND crash, plus enabling SimpleEdgeDiscovery at stage
`enabled` in the central config.
```

#### Additional documentation

This section can be blank.

```
docs

```