### PR TITLE
Pin 7 rules via regression/r4.2-broken-spec-subscriptions

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 76
+  total_tested: 83
   by_engine:
     spectral: 84
     gherkin: 25
@@ -311,6 +311,9 @@ tested_rules:
   P-004: [regression/r4.1-broken-spec-test-files]
   P-005: [regression/r4.1-broken-spec-test-files]
   P-006: [regression/r4.1-main-baseline]
+  P-015: [regression/r4.2-broken-spec-subscriptions]
+  P-016: [regression/r4.2-broken-spec-subscriptions]
+  P-020: [regression/r4.2-broken-spec-subscriptions]
   S-002: [regression/r4.1-broken-spec-routing]
   S-003: [regression/r4.1-broken-spec-routing]
   S-005: [regression/r4.1-broken-spec-yaml-fundamentals]
@@ -337,6 +340,10 @@ tested_rules:
   S-029: [regression/r4.1-broken-spec-descriptions]
   S-030: [regression/r4.1-broken-spec-schema-constraints]
   S-031: [regression/r4.1-broken-spec-descriptions]
+  S-032: [regression/r4.2-broken-spec-subscriptions]
+  S-033: [regression/r4.2-broken-spec-subscriptions]
+  S-034: [regression/r4.2-broken-spec-subscriptions]
+  S-035: [regression/r4.2-broken-spec-subscriptions]
   S-201: [regression/r4.1-broken-spec-api-metadata]
   S-210: [regression/r4.1-broken-spec-api-metadata]
   S-211: [regression/r4.1-main-baseline]


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Add `P-015`, `P-016`, `P-020`, `S-032`, `S-033`, `S-034`, `S-035` to
`tested_rules` in `rule-inventory.yaml` and update `total_tested` from
76 to 83.

These 7 subscription/CloudEvent rules are now pinned by the new
`regression/r4.2-broken-spec-subscriptions` branch on
`camaraproject/ReleaseTest`. The branch introduces 6 surgical edits to
`sample-service-subscriptions.yaml` covering notification content type,
sink HTTPS pattern, CloudEvent specversion, subscription protocol,
event type format, sinkCredential in responses, and inline CloudEvent
detection. Two of the rules (`P-015`, `P-020`) are r4.2-gated and
became active with Commonalities r4.2 (tagged 2026-04-24).

This is the first regression branch in the **r4.2 line**. The seven
existing `regression/r4.1-broken-spec-*` branches stay pinned to r4.1
and will migrate to r4.2 one-by-one in future sessions.

`P-014` (subscription filename) is intentionally **not** included on
this branch; triggering it requires a release-plan.yaml `api_name`
change plus a spec-file rename, which conflicts with the file's natural
identity as the explicit-subscription template. Coverage deferred to a
future regression branch or unit test.

Verified end-to-end: validation-regression workflow run
[24925218085](https://github.com/camaraproject/tooling/actions/runs/24925218085)
reports `PASS: 9/9 branches` (8 broken-spec branches + baseline).

#### Which issue(s) this PR fixes:

Part of https://github.com/camaraproject/ReleaseManagement/issues/484

#### Special notes for reviewers:

The `r4.2-broken-spec-subscriptions` branch was created from the
post-r4.2 `main` of ReleaseTest after the common-sync from
[ReleaseTest#121](https://github.com/camaraproject/ReleaseTest/pull/121).
Naming convention: the `r4.x` prefix tracks the branch's
`commonalities_release`, not a fixed `r4.1` value as on existing branches.

#### Changelog input

```
release-note
NONE
```

#### Additional documentation

```
docs
NONE
```