### PR TITLE
Split S-008 into camara-path-casing-convention + new camara-parameter-name-casing-convention (S-036)

### DIFF
--- a/linting/config/.spectral-r3.4.yaml
+++ b/linting/config/.spectral-r3.4.yaml
@@ -264,7 +264,7 @@ rules:
       function: camara-schema-casing-convention
     recommended: true  # Set to true/false to enable/disable this rule
 
-  camara-parameter-casing-convention:
+  camara-path-casing-convention:
     description: Paths should be kebab-case.
     severity: error
     message: "{{property}} is not kebab-case: {{error}}"

--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -279,7 +279,7 @@ rules:
       function: camara-schema-casing-convention
     recommended: true  # Set to true/false to enable/disable this rule
 
-  camara-parameter-casing-convention:
+  camara-path-casing-convention:
     description: Paths should be kebab-case.
     severity: error
     message: "{{property}} is not kebab-case: {{error}}"
@@ -289,6 +289,17 @@ rules:
       functionOptions:
         match: "^\/([a-z0-9]+(-[a-z0-9]+)*)?(\/[a-z0-9]+(-[a-z0-9]+)*|\/{.+})*$"  # doesn't allow /asasd{asdas}sadas pattern or not closed braces
     recommended: true  # Set to true/false to enable/disable this rule
+
+  camara-parameter-name-casing-convention:
+    description: Parameter names (path and query) must be lowerCamelCase.
+    message: "{{property}} is not lowerCamelCase: {{error}}"
+    severity: warn
+    given: $.paths[*][*].parameters[?(@.in != 'header')].name
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z][a-zA-Z0-9]*$"
+    recommended: true
 
   camara-schema-type-check:
     description: >

--- a/linting/config/.spectral.yaml
+++ b/linting/config/.spectral.yaml
@@ -259,7 +259,7 @@ rules:
         type: pascal
     recommended: true  # Set to true/false to enable/disable this rule
 
-  camara-parameter-casing-convention:
+  camara-path-casing-convention:
     description: Paths should be kebab-case.
     severity: error
     message: "{{property}} is not kebab-case: {{error}}"

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -14,13 +14,13 @@ version: 1
 generated: 2026-04-07
 
 summary:
-  total_implemented: 143
+  total_implemented: 144
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 83
+  total_tested: 84
   by_engine:
-    spectral: 84
+    spectral: 85
     gherkin: 25
     python: 21
     yamllint: 13
@@ -344,6 +344,7 @@ tested_rules:
   S-033: [regression/r4.2-broken-spec-subscriptions]
   S-034: [regression/r4.2-broken-spec-subscriptions]
   S-035: [regression/r4.2-broken-spec-subscriptions]
+  S-036: [regression/r4.1-broken-spec-routing]
   S-201: [regression/r4.1-broken-spec-api-metadata]
   S-210: [regression/r4.1-broken-spec-api-metadata]
   S-211: [regression/r4.1-main-baseline]

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -43,7 +43,7 @@
 
 - id: S-008
   engine: spectral
-  engine_rule: camara-parameter-casing-convention
+  engine_rule: camara-path-casing-convention
   short_title: "Path segments must be kebab-case"
 
 - id: S-009
@@ -195,6 +195,11 @@
   short_title: "Notification must use application/cloudevents+json"
   applicability:
     api_pattern: [implicit-subscription, explicit-subscription]
+
+- id: S-036
+  engine: spectral
+  engine_rule: camara-parameter-name-casing-convention
+  short_title: "Parameter names (path/query) must be lowerCamelCase"
 
 # ===== Built-in OAS rules (S-200+) =====
 

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -78,7 +78,7 @@ class TestStructuralIntegrity:
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
         assert counts["python"] == 25
