### PR TITLE
Add short_title field to rule metadata for annotation titles

### DIFF
--- a/validation/output/annotations.py
+++ b/validation/output/annotations.py
@@ -15,7 +15,12 @@ from typing import List
 
 from validation.postfilter.engine import PostFilterResult
 
-from .formatting import deduplicate_findings, format_rule_label, sort_findings_by_priority
+from .formatting import (
+    deduplicate_findings,
+    format_rule_label,
+    resolve_annotation_title,
+    sort_findings_by_priority,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +90,12 @@ def _build_command(finding: dict) -> str:
 
     rule_label = format_rule_label(finding)
 
-    # Title: human-readable message.  Rule ID in message body.
-    title = finding.get("message", "")
-    message = f"[{rule_label}] {title}"
+    # Title: short_title from rule metadata when present, otherwise the
+    # finding message truncated to fit the annotation UI.  The full
+    # untruncated message always goes in the body.
+    title = resolve_annotation_title(finding)
+    full_message = finding.get("message", "")
+    message = f"[{rule_label}] {full_message}"
     hint = finding.get("hint")
     if hint:
         message = f"{message} | Hint: {hint}"

--- a/validation/output/check_run.py
+++ b/validation/output/check_run.py
@@ -25,6 +25,7 @@ from .formatting import (
     count_findings,
     deduplicate_findings,
     format_rule_label,
+    resolve_annotation_title,
     sort_findings_by_priority,
 )
 
@@ -88,10 +89,12 @@ def _build_annotation(finding: dict) -> dict:
     line = finding.get("line", 1)
     rule_label = format_rule_label(finding)
 
-    # Title: human-readable message (rendered as bold heading in Check Run).
-    # Rule ID goes into the message body to reduce visual weight.
-    title = finding.get("message", "")
-    message = f"[{rule_label}] {title}"
+    # Title: short_title from rule metadata when present, otherwise the
+    # finding message truncated to fit (rendered as bold heading in
+    # Check Run).  Rule ID and full message go in the body.
+    title = resolve_annotation_title(finding)
+    full_message = finding.get("message", "")
+    message = f"[{rule_label}] {full_message}"
     hint = finding.get("hint")
     if hint:
         message = f"{message}\n\nHint: {hint}"

--- a/validation/output/formatting.py
+++ b/validation/output/formatting.py
@@ -207,6 +207,29 @@ def format_rule_label(finding: dict) -> str:
     return finding.get("rule_id") or finding.get("engine_rule", "unknown")
 
 
+# Hard cap matches rule-metadata-schema.yaml maxLength for short_title.
+# Titles wider than this wrap in the GitHub file-diff annotation UI.
+_ANNOTATION_TITLE_MAX = 70
+
+
+def resolve_annotation_title(finding: dict) -> str:
+    """Return the annotation title for a finding.
+
+    Uses ``short_title`` when present (populated from rule metadata by
+    the post-filter).  Otherwise falls back to the finding ``message``,
+    truncated with an ellipsis when it would exceed
+    :data:`_ANNOTATION_TITLE_MAX`.  The full, untruncated message
+    remains available on the finding for the annotation body.
+    """
+    short = finding.get("short_title")
+    if short:
+        return short
+    message = finding.get("message", "")
+    if len(message) <= _ANNOTATION_TITLE_MAX:
+        return message
+    return message[: _ANNOTATION_TITLE_MAX - 1].rstrip() + "…"
+
+
 def format_finding_location(finding: dict) -> str:
     """Format a finding's location as ``path:line`` or ``path:line:column``."""
     path = finding.get("path", "")

--- a/validation/postfilter/engine.py
+++ b/validation/postfilter/engine.py
@@ -121,6 +121,8 @@ def _enrich_finding(
         enriched["message"] = rule.message_override
     if rule.hint is not None:
         enriched["hint"] = rule.hint
+    if rule.short_title is not None:
+        enriched["short_title"] = rule.short_title
     return enriched
 
 

--- a/validation/postfilter/metadata_loader.py
+++ b/validation/postfilter/metadata_loader.py
@@ -67,6 +67,9 @@ class RuleMetadata:
     Attributes:
         id: Stable ID with engine prefix (e.g. ``"S-042"``).
         name: Human-readable kebab-case name.  Defaults to ``engine_rule``.
+        short_title: Short human-readable label used as the annotation
+            title.  ``None`` means fall back to the message (truncated by
+            the emitter).
         engine: Engine responsible for producing the finding.
         engine_rule: Native rule identifier within the engine.
         message_override: Replaces the engine's finding message.  ``None``
@@ -90,6 +93,7 @@ class RuleMetadata:
     hint: Optional[str]
     applicability: dict
     conditional_level: Optional[ConditionalLevel]
+    short_title: Optional[str] = None
     suppress_schema_paths: Tuple[str, ...] = ()
 
 
@@ -163,6 +167,7 @@ def parse_rule_metadata(raw: dict) -> RuleMetadata:
         hint=raw.get("hint"),
         applicability=raw.get("applicability", {}),
         conditional_level=conditional_level,
+        short_title=raw.get("short_title"),
         suppress_schema_paths=suppress_schema_paths,
     )
 

--- a/validation/rules/gherkin-rules.yaml
+++ b/validation/rules/gherkin-rules.yaml
@@ -5,99 +5,124 @@
 - id: G-001
   engine: gherkin
   engine_rule: allowed-tags
+  short_title: "Tag not in allowed list"
 
 - id: G-002
   engine: gherkin
   engine_rule: indentation
+  short_title: "Inconsistent Gherkin indentation"
 
 - id: G-003
   engine: gherkin
   engine_rule: keywords-in-logical-order
+  short_title: "Gherkin keywords out of order"
 
 - id: G-004
   engine: gherkin
   engine_rule: max-scenarios-per-file
+  short_title: "Too many scenarios in feature file"
 
 - id: G-005
   engine: gherkin
   engine_rule: name-length
+  short_title: "Feature or scenario name too long"
 
 - id: G-006
   engine: gherkin
   engine_rule: no-background-only-scenario
+  short_title: "Background used with only one scenario"
 
 - id: G-007
   engine: gherkin
   engine_rule: no-dupe-feature-names
+  short_title: "Duplicate feature name"
 
 - id: G-008
   engine: gherkin
   engine_rule: no-dupe-scenario-names
+  short_title: "Duplicate scenario name"
 
 - id: G-009
   engine: gherkin
   engine_rule: no-duplicate-tags
+  short_title: "Duplicate tag on same element"
 
 - id: G-010
   engine: gherkin
   engine_rule: no-empty-background
+  short_title: "Background has no steps"
 
 - id: G-011
   engine: gherkin
   engine_rule: no-empty-file
+  short_title: "Feature file is empty"
 
 - id: G-012
   engine: gherkin
   engine_rule: no-files-without-scenarios
+  short_title: "Feature file has no scenarios"
 
 - id: G-013
   engine: gherkin
   engine_rule: no-homogenous-tags
+  short_title: "All scenarios share the same tag"
 
 - id: G-014
   engine: gherkin
   engine_rule: no-multiple-empty-lines
+  short_title: "Multiple consecutive empty lines"
 
 - id: G-015
   engine: gherkin
   engine_rule: no-partially-commented-tag-lines
+  short_title: "Comment on tag line"
 
 - id: G-016
   engine: gherkin
   engine_rule: no-restricted-tags
+  short_title: "Tag is on restricted list"
 
 - id: G-017
   engine: gherkin
   engine_rule: no-scenario-outlines-without-examples
+  short_title: "Scenario Outline has no Examples"
 
 - id: G-018
   engine: gherkin
   engine_rule: no-superfluous-tags
+  short_title: "Tag duplicates an inherited tag"
 
 - id: G-019
   engine: gherkin
   engine_rule: no-trailing-spaces
+  short_title: "Trailing whitespace"
 
 - id: G-020
   engine: gherkin
   engine_rule: no-unnamed-features
+  short_title: "Feature has no name"
 
 - id: G-021
   engine: gherkin
   engine_rule: no-unnamed-scenarios
+  short_title: "Scenario has no name"
 
 - id: G-022
   engine: gherkin
   engine_rule: no-unused-variables
+  short_title: "Unused Examples variable"
 
 - id: G-023
   engine: gherkin
   engine_rule: one-space-between-tags
+  short_title: "Tags must be single-space separated"
 
 - id: G-024
   engine: gherkin
   engine_rule: required-tags
+  short_title: "Required tag missing"
 
 - id: G-025
   engine: gherkin
   engine_rule: use-and
+  short_title: "Use And / But instead of repeating keyword"

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -9,6 +9,7 @@
 - id: P-001
   engine: python
   engine_rule: check-filename-kebab-case
+  short_title: "API filename must be kebab-case"
   conditional_level:
     default: error
 
@@ -16,6 +17,7 @@
 - id: P-002
   engine: python
   engine_rule: check-filename-matches-api-name
+  short_title: "API definition file must match release-plan api_name"
   conditional_level:
     default: error
 
@@ -23,6 +25,7 @@
 - id: P-003
   engine: python
   engine_rule: check-info-version-format
+  short_title: "info.version must be wip on main or maintenance"
   conditional_level:
     default: error
 
@@ -30,6 +33,7 @@
 - id: P-004
   engine: python
   engine_rule: check-server-url-version
+  short_title: "Server URL must include version segment"
   conditional_level:
     default: error
 
@@ -37,6 +41,7 @@
 - id: P-005
   engine: python
   engine_rule: check-server-url-api-name
+  short_title: "Server URL api-name must match release-plan"
   conditional_level:
     default: error
 
@@ -49,6 +54,7 @@
 - id: P-006
   engine: python
   engine_rule: check-test-files-exist
+  short_title: "Missing test definition file for API"
   conditional_level:
     default: hint
     overrides:
@@ -74,6 +80,7 @@
 - id: P-007
   engine: python
   engine_rule: check-test-file-version
+  short_title: "Test file: feature-line version mismatch"
   conditional_level:
     default: hint
     overrides:
@@ -86,6 +93,7 @@
 - id: P-008
   engine: python
   engine_rule: check-test-directory-exists
+  short_title: "Test_definitions directory is missing"
   conditional_level:
     default: hint
     overrides:
@@ -97,6 +105,7 @@
 - id: P-009
   engine: python
   engine_rule: check-release-plan-semantics
+  short_title: "release-plan.yaml has semantic error"
   applicability:
     release_plan_changed: true
   conditional_level:
@@ -106,6 +115,7 @@
 - id: P-010
   engine: python
   engine_rule: check-changelog-format
+  short_title: "CHANGELOG.md or CHANGELOG/ is required"
   conditional_level:
     default: warn
 
@@ -115,6 +125,7 @@
 - id: P-011
   engine: python
   engine_rule: check-commonalities-version
+  short_title: "info.x-camara-commonalities missing or wrong"
   conditional_level:
     default: error
 
@@ -122,6 +133,7 @@
 - id: P-012
   engine: python
   engine_rule: check-release-review-file-restriction
+  short_title: "Release Review PR: only docs may change"
   applicability:
     is_release_review_pr: true
   conditional_level:
@@ -131,6 +143,7 @@
 - id: P-013
   engine: python
   engine_rule: check-readme-placeholder-removal
+  short_title: "Remove placeholder README alongside API definitions"
   conditional_level:
     default: warn
 
@@ -139,6 +152,7 @@
 - id: P-014
   engine: python
   engine_rule: check-subscription-filename
+  short_title: "Subscription API name must end with -subscriptions"
   applicability:
     api_pattern: [explicit-subscription]
   conditional_level:
@@ -157,6 +171,7 @@
 - id: P-015
   engine: python
   engine_rule: check-event-type-format
+  short_title: "CloudEvent type format is wrong"
   applicability:
     api_pattern: [explicit-subscription, implicit-subscription]
     commonalities_release: ">=r4.2"
@@ -178,6 +193,7 @@
 - id: P-016
   engine: python
   engine_rule: check-sinkcredential-not-in-response
+  short_title: "sinkCredential must not appear in response"
   applicability:
     api_pattern: [explicit-subscription]
   conditional_level:
@@ -188,6 +204,7 @@
 - id: P-017
   engine: python
   engine_rule: check-conflict-deprecated
+  short_title: "CONFLICT error code is deprecated"
   applicability:
     commonalities_release: ">=r4.0"
   conditional_level:
@@ -198,6 +215,7 @@
 - id: P-018
   engine: python
   engine_rule: check-contextcode-format
+  short_title: "contextCode must be SCREAMING_SNAKE_CASE enum"
   applicability:
     commonalities_release: ">=r4.0"
   conditional_level:
@@ -208,6 +226,7 @@
 - id: P-019
   engine: python
   engine_rule: check-orphan-api-definitions
+  short_title: "API YAML not listed in release-plan.yaml"
   conditional_level:
     default: warn
 
@@ -223,6 +242,7 @@
 - id: P-020
   engine: python
   engine_rule: check-cloudevent-via-ref
+  short_title: "CloudEvent should be $ref, not inline"
   applicability:
     api_pattern: [explicit-subscription, implicit-subscription]
     commonalities_release: ">=r4.2"
@@ -244,6 +264,7 @@
 - id: P-021
   engine: python
   engine_rule: check-common-cache-sync
+  short_title: "code/common/ is missing or out of sync"
   applicability:
     release_plan_changed: false
     commonalities_release: ">=r4.2"
@@ -265,6 +286,7 @@
 - id: P-022
   engine: python
   engine_rule: check-release-plan-exclusivity
+  short_title: "release-plan.yaml must change in its own PR"
   applicability:
     release_plan_changed: true
   conditional_level:
@@ -282,6 +304,7 @@
 - id: P-023
   engine: python
   engine_rule: check-declared-dependency-tags-exist
+  short_title: "Declared dependency tag not found upstream"
   applicability:
     release_plan_changed: true
   conditional_level:
@@ -299,6 +322,7 @@
 - id: P-024
   engine: python
   engine_rule: check-test-file-feature-line-untransformable
+  short_title: "Feature line has no wip/vwip/version token"
   conditional_level:
     default: error
 
@@ -312,5 +336,6 @@
 - id: P-025
   engine: python
   engine_rule: check-feature-file-url-version
+  short_title: "Feature-step URL version segment wrong"
   conditional_level:
     default: error

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -9,155 +9,190 @@
 - id: S-001
   engine: spectral
   engine_rule: camara-discriminator-use
+  short_title: "Add discriminator for oneOf / anyOf"
 
 - id: S-002
   engine: spectral
   engine_rule: camara-get-no-request-body
+  short_title: "GET / DELETE must not have a request body"
 
 - id: S-003
   engine: spectral
   engine_rule: camara-http-methods
+  short_title: "Unsupported HTTP method on path"
 
 - id: S-004
   engine: spectral
   engine_rule: camara-language-avoid-telco
+  short_title: "Avoid telco-specific terminology"
 
 - id: S-005
   engine: spectral
   engine_rule: camara-oas-version
+  short_title: "OpenAPI version must be 3.0.3"
 
 - id: S-006
   engine: spectral
   engine_rule: camara-operation-summary
+  short_title: "Operation must have a summary"
 
 - id: S-007
   engine: spectral
   engine_rule: camara-operationid-casing-convention
+  short_title: "operationId must be camelCase"
 
 - id: S-008
   engine: spectral
   engine_rule: camara-parameter-casing-convention
+  short_title: "Path segments must be kebab-case"
 
 - id: S-009
   engine: spectral
   engine_rule: camara-parameters-descriptions
+  short_title: "Parameter must have a description"
 
 - id: S-010
   engine: spectral
   engine_rule: camara-path-param-id
+  short_title: "Use resource_id, not id, in path params"
 
 - id: S-011
   engine: spectral
   engine_rule: camara-properties-descriptions
+  short_title: "Schema property must have a description"
 
 - id: S-012
   engine: spectral
   engine_rule: camara-reserved-words
+  short_title: "Reserved word used in identifier"
 
 - id: S-013
   engine: spectral
   engine_rule: camara-response-descriptions
+  short_title: "Response must have a description"
 
 - id: S-014
   engine: spectral
   engine_rule: camara-routes-description
+  short_title: "Operation must have a description"
 
 - id: S-015
   engine: spectral
   engine_rule: camara-schema-casing-convention
+  short_title: "Schema name must be PascalCase"
 
 - id: S-016
   engine: spectral
   engine_rule: camara-schema-type-check
+  short_title: "Schema must declare a type or combiner"
 
 - id: S-017
   engine: spectral
   engine_rule: camara-security-no-secrets-in-path-or-query-parameters
+  short_title: "Sensitive data (e.g. MSISDN) in path/query"
 
 # ===== Phase 2a gap rules (S-018+) =====
 
 - id: S-018
   engine: spectral
   engine_rule: camara-license-name
+  short_title: "License name must be 'Apache 2.0'"
 
 - id: S-019
   engine: spectral
   engine_rule: camara-license-url-value
+  short_title: "License URL must be the Apache 2.0 URL"
 
 - id: S-020
   engine: spectral
   engine_rule: camara-no-contact
+  short_title: "info.contact must not be present"
 
 - id: S-021
   engine: spectral
   engine_rule: camara-tag-name-title-case
+  short_title: "Tag name must be Title Case"
 
 - id: S-022
   engine: spectral
   engine_rule: camara-api-root-default
+  short_title: "apiRoot default should be http://localhost:9091"
 
 - id: S-023
   engine: spectral
   engine_rule: camara-api-root-description
+  short_title: "apiRoot description should match standard text"
 
 - id: S-024
   engine: spectral
   engine_rule: camara-response-403
+  short_title: "Operation must document a 403 response"
   hint: "All operations must document a 403 Forbidden response (CAMARA Design Guide section 3.2)."
 
 - id: S-025
   engine: spectral
   engine_rule: camara-error-code-not-numeric
+  short_title: "Error code must not be numeric"
 
 - id: S-026
   engine: spectral
   engine_rule: camara-error-code-screaming-snake-case
+  short_title: "Error code must be SCREAMING_SNAKE_CASE"
   applicability:
     commonalities_release: ">=r4.0"
 
 - id: S-027
   engine: spectral
   engine_rule: camara-error-code-api-specific-format
+  short_title: "Prefixed error code must be API_NAME.CODE"
 
 - id: S-028
   engine: spectral
   engine_rule: camara-datetime-rfc3339-description
+  short_title: "date-time field must mention RFC 3339"
 
 - id: S-029
   engine: spectral
   engine_rule: camara-duration-rfc3339-description
+  short_title: "duration field must mention RFC 3339"
 
 - id: S-030
   engine: spectral
   engine_rule: camara-required-properties-exist
+  short_title: "Required property not defined in properties"
 
 - id: S-031
   engine: spectral
   engine_rule: camara-array-items-description
+  short_title: "Array items must have a description"
   applicability:
     commonalities_release: ">=r4.0"
 
 - id: S-032
   engine: spectral
   engine_rule: camara-cloudevent-specversion
+  short_title: "CloudEvent specversion must be '1.0'"
   applicability:
     api_pattern: [implicit-subscription, explicit-subscription]
 
 - id: S-033
   engine: spectral
   engine_rule: camara-subscription-protocol-http
+  short_title: "Subscription Protocol must be HTTP"
   applicability:
     api_pattern: [implicit-subscription, explicit-subscription]
 
 - id: S-034
   engine: spectral
   engine_rule: camara-subscription-sink-https
+  short_title: "Subscription sink must enforce HTTPS"
   applicability:
     api_pattern: [implicit-subscription, explicit-subscription]
 
 - id: S-035
   engine: spectral
   engine_rule: camara-notification-content-type
+  short_title: "Notification must use application/cloudevents+json"
   applicability:
     api_pattern: [implicit-subscription, explicit-subscription]
 
@@ -166,50 +201,62 @@
 - id: S-200
   engine: spectral
   engine_rule: duplicated-entry-in-enum
+  short_title: "Duplicate value in enum"
 
 - id: S-201
   engine: spectral
   engine_rule: info-description
+  short_title: "info.description must be present"
 
 - id: S-202
   engine: spectral
   engine_rule: info-license
+  short_title: "info.license must be present"
 
 - id: S-203
   engine: spectral
   engine_rule: license-url
+  short_title: "info.license.url must be present"
 
 - id: S-204
   engine: spectral
   engine_rule: no-$ref-siblings
+  short_title: "$ref must not have sibling fields"
 
 - id: S-205
   engine: spectral
   engine_rule: no-eval-in-markdown
+  short_title: "Markdown must not contain eval()"
 
 - id: S-206
   engine: spectral
   engine_rule: no-script-tags-in-markdown
+  short_title: "Markdown must not contain <script>"
 
 - id: S-207
   engine: spectral
   engine_rule: oas3-api-servers
+  short_title: "servers array must be present"
 
 - id: S-208
   engine: spectral
   engine_rule: oas3-examples-value-or-externalValue
+  short_title: "Example must have value or externalValue"
 
 - id: S-209
   engine: spectral
   engine_rule: oas3-schema
+  short_title: "OpenAPI document fails OAS 3.x schema"
 
 - id: S-210
   engine: spectral
   engine_rule: oas3-server-trailing-slash
+  short_title: "Server URL must not end with /"
 
 - id: S-211
   engine: spectral
   engine_rule: oas3-unused-component
+  short_title: "Component may be unused"
   hint: "Spectral does not follow discriminator mappings — verify the schema is truly unused."
   conditional_level:
     default: hint
@@ -217,134 +264,165 @@
 - id: S-212
   engine: spectral
   engine_rule: oas3-valid-media-example
+  short_title: "Media example does not match schema"
 
 - id: S-213
   engine: spectral
   engine_rule: oas3-valid-schema-example
+  short_title: "Schema example does not match schema"
 
 - id: S-214
   engine: spectral
   engine_rule: openapi-tags-uniqueness
+  short_title: "Duplicate tag name"
 
 - id: S-215
   engine: spectral
   engine_rule: operation-description
+  short_title: "Operation must have a description"
 
 - id: S-216
   engine: spectral
   engine_rule: operation-operationId
+  short_title: "Operation must have an operationId"
 
 - id: S-217
   engine: spectral
   engine_rule: operation-operationId-unique
+  short_title: "Duplicate operationId"
 
 - id: S-218
   engine: spectral
   engine_rule: operation-operationId-valid-in-url
+  short_title: "operationId has URL-unsafe characters"
 
 - id: S-219
   engine: spectral
   engine_rule: operation-parameters
+  short_title: "Duplicate operation parameter"
 
 - id: S-220
   engine: spectral
   engine_rule: operation-singular-tag
+  short_title: "Operation must have exactly one tag"
 
 - id: S-221
   engine: spectral
   engine_rule: operation-success-response
+  short_title: "Operation must define a 2xx response"
 
 - id: S-222
   engine: spectral
   engine_rule: operation-tag-defined
+  short_title: "Operation tag not defined in tags list"
 
 - id: S-223
   engine: spectral
   engine_rule: operation-tags
+  short_title: "Operation must define at least one tag"
 
 - id: S-224
   engine: spectral
   engine_rule: path-declarations-must-exist
+  short_title: "Path parameter declaration is empty"
 
 - id: S-225
   engine: spectral
   engine_rule: path-keys-no-trailing-slash
+  short_title: "Path must not end with /"
 
 - id: S-226
   engine: spectral
   engine_rule: path-not-include-query
+  short_title: "Path must not include query string"
 
 - id: S-227
   engine: spectral
   engine_rule: path-params
+  short_title: "Path parameter mismatch"
 
 - id: S-228
   engine: spectral
   engine_rule: typed-enum
+  short_title: "enum value does not match schema type"
 
 # ===== OWASP API Security Top 10 2023 (S-300+) =====
 
 - id: S-300
   engine: spectral
   engine_rule: "owasp:api1:2023-no-numeric-ids"
+  short_title: "Use non-numeric resource IDs"
   hint: "Use non-numeric (e.g. string) resource identifiers to prevent enumeration attacks."
 
 - id: S-301
   engine: spectral
   engine_rule: "owasp:api2:2023-no-credentials-in-url"
+  short_title: "Credentials must not appear in URL"
 
 - id: S-302
   engine: spectral
   engine_rule: "owasp:api2:2023-short-lived-access-tokens"
+  short_title: "Access tokens must be short-lived"
 
 - id: S-303
   engine: spectral
   engine_rule: "owasp:api2:2023-write-restricted"
+  short_title: "Write operation must be security-restricted"
 
 - id: S-304
   engine: spectral
   engine_rule: "owasp:api5:2023-admin-security-unique"
+  short_title: "Admin ops must use a distinct security scheme"
 
 - id: S-305
   engine: spectral
   engine_rule: "owasp:api8:2023-no-scheme-http"
+  short_title: "HTTP scheme not allowed"
 
 - id: S-306
   engine: spectral
   engine_rule: "owasp:api8:2023-no-server-http"
+  short_title: "Server URL must not use http://"
 
 - id: S-307
   engine: spectral
   engine_rule: "owasp:api8:2023-define-error-responses-401"
+  short_title: "Operation must document a 401 response"
   hint: "All secured operations must document a 401 Unauthorized response (CAMARA Design Guide section 3.2)."
 
 - id: S-308
   engine: spectral
   engine_rule: "owasp:api2:2023-read-restricted"
+  short_title: "Read operation must be security-restricted"
 
 - id: S-309
   engine: spectral
   engine_rule: "owasp:api4:2023-array-limit"
+  short_title: "Array must declare maxItems"
   hint: "Add maxItems to constrain array size (CAMARA Design Guide section 2.2)."
 
 - id: S-310
   engine: spectral
   engine_rule: "owasp:api4:2023-integer-format"
+  short_title: "Integer must declare int32 or int64 format"
   hint: "Add format: int32 or int64 to integer properties (CAMARA Design Guide section 2.2)."
 
 - id: S-311
   engine: spectral
   engine_rule: "owasp:api4:2023-integer-limit-legacy"
+  short_title: "Integer must declare minimum and maximum"
   hint: "Add minimum and maximum to integer properties (CAMARA Design Guide section 2.2)."
 
 - id: S-312
   engine: spectral
   engine_rule: "owasp:api4:2023-string-limit"
+  short_title: "String must declare maxLength, enum, or const"
   hint: "Add maxLength, enum, or const to string properties (CAMARA Design Guide section 2.2)."
 
 - id: S-313
   engine: spectral
   engine_rule: "owasp:api4:2023-string-restricted"
+  short_title: "String has no format/pattern/enum"
   hint: "Acceptable if free-form field or implementation-dependent — no fix needed."
   conditional_level:
     default: hint
@@ -373,24 +451,30 @@
 - id: S-314
   engine: spectral
   engine_rule: "owasp:api3:2023-constrained-additionalProperties"
+  short_title: "Constrain additionalProperties"
 
 - id: S-315
   engine: spectral
   engine_rule: "owasp:api3:2023-constrained-unevaluatedProperties"
+  short_title: "Constrain unevaluatedProperties"
 
 - id: S-316
   engine: spectral
   engine_rule: "owasp:api3:2023-no-additionalProperties"
+  short_title: "additionalProperties must be false"
 
 - id: S-317
   engine: spectral
   engine_rule: "owasp:api3:2023-no-unevaluatedProperties"
+  short_title: "unevaluatedProperties must be false"
 
 - id: S-318
   engine: spectral
   engine_rule: "owasp:api8:2023-define-error-validation"
+  short_title: "Operation must document a 400/422 response"
   hint: "Document 400 or 422 error responses for input validation (CAMARA Design Guide section 3.2)."
 
 - id: S-319
   engine: spectral
   engine_rule: "owasp:api7:2023-concerning-url-parameter"
+  short_title: "URL parameter name may forward external URL"

--- a/validation/rules/yamllint-rules.yaml
+++ b/validation/rules/yamllint-rules.yaml
@@ -5,51 +5,64 @@
 - id: Y-001
   engine: yamllint
   engine_rule: braces
+  short_title: "Brace spacing error"
 
 - id: Y-002
   engine: yamllint
   engine_rule: brackets
+  short_title: "Bracket spacing error"
 
 - id: Y-003
   engine: yamllint
   engine_rule: colons
+  short_title: "Colon spacing error"
 
 - id: Y-004
   engine: yamllint
   engine_rule: commas
+  short_title: "Comma spacing error"
 
 - id: Y-005
   engine: yamllint
   engine_rule: comments
+  short_title: "Comment formatting error"
 
 - id: Y-006
   engine: yamllint
   engine_rule: comments-indentation
+  short_title: "Comment indentation mismatch"
 
 - id: Y-007
   engine: yamllint
   engine_rule: empty-lines
+  short_title: "Too many consecutive empty lines"
 
 - id: Y-008
   engine: yamllint
   engine_rule: hyphens
+  short_title: "Hyphen spacing error"
 
 - id: Y-009
   engine: yamllint
   engine_rule: indentation
+  short_title: "Inconsistent YAML indentation"
 
 - id: Y-010
   engine: yamllint
   engine_rule: key-duplicates
+  short_title: "Duplicate mapping key"
 
 - id: Y-011
   engine: yamllint
   engine_rule: new-line-at-end-of-file
+  short_title: "Missing newline at end of file"
 
 - id: Y-012
   engine: yamllint
   engine_rule: trailing-spaces
+  short_title: "Trailing whitespace"
 
 - id: Y-013
   engine: yamllint
   engine_rule: truthy
+  short_title: "Use true / false, not yes / no / on / off"

--- a/validation/schemas/rule-metadata-schema.yaml
+++ b/validation/schemas/rule-metadata-schema.yaml
@@ -29,6 +29,18 @@ properties:
       Human-readable kebab-case name.  Optional — defaults to engine_rule
       when omitted.
 
+  short_title:
+    type: string
+    minLength: 1
+    maxLength: 70
+    description: >
+      Short human-readable label used as the annotation title in the
+      GitHub file-diff popover and Check Run annotations.  Soft target
+      50 chars, hard cap 70 to avoid wrapping in the annotation UI.
+      Optional — when omitted, the emitter falls back to the finding
+      message truncated to 69 chars + "…"; the full untruncated message
+      is always preserved in the annotation body.
+
   engine:
     type: string
     enum: [spectral, yamllint, gherkin, python, manual]

--- a/validation/tests/test_output_annotations.py
+++ b/validation/tests/test_output_annotations.py
@@ -28,6 +28,7 @@ def _make_finding(
     engine_rule: str = "some-rule",
     api_name: str | None = "quality-on-demand",
     blocks: bool = False,
+    short_title: str | None = None,
 ) -> dict:
     f: dict = {
         "engine": "spectral",
@@ -45,6 +46,8 @@ def _make_finding(
         f["rule_id"] = rule_id
     if hint is not None:
         f["hint"] = hint
+    if short_title is not None:
+        f["short_title"] = short_title
     return f
 
 
@@ -114,10 +117,38 @@ class TestBuildCommand:
         cmd = _build_command(f)
         assert "col=" not in cmd
 
-    def test_title_uses_message(self):
+    def test_title_falls_back_to_short_message(self):
+        # No short_title — short message passes through unchanged.
         f = _make_finding(rule_id="S-042", message="Bad path")
         cmd = _build_command(f)
         assert "title=Bad path" in cmd
+
+    def test_title_truncates_long_message_when_no_short_title(self):
+        # > 70 chars triggers "…"-terminated truncation in the title.
+        long = "x" * 80
+        f = _make_finding(rule_id="S-042", message=long)
+        cmd = _build_command(f)
+        # Title is 70 chars ending in "…"; full message still appears in body.
+        assert "title=" + "x" * 69 + "…" in cmd
+        assert "[S-042] " + long in cmd
+
+    def test_short_title_used_when_present(self):
+        f = _make_finding(
+            rule_id="S-042",
+            message="Long-form engine message explaining the violation in detail",
+            short_title="Path must be kebab-case",
+        )
+        cmd = _build_command(f)
+        # Title is the short_title, not the message.
+        assert "title=Path must be kebab-case" in cmd
+        # Full untruncated message still appears in the body.
+        assert "[S-042] Long-form engine message explaining" in cmd
+
+    def test_short_title_sanitized(self):
+        # Edge chars (:, %, newline) must be encoded in the title param.
+        f = _make_finding(short_title="key:value %25 with\nnewline")
+        cmd = _build_command(f)
+        assert "key%3Avalue %2525 with newline" in cmd
 
     def test_rule_id_in_message_body(self):
         f = _make_finding(rule_id="S-042", message="Bad path")

--- a/validation/tests/test_output_check_run.py
+++ b/validation/tests/test_output_check_run.py
@@ -48,6 +48,7 @@ def _make_finding(
     rule_id: str | None = None,
     engine_rule: str = "some-rule",
     hint: str | None = None,
+    short_title: str | None = None,
 ) -> dict:
     f: dict = {
         "engine": "spectral",
@@ -63,6 +64,8 @@ def _make_finding(
         f["rule_id"] = rule_id
     if hint is not None:
         f["hint"] = hint
+    if short_title is not None:
+        f["short_title"] = short_title
     return f
 
 
@@ -164,12 +167,39 @@ class TestAnnotationContent:
         assert ann["start_line"] == 42
         assert ann["end_line"] == 42
 
-    def test_title_uses_message(self):
+    def test_title_falls_back_to_short_message(self):
+        # No short_title, message <= 70 chars — passes through unchanged.
         findings = [_make_finding(rule_id="S-042", message="Bad pattern")]
         payload = generate_check_run_payload(
             _make_result(findings), _make_context(),
         )
         assert payload.annotations[0]["title"] == "Bad pattern"
+
+    def test_title_truncates_long_message_when_no_short_title(self):
+        long = "x" * 80
+        findings = [_make_finding(rule_id="S-042", message=long)]
+        payload = generate_check_run_payload(
+            _make_result(findings), _make_context(),
+        )
+        ann = payload.annotations[0]
+        # Title is truncated to 70 chars ending in "…".
+        assert ann["title"] == "x" * 69 + "…"
+        # Full untruncated message stays in the body.
+        assert long in ann["message"]
+
+    def test_short_title_used_when_present(self):
+        findings = [_make_finding(
+            rule_id="S-042",
+            message="Long-form engine explanation with details",
+            short_title="Path must be kebab-case",
+        )]
+        payload = generate_check_run_payload(
+            _make_result(findings), _make_context(),
+        )
+        ann = payload.annotations[0]
+        assert ann["title"] == "Path must be kebab-case"
+        # Full message still appears in the body with rule-ID prefix.
+        assert "[S-042] Long-form engine explanation" in ann["message"]
 
     def test_rule_id_in_message_body(self):
         findings = [_make_finding(rule_id="S-042", message="Bad pattern")]

--- a/validation/tests/test_output_formatting.py
+++ b/validation/tests/test_output_formatting.py
@@ -10,6 +10,7 @@ from validation.output.formatting import (
     deduplicate_findings,
     format_finding_location,
     format_rule_label,
+    resolve_annotation_title,
     sort_findings_by_priority,
 )
 
@@ -308,3 +309,54 @@ class TestFormatFindingLocation:
 
     def test_empty_finding(self):
         assert format_finding_location({}) == ":0"
+
+
+# ---------------------------------------------------------------------------
+# resolve_annotation_title
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAnnotationTitle:
+    def test_uses_short_title_when_present(self):
+        f = {"short_title": "Path must be kebab-case", "message": "Long message"}
+        assert resolve_annotation_title(f) == "Path must be kebab-case"
+
+    def test_falls_back_to_message_when_short_title_missing(self):
+        f = {"message": "Bad pattern"}
+        assert resolve_annotation_title(f) == "Bad pattern"
+
+    def test_falls_back_to_message_when_short_title_empty(self):
+        # Empty string is treated as absent — use message instead.
+        f = {"short_title": "", "message": "Bad pattern"}
+        assert resolve_annotation_title(f) == "Bad pattern"
+
+    def test_message_exactly_at_70_chars_passes_through(self):
+        msg = "x" * 70
+        assert resolve_annotation_title({"message": msg}) == msg
+
+    def test_message_at_71_chars_truncated(self):
+        msg = "x" * 71
+        result = resolve_annotation_title({"message": msg})
+        assert result == "x" * 69 + "…"
+        assert len(result) == 70
+
+    def test_long_message_truncated_with_ellipsis(self):
+        msg = "The quick brown fox jumps over the lazy dog and carries on for quite a while"
+        result = resolve_annotation_title({"message": msg})
+        assert result.endswith("…")
+        # Cap enforces ≤ 70; trailing whitespace is rstripped before the
+        # ellipsis so the title reads cleanly on a word boundary.
+        assert len(result) <= 70
+        # Prefix matches the first up-to-69 chars of the message, rstripped.
+        assert result[:-1] == msg[:69].rstrip()
+
+    def test_empty_message_returns_empty(self):
+        assert resolve_annotation_title({}) == ""
+        assert resolve_annotation_title({"message": ""}) == ""
+
+    def test_short_title_not_length_capped_at_read(self):
+        # The emitter assumes rule-metadata validation already enforced
+        # the 70-char cap.  If somehow a longer short_title slipped
+        # through, it is returned as-is (rather than silently truncated).
+        long_short = "x" * 80
+        assert resolve_annotation_title({"short_title": long_short}) == long_short

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -115,6 +115,7 @@ def _minimal_rule(
     default_level: str = "warn",
     applicability: dict | None = None,
     overrides: list[dict] | None = None,
+    short_title: str | None = None,
 ) -> dict:
     """Build a rule with conditional_level (full behavior)."""
     rule: dict = {
@@ -131,6 +132,8 @@ def _minimal_rule(
         rule["applicability"] = applicability
     if overrides:
         rule["conditional_level"]["overrides"] = overrides
+    if short_title is not None:
+        rule["short_title"] = short_title
     return rule
 
 
@@ -270,6 +273,27 @@ class TestRunPostFilter:
         assert f["hint"] == "Do this instead."
         assert f["level"] == "error"  # remapped from warn to error by metadata
         assert f["blocks"] is True
+        # No short_title in metadata → not added to finding
+        assert "short_title" not in f
+
+    def test_short_title_propagated_to_finding(self, tmp_path: Path):
+        """short_title in metadata is copied onto the enriched finding."""
+        _write_rules(tmp_path, [
+            _minimal_rule(
+                id="S-001",
+                engine_rule="some-rule",
+                short_title="Path must be kebab-case",
+            )
+        ])
+        ctx = _make_context(profile="standard")
+        findings = [_make_finding(message="Original msg")]
+        result = run_post_filter(findings, ctx, tmp_path)
+
+        assert len(result.findings) == 1
+        f = result.findings[0]
+        assert f["short_title"] == "Path must be kebab-case"
+        # Message is untouched — short_title supplements, never replaces.
+        assert f["message"] == "Original msg"
 
     def test_applicability_filters_finding(self, tmp_path: Path):
         """Non-applicable findings are silently removed."""

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -333,3 +333,43 @@ class TestMetadataQuality:
         assert overrides[0].level == "warn"
         assert rule.hint is not None
         assert "Commonalities#608" in rule.hint
+
+
+# ---------------------------------------------------------------------------
+# short_title convention
+# ---------------------------------------------------------------------------
+
+# Maximum annotation title length that fits on one line in the GitHub
+# file-diff popover (matches rule-metadata-schema.yaml short_title.maxLength).
+_SHORT_TITLE_MAX = 70
+
+
+class TestShortTitleConvention:
+    """Verify every rule carries a short_title and the length cap holds.
+
+    short_title is schema-optional to keep rule-adding PRs unblocked, but
+    every rule in the current set must carry one (see the short-title
+    rollout plan in private-dev-docs).  The emitter's truncation fallback
+    keeps annotations usable when a future rule lands without one, but
+    this test flags the omission so reviewers know to add it.
+    """
+
+    def test_all_rules_have_short_title(self, all_rules):
+        missing = [r.id for r in all_rules if r.short_title is None]
+        assert not missing, (
+            f"Rules missing short_title ({len(missing)}): {missing}"
+        )
+
+    def test_short_titles_respect_length_cap(self, all_rules):
+        too_long = [
+            (r.id, len(r.short_title), r.short_title)
+            for r in all_rules
+            if r.short_title is not None and len(r.short_title) > _SHORT_TITLE_MAX
+        ]
+        assert not too_long, (
+            f"short_title exceeds {_SHORT_TITLE_MAX}-char cap: {too_long}"
+        )
+
+    def test_short_titles_are_non_empty(self, all_rules):
+        empty = [r.id for r in all_rules if r.short_title == ""]
+        assert not empty, f"Rules with empty short_title: {empty}"


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Introduces an optional `short_title` field on rule metadata and uses it as
the GitHub annotation title in the file-diff popover and Check Run output.
Today the bold title and the message body show the same sentence, and long
titles wrap awkwardly in the UI.

Scope:

- **Schema**: `short_title` is optional, `maxLength: 70` (soft target 50).
- **Loader**: `RuleMetadata` dataclass carries an optional `short_title`;
  the YAML parser reads it alongside `name`, `hint`, `message_override`.
- **Post-filter**: `_enrich_finding` copies `short_title` onto the finding
  dict when the rule metadata provides one.
- **Emitters**: new `resolve_annotation_title()` helper in
  `output/formatting.py` returns `short_title` when present, otherwise the
  finding `message` truncated to ≤ 69 chars + `…` on a word boundary.
  `annotations.py` (workflow-command path) and `check_run.py` (Checks API
  path) both use it. The full untruncated message still appears in the
  annotation body with the `[rule-id]` prefix and optional hint.
- **Rules**: all 147 currently defined rules populated — 25 Python, 35
  Spectral CAMARA custom, 29 Spectral built-in OAS, 20 Spectral OWASP, 25
  gherkin-lint, 13 yamllint. Longest is 52 characters.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

- `short_title` is schema-optional so future rule-adding PRs aren't blocked
  on picking a title. A coverage test in `test_rule_metadata_integrity.py`
  ensures every currently defined rule has one, and the emitter's
  truncation fallback keeps annotations usable if a future rule lands
  without one.
- 1633 tests pass locally. 14 new tests added: 8 for
  `resolve_annotation_title`, 3 each for the annotations / check_run
  emitters, 1 for post-filter propagation, 3 for the coverage / length
  convention on the rule set.

#### Changelog input

```
release-note
Added short_title field to rule metadata; annotation titles now show a short label instead of the full finding message.
```

#### Additional documentation

This section can be blank.

```
docs
```