### PR TITLE
Fix camara-reserved-words and camara-security-no-secrets-in-path-or-query-parameters: emit findings, tighten regex

### DIFF
--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -116,12 +116,14 @@ rules:
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-security-no-secrets-in-path-or-query-parameters:
-    message: "Sensitive data found in path: {{error}} Consider avoiding the use of sensitive data "
+    message: "{{error}}"
     severity: warn
     description: |
-      This rule checks for sensitive data ('MSISDN' and 'IMSI') in API paths and suggests avoiding their use.
+      Flags 'MSISDN', 'IMSI', and 'phoneNumber' appearing as standalone
+      tokens in path strings or in path/query parameter names.
     given:
       - "$.paths"
+      - "$..parameters[?(@.in != 'header')]"
     then:
       function: camara-security-no-secrets-in-path-or-query-parameters
     recommended: true  # Set to true/false to enable/disable this rule
@@ -149,18 +151,20 @@ rules:
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-reserved-words:
-    message: "Reserved words found {{error}} Consider avoiding the use of reserved word "
+    message: "{{error}}"
     severity: warn
     description: |
-      This rule checks Reserved words must not be used in the following parts of an API specification [Paths, Request Body properties, Component, Operation Id, Security Schema]
+      Reserved words (Java/etc. language keywords used by code-generation
+      tooling) must not appear as standalone tokens in path segments,
+      parameter names, schema/property/component names, security scheme
+      names, or operationId values.
     given:
       - "$.paths"                              # Paths
-      - "$..parameters[*]"                     # Path or Query Parameter Names:
-      - "$..components.schemas.*.properties.*"   # Request and Response body parameter
-      - "$.paths.*."                           # Path and Operation Names:
-      - "$.components.securitySchemes"         # Security Schemes:
-      - "$.components.*.*"                     # Component Names:
-      - "$.paths.*.*.operationId"              # OperationIds:
+      - "$..parameters[*]"                     # Path or Query Parameter Names
+      - "$..components.schemas.*.properties.*" # Request and Response body parameter names
+      - "$.components.securitySchemes"         # Security Schemes
+      - "$.components.*.*"                     # Component Names
+      - "$.paths.*.*.operationId"              # OperationIds
     then:
       function: camara-reserved-words
     recommended: true  # Set to true/false to enable/disable this rule

--- a/linting/config/lint_function/camara-reserved-words.js
+++ b/linting/config/lint_function/camara-reserved-words.js
@@ -1,5 +1,15 @@
 // CAMARA Project - support function for Spectral linter
