### PR TITLE
feat: seed config/validation-settings.yaml on main (refs #226)

### DIFF
--- a/config/validation-settings.yaml
+++ b/config/validation-settings.yaml
@@ -1,0 +1,28 @@
+# Central CAMARA validation settings.
+#
+# This file is the authoritative runtime configuration for the validation
+# framework. It is read directly from `main` of camaraproject/tooling on every
+# validation workflow run, independent of which tag the caller workflow has
+# pinned. Routine stage flips for individual repositories are PR-merges to this
+# file; no tag-move is required for the validation framework caller workflow.
+#
+# Schema: validation/schemas/validation-settings-schema.yaml
+#
+# Forward-compatibility rule: schema additions are always backward compatible.
+# Older callers reading this file ignore unknown keys; only known fields are
+# enum/type-checked. This makes hotfix-gated fields (added in a hotfix tag and
+# applied to a subset of repositories) safe to introduce without re-cutting any
+# already-deployed tag.
+
+version: 1
+
+defaults:
+  stage: advisory
+  pr_profile: standard
+  release_profile: standard
+
+repositories:
+  ReleaseTest:
+    stage: enabled
+  SimpleEdgeDiscovery:
+    stage: enabled


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds `config/validation-settings.yaml` at the top level of the tooling
repository with the migrated content of today's
`validation/config/validation-config.yaml` (minus `fork_owners`). This is
the first of two PRs implementing the central-validation-settings change
described in #226.

This PR is a no-op for production: no consumer reads the file yet. The
companion PR against `validation-framework` rewires the reusable validation
workflow to read this file from `main` at runtime; that PR is opened
separately and depends on this one having landed.

#### Which issue(s) this PR fixes:

Refs #226

#### Special notes for reviewers:

- Single-file addition. The same content lives on the `validation-framework`
  branch (in the companion PR) as the pinned-ref last-known-good fallback.
- `fork_owners` is intentionally absent; fork-developer runs are handled via
  `workflow_dispatch` / `tooling_ref_override` in the consuming workflow.
- Schema validation against `validation/schemas/validation-settings-schema.yaml`
  ships in the companion PR (the schema lives with the workflow code at the
  pinned ref). A repeating CI job that validates this file on every PR also
  ships in that PR; it activates once that PR merges.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.

```
docs

```