### PR TITLE
docs(release_automation): clarify Release Review PR template

### DIFF
--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -1,8 +1,10 @@
-## Release {{release_tag}} ({{short_type}})
+## Release Review: {{release_tag}} {{short_type}}
 
-Codeowners update and review this PR. After codeowner and release management approval, merge into the release snapshot to create a draft release.
+This PR finalizes the reviewable release content for the active snapshot.
 
-### APIs in this release
+Edit and review this PR before merging it into the release snapshot. After Codeowner and Release Management approval, merging this PR creates the draft release.
+
+### Release contents
 
 | API | Version | Status |
 |-----|---------|--------|
@@ -12,16 +14,19 @@ Codeowners update and review this PR. After codeowner and release management app
 
 {{#commonalities_release}}**Dependencies:** Commonalities {{commonalities_release}}{{#identity_consent_management_release}}, ICM {{identity_consent_management_release}}{{/identity_consent_management_release}}{{/commonalities_release}}
 
-### Codeowner Review
+### Codeowner Actions
 
-**Update this PR:**
-- [ ] All relevant changes copied into Added / Changed / Fixed / Removed (per API as needed)
+#### 1. Update release notes
 
-**Confirm readiness:**
+- [ ] CHANGELOG updated: copy all API-consumer-relevant changes into the appropriate Added / Changed / Fixed / Removed sections for each API as needed.
+      Do not copy administrative, tooling-only, or internal maintenance changes unless they affect API consumers.
+
+#### 2. Confirm API release readiness
+
 - [ ] API version numbers match the intent declared in `release-plan.yaml`
 {{#is_alpha}}
-- [ ] API definitions are consistent with the declared API version
-- [ ] API documentation (`info.description`) is up to date with the API definition
+- [ ] API definitions are consistent with the declared API versions
+- [ ] API documentation (`info.description`) is up to date with the API definitions
 {{/is_alpha}}
 {{#is_rc}}
 - [ ] API definitions comply with declared Commonalities version
@@ -43,11 +48,11 @@ Codeowners update and review this PR. After codeowner and release management app
 - [ ] API Description is up to date for the API(s)
 {{/is_stable_public}}
 
-### Release Management Review
+### Release Management Actions
 
 - [ ] CHANGELOG follows the release documentation rules
 - [ ] Breaking changes are documented and version updates follow SemVer rules
-- [ ] All mandatory release assets for the APIs are present per the API status and confirmed
+- [ ] Mandatory release assets are present for each API according to its status
 
 <details>
 <summary><b>Required release assets per API status</b></summary>
@@ -67,15 +72,18 @@ M = Mandatory, O = Optional — [Full documentation](https://github.com/camarapr
 
 </details>
 
-**Verify snapshot content (during automation introduction phase only):**
+### Temporary checks during automation introduction
+
+These checks are only needed while the automation is being introduced.
+
 - [ ] `release-metadata.yaml` content is correct
-- [ ] API version numbers and applicable extensions were generated correctly (server URLs, references, version fields)
-- [ ] README update looks correct (release tag, versions, latest vs pre-release)
+- [ ] API version numbers and applicable extensions were generated correctly, including server URLs, references, and version fields
+- [ ] README update looks correct, including release tag, versions, latest vs pre-release handling
 
 ### Valid actions
 
-- **Merge this PR** when both codeowner and release management approvals are given — creates a draft release
-- **`/discard-snapshot`** in the {{#release_issue_url}}[Release Issue]({{release_issue_url}}){{/release_issue_url}}{{^release_issue_url}}Release Issue{{/release_issue_url}} to discard, return to `planned`, and update content on `main`
+- **Merge this PR** when all Codeowner Actions and Release Management Actions are complete and the required approvals are present — creates the draft release
+- Use **`/discard-snapshot <reason>`** in the {{#release_issue_url}}[Release Issue]({{release_issue_url}}){{/release_issue_url}}{{^release_issue_url}}Release Issue{{/release_issue_url}} to discard this snapshot, return to `planned`, and update content on `main`
 
 ---
 Snapshot: [`{{snapshot_id}}`]({{snapshot_branch_url}})

--- a/release_automation/tests/test_template_loader.py
+++ b/release_automation/tests/test_template_loader.py
@@ -27,19 +27,19 @@ class TestRenderTemplate:
 
         result = render_template("release_review_pr", context)
 
-        assert "## Release r4.1 (rc)" in result
+        assert "## Release Review: r4.1 rc" in result
         assert "| API | Version | Status |" in result
         assert "| QualityOnDemand | `v1.0.0` | rc |" in result
         assert "| DeviceLocation | `v2.0.0` | rc |" in result
-        assert "### Codeowner Review" in result
-        assert "### Release Management Review" in result
-        assert "**Verify snapshot content (during automation introduction phase only):**" in result
-        assert "**Update this PR:**" in result
-        assert "**Confirm readiness:**" in result
-        assert "All relevant changes copied into Added" in result
+        assert "### Codeowner Actions" in result
+        assert "### Release Management Actions" in result
+        assert "### Temporary checks during automation introduction" in result
+        assert "#### 1. Update release notes" in result
+        assert "#### 2. Confirm API release readiness" in result
+        assert "CHANGELOG updated: copy all API-consumer-relevant changes" in result
         assert "declared Commonalities version" in result
         assert "Commonalities r3.4" in result
-        assert "mandatory release assets for the APIs are present per the API status and confirmed" in result
+        assert "Mandatory release assets are present for each API according to its status" in result
         assert "README update looks correct" in result
         assert "### Valid actions" in result
         assert "Snapshot: [`r4.1-abc1234`]" in result
@@ -60,11 +60,11 @@ class TestRenderTemplate:
 
         result = render_template("release_review_pr", context)
 
-        assert "## Release r3.2 (alpha)" in result
+        assert "## Release Review: r3.2 alpha" in result
         assert "| NumberVerification | `v0.3.0-alpha.1` | alpha |" in result
-        assert "API definitions are consistent with the declared API version" in result
+        assert "API definitions are consistent with the declared API versions" in result
         assert "API documentation (`info.description`) is up to date" in result
-        assert "All relevant changes copied into Added" in result
+        assert "CHANGELOG updated: copy all API-consumer-relevant changes" in result
         # Alpha should NOT have rc/public-specific items
         assert "Enhanced test cases" not in result
 
@@ -83,10 +83,10 @@ class TestRenderTemplate:
 
         result = render_template("release_review_pr", context)
 
-        assert "## Release r5.0 (public)" in result
+        assert "## Release Review: r5.0 public" in result
         assert "| TestAPI | `v0.5.0` | initial public |" in result
         assert "API Description is set" in result
-        assert "mandatory release assets for the APIs are present per the API status and confirmed" in result
+        assert "Mandatory release assets are present for each API according to its status" in result
         # Initial public should NOT have stable-public-only items
         assert "Enhanced test cases" not in result
         assert "User stories" not in result
@@ -106,12 +106,12 @@ class TestRenderTemplate:
 
         result = render_template("release_review_pr", context)
 
-        assert "## Release r6.1 (maintenance)" in result
+        assert "## Release Review: r6.1 maintenance" in result
         assert "| TestAPI | `v1.0.0` | stable public |" in result
         assert "Enhanced test cases cover rainy day scenarios" in result
         assert "User stories are current" in result
         assert "API Description is up to date" in result
-        assert "mandatory release assets for the APIs are present per the API status and confirmed" in result
+        assert "Mandatory release assets are present for each API according to its status" in result
 
     def test_render_release_review_pr_no_apis(self):
         """Test rendering with no APIs (edge case)."""
@@ -124,7 +124,7 @@ class TestRenderTemplate:
 
         result = render_template("release_review_pr", context)
 
-        assert "## Release r5.0 (rc)" in result
+        assert "## Release Review: r5.0 rc" in result
         assert "Snapshot: [`r5.0-xyz9999`]" in result
 
     def test_render_release_review_pr_with_release_issue_link(self):
@@ -169,7 +169,7 @@ class TestRenderTemplate:
         # Should not raise - missing tags are ignored
         result = render_template("release_review_pr", context)
 
-        assert "## Release r1.0" in result
+        assert "## Release Review: r1.0" in result
         # Missing snapshot_id should render as empty in link
         assert "Snapshot: [``]" in result
 
@@ -190,7 +190,7 @@ class TestTemplateLoader:
 
         result = loader.render("release_review_pr", context)
 
-        assert "## Release r4.2 (rc)" in result
+        assert "## Release Review: r4.2 rc" in result
         assert "| TestAPI | `v1.0.0` | rc |" in result
 
     def test_loader_render_sync_pr(self):


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Reword and restructure the Release Review PR body for codeowner clarity, as discussed on [ReleaseManagement#491](https://github.com/camaraproject/ReleaseManagement/issues/491).

Same template logic and context variables — only wording, headings, and section grouping change. No runtime code paths affected.

Highlights:
- Title prefix `Release Review:` so the PR's purpose is obvious from the title alone
- Codeowner section split into numbered subsections "Update release notes" and "Confirm API release readiness"
- CHANGELOG checkbox spells out "API-consumer-relevant" and excludes administrative / tooling-only changes
- Temporary automation-introduction checks lifted into their own `### Temporary checks during automation introduction` section, separating them from durable Release Management Actions
- `Valid actions` wording made more directive (`/discard-snapshot <reason>`)

#### Which issue(s) this PR fixes:

Refs camaraproject/ReleaseManagement#491

(The issue is intentionally kept open per its own body so further wording fixes can land in follow-up PRs as Teams use the automation.)

#### Special notes for reviewers:

- `{{#is_alpha}}` / `{{#is_rc}}` / `{{#is_initial_public}}` / `{{#is_stable_public}}` conditional blocks preserved; only the alpha-branch items were pluralized for consistency with multi-API releases.
- 17 string assertions across 7 tests in `release_automation/tests/test_template_loader.py` updated to match the new wording. Full `release_automation/tests/` suite passes (665/665).
- Tag-move scope: template-only edits do not exercise runtime paths; this will be bundled into the next full E2E rather than triggering a separate `@v1-rc` move.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.

```
docs
NONE
```