-// 31.01.2024 - initial version
+// Flags reserved words that conflict with code-generated identifiers
+// (Java/etc. keywords) when they appear as standalone tokens in path
+// segments, parameter names, schema/property/component names, security
+// scheme names, or operationId values.
+//
+// Word-boundary regex excludes hyphen and underscore: reserved-word
+// substrings inside hyphenated path segments (e.g. "public" inside
+// "blockchain-public-addresses") and inside snake_case names do not
+// match — code-gen tools tokenize/camelCase those into valid
+// identifiers. camelCase identifiers (e.g. "getPublic") are also safe
+// because there is no boundary between letters.
 
 const reservedWords = [
   'abstract',
@@ -76,23 +86,85 @@ const reservedWords = [
   'volatile',
   'while'
 ];
-// Reserved word 'enum' and 'default' are removed from above reserved word array as they are common in openAPI keyword
-export default async function lintReservedWords(input) {
-  // Iterate over properties of the input object
-  for (const path in input) {
-    if (typeof path === 'string') {
+// Reserved words 'enum' and 'default' intentionally excluded — common
+// in OpenAPI keywords.
 
-      for (const word of reservedWords) {
-        const regex = new RegExp(`\\b${word}\\b`, 'g');  // Use a regular expression to match 'word' as a standalone word
+const PATTERNS = reservedWords.map((word) => ({
+  word,
+  re: new RegExp(`(?<![A-Za-z0-9_-])${word}(?![A-Za-z0-9_-])`)
+}));
 
-        if (regex.test(path)) {
-          const warningRuleName = 'camara-reserved-words';
-          const description = `Reserved words found in input: Consider avoiding the use of reserved word '${word}'`;
-         // const location = `${path}`;
+// Container path-tail names where the rule should iterate the input
+// object's own keys (each key is a user-controlled name). For other
+// inputs at a non-container path tail, the path tail itself is the
+// user-controlled name.
+const ITERATE_KEYS_CONTAINERS = new Set([
+  'paths',
+  'securitySchemes',
+  'parameters',
+  'schemas',
+  'responses',
+  'requestBodies',
+  'headers',
+  'examples',
+  'links',
+  'callbacks',
+  'pathItems'
+]);
 
-          console.log(`warning  ${warningRuleName}  ${description}  ${path}`);
-        }
-      }
-    }
+function matchedWord(value) {
+  if (typeof value !== 'string') return null;
+  for (const { word, re } of PATTERNS) {
+    if (re.test(value)) return word;
   }
+  return null;
 }
+
+function makeError(path, name, word) {
+  return {
+    message: `Consider avoiding the use of reserved word '${word}' in '${name}'`,
+    path
+  };
+}
+
+export default (input, _options, context) => {
+  const errors = [];
+  const basePath = [...(context.path || [])];
+
+  // 1. Direct string input (e.g. operationId).
+  if (typeof input === 'string') {
+    const word = matchedWord(input);
+    if (word) errors.push(makeError(basePath, input, word));
+    return errors;
+  }
+
+  if (!input || typeof input !== 'object') return errors;
+
+  // 2. Parameter object — check the user-controlled `.name` field.
+  // Skip header parameters (HTTP headers are case-insensitive per RFC).
+  if (typeof input.name === 'string' && input.in !== 'header') {
+    const word = matchedWord(input.name);
+    if (word) errors.push(makeError([...basePath, 'name'], input.name, word));
+    return errors;
+  }
+
+  // 3. Map at a known container path (paths object, securitySchemes,
+  // generic component maps): iterate keys (each is a user-controlled
+  // name).
+  const last = basePath.length ? basePath[basePath.length - 1] : null;
+  if (basePath.length === 0 || ITERATE_KEYS_CONTAINERS.has(last)) {
+    for (const key of Object.keys(input)) {
+      const word = matchedWord(key);
+      if (word) errors.push(makeError([...basePath, key], key, word));
+    }
+    return errors;
+  }
+
+  // 4. Otherwise check the path tail (component name, property name)
+  // unless it is an array index.
+  if (typeof last === 'string' && !/^\d+$/.test(last)) {
+    const word = matchedWord(last);
+    if (word) errors.push(makeError(basePath, last, word));
+  }
+  return errors;
+};

--- a/linting/config/lint_function/camara-security-no-secrets-in-path-or-query-parameters.js
+++ b/linting/config/lint_function/camara-security-no-secrets-in-path-or-query-parameters.js
@@ -1,26 +1,54 @@
 // CAMARA Project - support function for Spectral linter
-// 31.01.2024 - initial version
+// Flags sensitive identifiers (MSISDN, IMSI, phoneNumber) in path
+// strings and in path/query parameter names. Per the rule's own name
+// the wired `given` should cover both paths and parameters; previous
+// implementation logged via console.log and emitted no Spectral
+// findings.
+//
+// Word-boundary regex excludes hyphen and underscore so accidental
+// substring matches inside hyphenated identifiers do not trigger.
 
-const sensitiveData = ['MSISDN','IMSI','phoneNumber'];
+const sensitiveData = ['MSISDN', 'IMSI', 'phoneNumber'];
 
-export default async function (input) {
+const PATTERNS = sensitiveData.map((word) => ({
+  word,
+  re: new RegExp(`(?<![A-Za-z0-9_-])${word}(?![A-Za-z0-9_-])`)
+}));
 
-  // Iterate over properties of the input object
-  for (const path in input) {
+function matchedWord(value) {
+  if (typeof value !== 'string') return null;
+  for (const { word, re } of PATTERNS) {
+    if (re.test(value)) return word;
+  }
+  return null;
+}
 
-    if (typeof path === 'string') {
-      for (const word of sensitiveData ) {
-        const regex = new RegExp(`\\b${word}\\b`, 'g');  // Use a regular expression to match 'word' as a standalone word
+function makeError(path, name, word) {
+  return {
+    message: `Consider avoiding the use of sensitive data '${word}' in '${name}'`,
+    path
+  };
+}
 
-           if (regex.test(path)) {
+export default (input, _options, context) => {
+  const errors = [];
+  const basePath = [...(context.path || [])];
 
-              const warningRuleName = 'camara-security-no-secrets-in-path-or-query-parameters';
-              const description = `sensitiveData  Data found in path: Consider avoiding the use of sensitiveData  data '${word}'`;
-              const location = `paths.${path}`;
-              console.log(`warning  ${warningRuleName}  ${description}  ${location}`);
+  // Parameter object — check user-controlled `.name`. Skip header
+  // parameters (HTTP headers are case-insensitive per RFC).
+  if (input && typeof input === 'object' &&
+      typeof input.name === 'string' && input.in !== 'header') {
+    const word = matchedWord(input.name);
+    if (word) errors.push(makeError([...basePath, 'name'], input.name, word));
+    return errors;
+  }
 
-        }
-      }
+  // Paths object — iterate keys (each is a user-controlled path string).
+  if (input && typeof input === 'object') {
+    for (const key of Object.keys(input)) {
+      const word = matchedWord(key);
+      if (word) errors.push(makeError([...basePath, key], key, word));
     }
   }
-}
+  return errors;
+};

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 83
+  total_tested: 85
   by_engine:
     spectral: 84
     gherkin: 25
@@ -323,9 +323,11 @@ tested_rules:
   S-009: [regression/r4.1-broken-spec-descriptions]
   S-010: [regression/r4.1-broken-spec-routing]
   S-011: [regression/r4.1-broken-spec-descriptions]
+  S-012: [regression/r4.1-broken-spec-schema-constraints]
   S-013: [regression/r4.1-broken-spec-descriptions]
   S-014: [regression/r4.1-broken-spec-descriptions]
   S-016: [regression/r4.1-broken-spec-yaml-fundamentals]
+  S-017: [regression/r4.1-broken-spec-schema-constraints]
   S-018: [regression/r4.1-broken-spec-api-metadata]
   S-019: [regression/r4.1-broken-spec-api-metadata]
   S-020: [regression/r4.1-broken-spec-api-metadata]


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Both custom Spectral functions used `console.log` instead of returning `[{ message, path }]`, so neither rule emitted findings despite being wired with `severity: warn` and `recommended: true`. Rewrites both to follow the `camara-array-items-description.js` contract, tightens the regex to exclude hyphen as a word boundary, and extends S-017's `given` to actually cover parameter names per its own title.

#### Which issue(s) this PR fixes:

Fixes #192

#### Special notes for reviewers:

- Tightened regex `(?<![A-Za-z0-9_-])${word}(?![A-Za-z0-9_-])` eliminates 5 pre-existing false positives across `BlockchainPublicAddress` and `eSimRemoteManagement` (substrings `public` / `list` inside hyphenated path segments). Verified locally; survey across all upstream API repos found no other matches.
- camelCase identifiers are unaffected (no boundary between letters).
- S-017 `given` extended to `$..parameters[?(@.in != 'header')]` in r4 only.
- Rule-metadata scope: canary alone is sufficient for the post-merge `@v1-rc` advance.

#### Changelog input

```
release-note

Custom Spectral functions `camara-reserved-words` and `camara-security-no-secrets-in-path-or-query-parameters` now return findings instead of writing to stdout, so both previously-dormant rules emit diagnostics as wired. Tightened word-boundary regex eliminates substring matches inside hyphenated path segments.
```

#### Additional documentation

This section can be blank.

```
docs

```