### PR TITLE
Fix four release-plan validation rule false positives surfaced in E2E

### DIFF
--- a/validation/context/release_plan_parser.py
+++ b/validation/context/release_plan_parser.py
@@ -12,6 +12,7 @@ Design doc references:
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Tuple
@@ -20,6 +21,31 @@ import yaml
 from jsonschema import Draft7Validator
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tag-format validation
+# ---------------------------------------------------------------------------
+
+# CAMARA release tag format: r<major>.<minor>, both positive integers.
+# Excludes r0.x and components with leading zeros.
+_VALID_RELEASE_TAG_RE = re.compile(r"^r[1-9]\d*\.[1-9]\d*$")
+
+
+def is_valid_release_tag(tag: str) -> bool:
+    """Check whether a string is a valid CAMARA release tag.
+
+    Valid format: ``r<major>.<minor>`` with positive integer components
+    (e.g. ``r1.1``, ``r4.2``, ``r10.20``). Excludes ``r0.x`` and tags
+    with leading-zero components.
+
+    Used as a precheck for dependency tags (commonalities_release,
+    icm_release) before lookup/existence checks — distinguishes
+    "tag is malformed" from "tag does not exist".
+    """
+    if not tag:
+        return False
+    return bool(_VALID_RELEASE_TAG_RE.fullmatch(tag))
 
 # ---------------------------------------------------------------------------
 # Dataclasses

