### PR TITLE
chore: rename Release Automation to CAMARA Release Automation

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -9,7 +9,7 @@
 #
 # Called by: release-automation-caller.yml in API repositories
 
-name: Release Automation
+name: CAMARA Release Automation
 
 on:
   workflow_call:


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Aligns the `release-automation-reusable.yml` workflow display name with two pre-existing CAMARA-prefixed siblings:
- `validation.yml` — `name: CAMARA Validation`
- API repo callers (e.g. ReleaseTest's `release-automation.yml`) — `name: CAMARA Release Automation`

Workflow `name:` is a GitHub Actions UI label only — no behavioral change, no consumer touches.

The two regression canaries (`validation-regression.yml`, `release-automation-regression.yml`) intentionally stay unprefixed; that mirrors the established pattern (internal canaries unprefixed, public-facing workflows CAMARA-prefixed).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

One-line change. No effect on workflow execution.

#### Changelog input

```
 release-note
 chore: rename Release Automation reusable workflow display name to CAMARA Release Automation
```

#### Additional documentation 

```
 docs
 
```