### PR TITLE
fix(create-snapshot): consume redocly from validation/node_modules

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -1113,6 +1113,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           base_branch: main
           github_token: ${{ steps.app-token.outputs.token || github.token }}
+          tooling_path: ${{ github.workspace }}/_tooling
           bot_name: ${{ steps.bot-identity.outputs.bot_name }}
           bot_email: ${{ steps.bot-identity.outputs.bot_email }}
 

--- a/shared-actions/create-snapshot/action.yml
+++ b/shared-actions/create-snapshot/action.yml
@@ -25,6 +25,14 @@ inputs:
   github_token:
     description: 'GitHub token with repo and PR write permissions'
     required: true
+  tooling_path:
+    description: >
+      Absolute path to the tooling checkout (parent of validation/).  Used
+      to locate the Redocly CLI binary in validation/node_modules/.bin so a
+      single `validation/package.json` pin governs both PR-time bundling
+      and snapshot bundling.  Caller must have populated this directory by
+      running shared-actions/run-validation first.
+    required: true
   bot_name:
     description: 'Git committer name for snapshot commits'
     required: false
@@ -72,15 +80,6 @@ runs:
       shell: bash
       run: pip install --quiet pyyaml pystache
 
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: '24'
-
-    - name: Install Redocly CLI
-      shell: bash
-      run: npm install -g @redocly/cli@^1.31.0
-
     - name: Create Snapshot
       id: create
       shell: python
@@ -93,10 +92,16 @@ runs:
         SCRIPTS_PATH: ${{ github.action_path }}/../../release_automation/scripts
         BOT_NAME: ${{ inputs.bot_name }}
         BOT_EMAIL: ${{ inputs.bot_email }}
+        PATH_NODE_MODULES: ${{ inputs.tooling_path }}/validation/node_modules/.bin
       run: |
         import os
         import sys
         import json
+
+        # Make `redocly` resolvable from validation/node_modules/.bin so a
+        # single validation/package.json pin governs both PR-time bundling
+        # and snapshot bundling.
+        os.environ['PATH'] = os.environ['PATH_NODE_MODULES'] + os.pathsep + os.environ['PATH']
 
         # Add scripts path to module search path
         scripts_path = os.path.realpath(os.environ['SCRIPTS_PATH'])


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Eliminates the duplicate Redocly CLI version pin in `shared-actions/create-snapshot/action.yml` so `validation/package.json` is the single source of truth for the Redocly version. Dependabot's npm watcher (added in #223) already covers `validation/package.json`; future Redocly bumps will land via Dependabot without a companion edit — the second pin was missed in the #229 1.x → 2.x bump.

Two changes:

- `shared-actions/create-snapshot/action.yml` adds a required `tooling_path` input and prepends `{tooling_path}/validation/node_modules/.bin` to `PATH` inside the `Create Snapshot` step, so the existing `subprocess.run(["redocly", ...])` in `snapshot_creator.py` resolves to the package.json-pinned binary. The composite action's previous `Setup Node` and `Install Redocly CLI` steps are dropped — Node is already set up by the caller before `run-validation`, and `run-validation`'s `npm ci` populates the binary before `create-snapshot` runs.
- `release-automation-reusable.yml` passes `tooling_path: ${{ github.workspace }}/_tooling` to the composite action.

#### Which issue(s) this PR fixes:

<!-- follow-up to #229; no separate issue -->

Fixes #

#### Special notes for reviewers:

- No external callers of `shared-actions/create-snapshot` exist; sole caller is `release-automation-reusable.yml`.
- Smoke-tested: Redocly 1.34.11 and 2.30.0 produce byte-identical bundles on the three `$ref`-using sample specs in `ReleaseTest`, so eliminating the pin split has no observable output effect. The behavioral path is exercised end-to-end by the Release Automation Regression canary.
- 69/69 unit tests pass in `release_automation/tests/test_snapshot_creator.py`.

#### Changelog input

```
 release-note
 chore: deduplicate Redocly CLI version pin; create-snapshot composite action now consumes the binary populated by run-validation's npm ci
```

#### Additional documentation 

```
 docs
 
```