### PR TITLE
fix(p021): expand hint to cover manual edits and stale branches

### DIFF
--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -286,8 +286,12 @@
           trigger_types: [release-automation]
         level: error
   hint: >-
-    Merge the auto-created sync PR or trigger the release automation
-    workflow manually (workflow_dispatch) to update code/common/ files.
+    `code/common/` is managed by the sync mechanism. If your PR diff
+    includes manual edits to `code/common/`, revert them. If your branch
+    is missing files that should be present, merge `main` into your
+    branch — it carries the latest synced files; if `main` is also
+    behind, merge the auto-created sync PR or dispatch the release
+    automation workflow.
 
 # P-022: check-release-plan-exclusivity
 # release-plan.yaml changes must be in their own PR — any co-changed


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

The P-021 hint only covered the "out of sync" case (merge the sync PR). It did not address contributors who manually edited `code/common/` in a PR. The rewritten hint covers both paths: revert manual edits, or merge `main` / the sync PR if behind.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Hint text only — no code or rule-applicability change. Surfaced while testing v0/v1 behavior on broken-`$ref` PRs (camaraproject/ReleaseTest#125).