-        assert counts["spectral"] == 84
+        assert counts["spectral"] == 85
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
 

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -31,7 +31,7 @@ from validation.engines.spectral_adapter import (
 
 # A typical Spectral JSON finding (one element of the --format json array).
 SAMPLE_SPECTRAL_FINDING = {
-    "code": "camara-parameter-casing-convention",
+    "code": "camara-path-casing-convention",
     "path": ["paths", "/qualityOnDemand", "post"],
     "message": "qualityOnDemand is not kebab-case",
     "severity": 0,
@@ -213,7 +213,7 @@ class TestNormalizeFinding:
     def test_standard_finding(self):
         finding = normalize_finding(SAMPLE_SPECTRAL_FINDING)
         assert finding["engine"] == "spectral"
-        assert finding["engine_rule"] == "camara-parameter-casing-convention"
+        assert finding["engine_rule"] == "camara-path-casing-convention"
         assert finding["level"] == "error"
         assert finding["message"] == "qualityOnDemand is not kebab-case"
         assert finding["path"] == "code/API_definitions/quality-on-demand.yaml"
@@ -339,7 +339,7 @@ class TestParseSpectralOutput:
         raw = json.dumps([SAMPLE_SPECTRAL_FINDING, SAMPLE_SPECTRAL_WARN])
         findings = parse_spectral_output(raw)
         assert len(findings) == 2
-        assert findings[0]["engine_rule"] == "camara-parameter-casing-convention"
+        assert findings[0]["engine_rule"] == "camara-path-casing-convention"
         assert findings[1]["engine_rule"] == "camara-path-param-id"
 
     def test_empty_array(self):
@@ -461,7 +461,7 @@ class TestRunSpectral:
         )
         assert result.success is True
         assert len(result.findings) == 1
-        assert result.findings[0]["engine_rule"] == "camara-parameter-casing-convention"
+        assert result.findings[0]["engine_rule"] == "camara-path-casing-convention"
 
     @patch("validation.engines.spectral_adapter.subprocess.run")
     def test_exit_2_runtime_error(self, mock_run, tmp_path):

--- a/validation/tests/test_spectral_gap_rules.py
+++ b/validation/tests/test_spectral_gap_rules.py
@@ -248,6 +248,50 @@ class TestGroupA:
         findings = _run_spectral(spec)
         assert "camara-response-403" in _codes(findings)
 
+    def test_parameter_name_lowerCamelCase_passes(self):
+        spec = _VALID_SPEC.replace(
+            "      summary: Get test",
+            "      parameters:\n"
+            "        - name: sessionId\n"
+            "          in: query\n"
+            "          required: false\n"
+            "          schema:\n"
+            "            type: string\n"
+            "      summary: Get test",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-parameter-name-casing-convention" not in _codes(findings)
+
+    def test_parameter_name_non_lowerCamelCase_fails(self):
+        spec = _VALID_SPEC.replace(
+            "      summary: Get test",
+            "      parameters:\n"
+            "        - name: Session_id\n"
+            "          in: query\n"
+            "          required: false\n"
+            "          schema:\n"
+            "            type: string\n"
+            "      summary: Get test",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-parameter-name-casing-convention" in _codes(findings)
+
+    def test_parameter_name_header_excluded(self):
+        # Header parameter names are excluded — HTTP headers are
+        # case-insensitive per RFC; CAMARA documents x-correlator etc.
+        spec = _VALID_SPEC.replace(
+            "      summary: Get test",
+            "      parameters:\n"
+            "        - name: X-Correlator\n"
+            "          in: header\n"
+            "          required: false\n"
+            "          schema:\n"
+            "            type: string\n"
+            "      summary: Get test",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-parameter-name-casing-convention" not in _codes(findings)
+
 
 class TestGroupB:
     """Group B: Error code checks."""


### PR DESCRIPTION
#### What type of PR is this?

correction
enhancement/feature

#### What this PR does / why we need it:

Splits the misnamed Spectral rule `camara-parameter-casing-convention` (S-008) — the body has only ever validated path-key kebab-case, never parameter names. Renames it to `camara-path-casing-convention` and adds sibling `camara-parameter-name-casing-convention` (S-036) covering the Design Guide §5.7.4 lowerCamelCase requirement that was previously uncovered.

#### Which issue(s) this PR fixes:

Fixes #194

#### Special notes for reviewers:

- Rename applied across `.spectral.yaml`, `.spectral-r3.4.yaml`, and `.spectral-r4.yaml`; new rule added to r4 only. Rule body unchanged.
- New rule excludes header parameters (`@.in != 'header'`) — HTTP headers are case-insensitive per RFC.
- Catalog entry uses **S-036** (lowest unused). Counts updated in `rule-inventory.yaml` and `test_rule_metadata_integrity.py`. Three new pytest tests in `test_spectral_gap_rules.py`.
- Rule-metadata scope: canary alone is sufficient for the post-merge `@v1-rc` advance.

#### Changelog input

```
release-note

Renamed Spectral rule `camara-parameter-casing-convention` to `camara-path-casing-convention` to match its actual behavior. Added new Spectral rule `camara-parameter-name-casing-convention` (S-036) enforcing lowerCamelCase on path/query parameter names per Design Guide §5.7.4.
```

#### Additional documentation

This section can be blank.

```
docs

```