--- a/validation/engines/python_checks/common_cache_checks.py
+++ b/validation/engines/python_checks/common_cache_checks.py
@@ -27,11 +27,20 @@ def check_common_cache_sync(
 
     Repo-level check — runs once, not per-API.
 
+    Skipped when ``release-plan.yaml`` is absent at the repo root
+    (release-review/snapshot branches post-bundling per DEC-021):
+    ``code/common/`` is intentionally absent in the same context, so
+    there is nothing to verify. ``commonalities_release`` may still be
+    populated from the release-metadata.yaml fallback in those cases.
+
     Builds the expected-releases dict from *context* and delegates to
     :func:`~tooling_lib.cache_sync.check_sync_status`.  Returns an
     empty list when no expected releases can be determined (e.g. no
     ``release-plan.yaml``).
     """
+    if not (repo_path / "release-plan.yaml").is_file():
+        return []
+
     expected = _build_expected_releases(context)
     if not expected:
         return []

--- a/validation/engines/python_checks/release_plan_checks.py
+++ b/validation/engines/python_checks/release_plan_checks.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from validation.context import ValidationContext
+from validation.context.release_plan_parser import is_valid_release_tag
 
 from ._types import load_yaml_safe, make_finding
 
@@ -444,6 +445,27 @@ def check_declared_dependency_tags_exist(
         if not declared_tag:
             # Declaration advanced to null/removed — not P-023's concern
             # (schema or P-009 semantics handle this).
+            continue
+
+        if not is_valid_release_tag(str(declared_tag)):
+            # Format-invalid tags (e.g. "r0.0", "r4.x") would otherwise
+            # surface as the misleading "tag does not exist" message
+            # below. Emit a dedicated format error and skip the
+            # existence lookup.
+            findings.append(
+                make_finding(
+                    engine_rule="check-declared-dependency-tags-exist",
+                    level="error",
+                    message=(
+                        f"Declared {display_name} tag '{declared_tag}' "
+                        f"is not a valid CAMARA release tag format. "
+                        f"Expected r<major>.<minor> with positive "
+                        f"integer components (e.g. r4.2)."
+                    ),
+                    path=_RELEASE_PLAN_PATH,
+                    line=1,
+                )
+            )
             continue
 
         exists = getattr(context, exists_attr, None)

--- a/validation/engines/python_checks/version_checks.py
+++ b/validation/engines/python_checks/version_checks.py
@@ -102,8 +102,9 @@ def check_info_version_format(
 ) -> List[dict]:
     """Validate info.version format based on branch type.
 
-    On main: must be ``"wip"``.
-    On release/maintenance: must be a valid semantic version (not wip).
+    On main and maintenance: must be ``"wip"`` (both are source
+    branches; version pinning happens at snapshot time via T2b).
+    On release: must be a valid semantic version (not wip).
     On feature branches: no constraint (skip).
     """
     api = context.apis[0]
@@ -129,22 +130,23 @@ def check_info_version_format(
 
     info_version = str(info_version).strip()
 
-    if context.branch_type == "main":
+    if context.branch_type in ("main", "maintenance"):
         if info_version != "wip":
             return [
                 make_finding(
                     engine_rule="check-info-version-format",
                     level="error",
                     message=(
-                        f"info.version must be 'wip' on main branch, "
-                        f"found '{info_version}'"
+                        f"info.version must be 'wip' on "
+                        f"{context.branch_type} branch, found "
+                        f"'{info_version}'"
                     ),
                     path=api.spec_file,
                     line=1,
                     api_name=api.api_name,
                 )
             ]
-    elif context.branch_type in ("release", "maintenance"):
+    elif context.branch_type == "release":
         if info_version == "wip":
             return [
                 make_finding(

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -14,12 +14,23 @@
     default: error
 
 # P-002: check-filename-matches-api-name
+# Draft entries are intentionally allowed to have no spec file yet
+# (placeholder for upcoming work). Downgrade to hint for draft so the
+# missing file still surfaces in the codeowner annotation list, but
+# stays an error for alpha/rc/public where it gates release advancement.
 - id: P-002
   engine: python
   engine_rule: check-filename-matches-api-name
   short_title: "API definition file must match release-plan api_name"
   conditional_level:
     default: error
+    overrides:
+      - condition:
+          target_api_status: [draft]
+        level: hint
+  hint: >-
+    Spec file not yet present. For draft entries this is acceptable;
+    add the spec file before advancing target_api_status to alpha.
 
 # P-003: check-info-version-format
 - id: P-003

--- a/validation/tests/test_python_checks_common_cache.py
+++ b/validation/tests/test_python_checks_common_cache.py
@@ -71,6 +71,17 @@ def _write_common_file(tmp_path: Path, filename: str, content: str) -> str:
     return _blob_sha(data)
 
 
+def _write_release_plan(tmp_path: Path) -> None:
+    """Stub release-plan.yaml at repo root.
+
+    P-021 short-circuits when release-plan.yaml is absent (DEC-021
+    bundling: code/common/ and release-plan.yaml are sibling state).
+    Tests exercising the sync logic need a release-plan.yaml present;
+    the file's content is irrelevant — only its existence is checked.
+    """
+    (tmp_path / "release-plan.yaml").write_text("apis: []\n", encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Tests — context-to-expected mapping
 # ---------------------------------------------------------------------------
@@ -79,11 +90,13 @@ def _write_common_file(tmp_path: Path, filename: str, content: str) -> str:
 class TestContextMapping:
 
     def test_no_commonalities_release_returns_empty(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         ctx = _make_context(commonalities_release=None)
         assert check_common_cache_sync(tmp_path, ctx) == []
 
     def test_commonalities_release_populates_expected(self, tmp_path: Path):
         """When commonalities_release is set, the check runs."""
+        _write_release_plan(tmp_path)
         ctx = _make_context(commonalities_release="r4.2")
         # No code/common/ dir → should produce a finding.
         findings = check_common_cache_sync(tmp_path, ctx)
@@ -99,6 +112,7 @@ class TestContextMapping:
 class TestFindingsConversion:
 
     def test_no_common_dir(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         ctx = _make_context(commonalities_release="r4.2")
         findings = check_common_cache_sync(tmp_path, ctx)
         assert len(findings) == 1
@@ -109,6 +123,7 @@ class TestFindingsConversion:
         assert f["path"] == "code/common"
 
     def test_no_manifest(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         (tmp_path / "code" / "common").mkdir(parents=True)
         ctx = _make_context(commonalities_release="r4.2")
         findings = check_common_cache_sync(tmp_path, ctx)
@@ -117,6 +132,7 @@ class TestFindingsConversion:
         assert findings[0]["path"] == "code/common/.sync-manifest.yaml"
 
     def test_all_in_sync(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "ok")
         _write_manifest(
             tmp_path,
@@ -132,6 +148,7 @@ class TestFindingsConversion:
         assert check_common_cache_sync(tmp_path, ctx) == []
 
     def test_tag_mismatch_finding(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         sha = _write_common_file(tmp_path, "CAMARA_common.yaml", "data")
         _write_manifest(
             tmp_path,
@@ -150,6 +167,7 @@ class TestFindingsConversion:
         assert "r4.1" in findings[0]["message"]
 
     def test_missing_file_finding(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         (tmp_path / "code" / "common").mkdir(parents=True, exist_ok=True)
         _write_manifest(
             tmp_path,
@@ -168,6 +186,7 @@ class TestFindingsConversion:
         assert findings[0]["path"] == "code/common/CAMARA_common.yaml"
 
     def test_modified_file_finding(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         original_sha = _blob_sha(b"original")
         _write_common_file(tmp_path, "CAMARA_common.yaml", "modified")
         _write_manifest(
@@ -187,13 +206,50 @@ class TestFindingsConversion:
 
     def test_all_findings_are_warn(self, tmp_path: Path):
         """Every finding from P-021 is 'warn' (post-filter handles escalation)."""
+        _write_release_plan(tmp_path)
         ctx = _make_context(commonalities_release="r4.2")
         findings = check_common_cache_sync(tmp_path, ctx)
         assert all(f["level"] == "warn" for f in findings)
 
     def test_all_findings_have_engine_rule(self, tmp_path: Path):
+        _write_release_plan(tmp_path)
         ctx = _make_context(commonalities_release="r4.2")
         findings = check_common_cache_sync(tmp_path, ctx)
         assert all(
             f["engine_rule"] == "check-common-cache-sync" for f in findings
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests — release-plan.yaml presence gate
+# ---------------------------------------------------------------------------
+
+
+class TestReleasePlanPresenceGate:
+    """P-021 short-circuits when release-plan.yaml is absent.
+
+    Covers the release-review/snapshot-branch context: bundling
+    (DEC-021) removes both release-plan.yaml and code/common/, but
+    commonalities_release remains populated via the
+    release-metadata.yaml fallback. The check has nothing meaningful
+    to verify in that state.
+    """
+
+    def test_skipped_when_release_plan_absent_no_common_dir(
+        self, tmp_path: Path
+    ):
+        # commonalities_release set (as if from release-metadata fallback);
+        # no release-plan.yaml; no code/common/. Pre-fix this would emit
+        # the misleading "directory missing" warn.
+        ctx = _make_context(commonalities_release="r4.2")
+        assert check_common_cache_sync(tmp_path, ctx) == []
+
+    def test_skipped_when_release_plan_absent_with_common_dir(
+        self, tmp_path: Path
+    ):
+        # Even with code/common/ present but no release-plan.yaml, the
+        # check is skipped — branch state is what matters, not file
+        # combinations.
+        (tmp_path / "code" / "common").mkdir(parents=True)
+        ctx = _make_context(commonalities_release="r4.2")
+        assert check_common_cache_sync(tmp_path, ctx) == []

--- a/validation/tests/test_python_checks_release_plan.py
+++ b/validation/tests/test_python_checks_release_plan.py
@@ -540,3 +540,49 @@ class TestCheckDeclaredDependencyTagsExist:
         findings = check_declared_dependency_tags_exist(tmp_path, context)
         assert len(findings) == 1
         assert "icm_release" in findings[0]["message"]
+
+    def test_commonalities_invalid_format_emits_format_error(
+        self, tmp_path: Path
+    ):
+        """Malformed tag emits a format error before the existence lookup.
+
+        Pre-fix this surfaced as the misleading "tag does not exist"
+        even though the tag was rejected at the workflow layer for
+        format reasons. The format precheck short-circuits the lookup.
+        """
+        _write_release_plan_with_dependencies(tmp_path, commonalities="r0.0")
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            # Lookup result intentionally non-False to prove the format
+            # error fires regardless of what the workflow layer returned.
+            commonalities_tag_exists=True,
+        )
+        findings = check_declared_dependency_tags_exist(tmp_path, context)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert "r0.0" in findings[0]["message"]
+        assert "not a valid CAMARA release tag format" in findings[0]["message"]
+        assert "does not exist" not in findings[0]["message"]
+
+    def test_icm_invalid_format_emits_format_error(self, tmp_path: Path):
+        _write_release_plan_with_dependencies(tmp_path, icm="r4.x")
+        context = _context_with_dependency_changes(
+            icm_release_changed=True,
+            icm_tag_exists=None,
+        )
+        findings = check_declared_dependency_tags_exist(tmp_path, context)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert "r4.x" in findings[0]["message"]
+        assert "not a valid CAMARA release tag format" in findings[0]["message"]
+
+    def test_valid_tag_passes_precheck(self, tmp_path: Path):
+        """Valid tag falls through to existence handling (regression
+        check: precheck does not eat valid tags)."""
+        _write_release_plan_with_dependencies(tmp_path, commonalities="r4.2")
+        context = _context_with_dependency_changes(
+            commonalities_release_changed=True,
+            commonalities_tag_exists=True,
+        )
+        # Tag exists → no finding (existence handling reached normally).
+        assert check_declared_dependency_tags_exist(tmp_path, context) == []

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -154,11 +154,23 @@ class TestCheckInfoVersionFormat:
         assert len(findings) == 1
         assert "not a valid semantic version" in findings[0]["message"]
 
-    def test_wip_on_maintenance_error(self, tmp_path: Path):
+    def test_wip_on_maintenance_ok(self, tmp_path: Path):
+        """Maintenance is a source branch like main; wip is required."""
         _write_spec(tmp_path, "qod", "wip")
+        ctx = _make_context("qod", branch_type="maintenance")
+        assert check_info_version_format(tmp_path, ctx) == []
+
+    def test_semver_on_maintenance_error(self, tmp_path: Path):
+        """Pinned versions on maintenance fail like they do on main —
+        version pinning happens at snapshot via T2b, not on the source
+        branch itself."""
+        _write_spec(tmp_path, "qod", "1.2.3")
         ctx = _make_context("qod", branch_type="maintenance")
         findings = check_info_version_format(tmp_path, ctx)
         assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert "wip" in findings[0]["message"]
+        assert "maintenance" in findings[0]["message"]
 
     def test_feature_branch_no_constraint(self, tmp_path: Path):
         _write_spec(tmp_path, "qod", "anything-goes")

--- a/validation/tests/test_release_plan_parser.py
+++ b/validation/tests/test_release_plan_parser.py
@@ -7,6 +7,7 @@ import yaml
 
 from validation.context.release_plan_parser import (
     ReleasePlanData,
+    is_valid_release_tag,
     load_release_plan,
     parse_release_plan,
 )
@@ -140,3 +141,41 @@ class TestLoadReleasePlan:
         plan_path.write_text("", encoding="utf-8")
         result = load_release_plan(plan_path, schema_path)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_valid_release_tag
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidReleaseTag:
+    """CAMARA release-tag format precheck used by P-023."""
+
+    @pytest.mark.parametrize(
+        "tag",
+        ["r1.1", "r1.2", "r4.2", "r10.20", "r99.99"],
+    )
+    def test_valid_tags(self, tag: str):
+        assert is_valid_release_tag(tag) is True
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "r0.0",  # zero major
+            "r0.1",  # zero major
+            "r1.0",  # zero minor (not used in CAMARA history)
+            "r4.x",  # non-numeric minor
+            "r4",  # missing minor
+            "4.2",  # missing leading r
+            "R4.2",  # uppercase R
+            "r04.2",  # leading-zero major
+            "r4.02",  # leading-zero minor
+            "r4.2-rc.1",  # extra suffix
+            "r4.2 (1.2.0-rc.1)",  # enriched format — not a valid raw tag
+            "",  # empty
+            " r4.2",  # leading whitespace
+            "r4.2 ",  # trailing whitespace
+        ],
+    )
+    def test_invalid_tags(self, tag: str):
+        assert is_valid_release_tag(tag) is False

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -306,14 +306,32 @@ class TestMetadataQuality:
         """
         with_hints = [r.id for r in all_rules if r.hint is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 15, (
-            f"Expected 15 explicit hints (update test if adding hints): "
+        assert len(with_hints) == 16, (
+            f"Expected 16 explicit hints (update test if adding hints): "
             f"{with_hints}"
         )
         assert len(with_overrides) == 0, (
             f"Expected 0 message overrides (update test if adding overrides): "
             f"{with_overrides}"
         )
+
+    def test_p002_conditional_on_target_api_status(self, rule_index):
+        """P-002 stays error by default, downgrades to hint for draft entries.
+
+        Draft entries are intentionally allowed to have no spec file yet
+        (placeholder for upcoming work). Keep error for alpha/rc/public so
+        missing files still gate release advancement.
+        """
+        rule = rule_index[("python", "check-filename-matches-api-name")]
+        assert rule.id == "P-002"
+        assert rule.conditional_level is not None
+        assert rule.conditional_level.default == "error"
+        overrides = rule.conditional_level.overrides
+        assert len(overrides) == 1
+        assert overrides[0].condition == {"target_api_status": ["draft"]}
+        assert overrides[0].level == "hint"
+        assert rule.hint is not None
+        assert "draft" in rule.hint.lower()
 
     def test_p015_conditional_on_api_pattern(self, rule_index):
         """P-015 stays error on explicit-subscription, warn on implicit.


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes four false-positive findings surfaced on the most recent ReleaseTest end-to-end run, drawn from the validation-framework v1 stabilization backlog. All four are rule-metadata-class changes (rule YAML or Python checker logic, no workflow / runtime path).

- **P-021 (`check-common-cache-sync`)**: skip when `release-plan.yaml` is absent at the repo root. On release-review/snapshot branches `code/common/` is intentionally absent post-bundling, and `release-plan.yaml` is also absent (only `release-metadata.yaml` provides `commonalities_release` via the snapshot fallback). The check has nothing to verify there. Implemented as an in-checker guard, mirroring how P-003 / P-007 make branch-state decisions in Python.

- **P-002 (`check-filename-matches-api-name`)**: downgrade to `hint` for entries with `target_api_status: draft`. Draft entries are intentionally allowed to have no spec file yet (placeholder for upcoming work). Severity stays `error` for alpha/rc/public so missing files still gate release advancement.

- **P-003 (`check-info-version-format`)**: require `wip` on `maintenance/**` branches, treating maintenance as a source branch like `main`. Pinning happens at snapshot time via T2b on `release-snapshot/**`. Previous behavior (require non-`wip` semver on maintenance) was a carry-over from the legacy model. P-007 already groups `main` and `maintenance` correctly in `check_test_file_version` — no change needed there, only confirmed.

- **P-023 (`check-declared-dependency-tags-exist`)**: validate dependency tag format before the existence lookup. A malformed tag like `r0.0` previously surfaced the misleading "tag does not exist" message; the new precheck emits a dedicated format error. Adds a shared `is_valid_release_tag()` helper in `release_plan_parser.py` so the same check can be reused.

#### Which issue(s) this PR fixes:

No specific issue to fix; related to the validation framework v1 umbrella tracking issue [ReleaseManagement#448](https://github.com/camaraproject/ReleaseManagement/issues/448).

#### Special notes for reviewers:

Files touched:
- `validation/rules/python-rules.yaml` — P-002 only
- `validation/engines/python_checks/{common_cache,version,release_plan}_checks.py` — P-021, P-003, P-023
- `validation/context/release_plan_parser.py` — small `is_valid_release_tag` helper added for P-023
- `validation/tests/**` — extended coverage for each fix

All four fixes are rule-metadata scope. The `@v1-rc` tag-move gate's scope exception applies — Validation Regression canary green is sufficient evidence; no full manual E2E required for these changes.

#### Changelog input

```
 release-note

```

#### Additional documentation

This section can be blank.

```
docs

```