### PR TITLE
chore: enable npm Dependabot for validation/ on validation-framework

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,17 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 5
+
+  # npm on validation-framework (validation/) - until it merges into main
+  - package-ecosystem: "npm"
+    directory: "/validation"
+    target-branch: "validation-framework"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Adds a third `dependabot.yml` entry covering the npm dependencies in
`validation/package.json` (Redocly CLI, Spectral, gherkin-lint) so they
receive weekly update PRs alongside the existing GitHub Actions tracking
on the `validation-framework` branch.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

The new `javascript` label has been created in this repository so that
Dependabot can apply it (otherwise it would be silently dropped).

Once `validation-framework` merges into `main`, both target-branch
entries (the existing `github-actions` one and this new `npm` one)
should be removed and replaced with main-targeted equivalents.

#### Changelog input

```
 release-note

```

#### Additional documentation

This section can be blank.

```
docs

```