### PR TITLE
fix(regression-runner): disambiguate caller run by displayTitle

### DIFF
--- a/release_automation/scripts/regression_runner.py
+++ b/release_automation/scripts/regression_runner.py
@@ -285,6 +285,31 @@ def get_release_issue_state(repo: str, issue_number: int) -> str | None:
     return read_state_label(data.get("labels", []))
 
 
+def get_issue_title(repo: str, issue_number: int) -> str:
+    """Return the title of *issue_number* in *repo*.
+
+    Used by ``find_recent_caller_run`` to disambiguate same-named workflow
+    runs triggered by unrelated ``issue_comment`` events. For ``issue_comment``
+    events, GitHub sets the run's ``display_title`` to the title of the issue
+    or PR where the comment was posted, so this title is the discriminator
+    between the canary's slash command on the Release Issue and a stray
+    comment on a Release Review PR.
+    """
+    data = gh(
+        [
+            "api", f"repos/{repo}/issues/{issue_number}",
+            "--jq", "{title: .title}",
+        ],
+        parse_json=True,
+    )
+    title = data.get("title")
+    if not isinstance(title, str) or not title:
+        raise InfrastructureError(
+            f"{repo}#{issue_number}: could not read issue title"
+        )
+    return title
+
+
 def snapshot_id_from_branch(branch_name: str) -> str:
     """Extract snapshot id from a release-snapshot/ or release-review/ branch name.
 
@@ -544,13 +569,24 @@ def find_recent_caller_run(
     *,
     workflow_file: str,
     since: datetime,
+    expected_display_title: str,
     attempts: int = 15,
     interval: float = 2.0,
 ) -> dict[str, Any]:
     """Poll `gh run list` for an issue_comment-triggered run newer than *since*.
 
-    Returns the run dict (with databaseId, createdAt, url, status, conclusion)
-    once one is observed. Raises InfrastructureError on timeout.
+    Filters candidates by ``displayTitle == expected_display_title`` to
+    disambiguate from unrelated ``issue_comment`` runs that fire on the same
+    workflow concurrently — e.g. a validation-bot result comment on the
+    Release Review PR creates a same-named run that immediately skips via
+    the workflow's ``if:`` filter, and without the title check the runner
+    can pick that skipped run instead of the slash command's run. For
+    ``issue_comment`` events GitHub sets ``display_title`` to the issue/PR
+    title where the comment was posted, so this filter pinpoints runs
+    triggered by comments on the Release Issue.
+
+    Returns the run dict (with databaseId, createdAt, url, status, conclusion,
+    displayTitle) once one is observed. Raises InfrastructureError on timeout.
     """
     for _ in range(attempts):
         time.sleep(interval)
@@ -560,7 +596,7 @@ def find_recent_caller_run(
                 "--repo", repo,
                 "--workflow", workflow_file,
                 "--event", "issue_comment",
-                "--json", "databaseId,createdAt,status,conclusion,url",
+                "--json", "databaseId,createdAt,displayTitle,status,conclusion,url",
                 "--limit", "10",
             ],
             parse_json=True,
@@ -571,8 +607,11 @@ def find_recent_caller_run(
                 created = _iso_to_dt(run["createdAt"])
             except (KeyError, ValueError):
                 continue
-            if created >= since:
-                candidates.append(run)
+            if created < since:
+                continue
+            if run.get("displayTitle") != expected_display_title:
+                continue
+            candidates.append(run)
         if candidates:
             # Newest first — take the one with the latest createdAt.
             candidates.sort(key=lambda r: r["createdAt"], reverse=True)
@@ -583,7 +622,8 @@ def find_recent_caller_run(
             )
             return run
     raise InfrastructureError(
-        f"{repo}: no {workflow_file} issue_comment run appeared within "
+        f"{repo}: no {workflow_file} issue_comment run with "
+        f"displayTitle={expected_display_title!r} appeared within "
         f"{attempts * interval:.0f}s since {since.isoformat()}"
     )
 
@@ -678,12 +718,19 @@ def _fire_command_phase(
     body = _build_command_body(command, purpose)
     marker = datetime.now(timezone.utc).replace(microsecond=0)
     try:
+        # Fetch the issue title before posting so find_recent_caller_run
+        # can disambiguate the slash-command run from unrelated
+        # issue_comment runs on the same workflow (e.g. validation-bot
+        # comments on the Release Review PR). For issue_comment events,
+        # GitHub sets the run's display_title to the issue/PR title.
+        issue_title = get_issue_title(repo, issue_number)
         post_issue_comment(repo, issue_number, body)
         logger.info("posted %s on %s#%s; polling for caller run", command, repo, issue_number)
         run = find_recent_caller_run(
             repo,
             workflow_file=_RA_CALLER_WORKFLOW,
             since=marker,
+            expected_display_title=issue_title,
         )
     except InfrastructureError as exc:
         report.detail = f"could not fire {command}: {exc}"

--- a/release_automation/tests/test_regression_runner.py
+++ b/release_automation/tests/test_regression_runner.py
@@ -26,6 +26,7 @@ from release_automation.scripts.regression_runner import (
     fetch_last_bot_comment,
     find_recent_caller_run,
     find_release_issue,
+    get_issue_title,
     get_release_issue_state,
     load_expected_comment_titles,
     phase_fire_create_snapshot,
@@ -232,6 +233,36 @@ class TestGetReleaseIssueState:
 
 
 # ---------------------------------------------------------------------------
+# get_issue_title
+# ---------------------------------------------------------------------------
+
+
+class TestGetIssueTitle:
+    def test_returns_title(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value={"title": "Release for r1.2"},
+        ):
+            assert get_issue_title("o/r", 90) == "Release for r1.2"
+
+    def test_raises_when_title_missing(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value={},
+        ):
+            with pytest.raises(InfrastructureError, match="could not read"):
+                get_issue_title("o/r", 90)
+
+    def test_raises_when_title_empty(self):
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value={"title": ""},
+        ):
+            with pytest.raises(InfrastructureError, match="could not read"):
+                get_issue_title("o/r", 90)
+
+
+# ---------------------------------------------------------------------------
 # find_recent_caller_run — event filter + newest-after-marker selection
 # ---------------------------------------------------------------------------
 
@@ -243,6 +274,7 @@ class TestFindRecentCallerRun:
             {
                 "databaseId": 1,
                 "createdAt": "2026-04-22T09:59:00Z",
+                "displayTitle": "Release for r1.2",
                 "status": "completed",
                 "conclusion": "success",
                 "url": "https://x/1",
@@ -250,6 +282,7 @@ class TestFindRecentCallerRun:
             {
                 "databaseId": 2,
                 "createdAt": "2026-04-22T10:01:00Z",
+                "displayTitle": "Release for r1.2",
                 "status": "in_progress",
                 "conclusion": None,
                 "url": "https://x/2",
@@ -257,6 +290,7 @@ class TestFindRecentCallerRun:
             {
                 "databaseId": 3,
                 "createdAt": "2026-04-22T10:02:00Z",
+                "displayTitle": "Release for r1.2",
                 "status": "queued",
                 "conclusion": None,
                 "url": "https://x/3",
@@ -270,10 +304,11 @@ class TestFindRecentCallerRun:
                 "o/r",
                 workflow_file="release-automation.yml",
                 since=marker,
+                expected_display_title="Release for r1.2",
                 attempts=1,
                 interval=0.0,
             )
-        # Newest (after marker) is run 3.
+        # Newest (after marker, matching title) is run 3.
         assert run["databaseId"] == 3
 
     def test_ignores_runs_before_marker(self):
@@ -282,6 +317,7 @@ class TestFindRecentCallerRun:
             {
                 "databaseId": 1,
                 "createdAt": "2026-04-22T09:00:00Z",
+                "displayTitle": "Release for r1.2",
                 "status": "completed",
                 "conclusion": "success",
                 "url": "https://x/1",
@@ -291,11 +327,12 @@ class TestFindRecentCallerRun:
             "release_automation.scripts.regression_runner.gh",
             return_value=runs,
         ):
-            with pytest.raises(InfrastructureError, match="no .* run appeared"):
+            with pytest.raises(InfrastructureError, match="no .* run .* appeared"):
                 find_recent_caller_run(
                     "o/r",
                     workflow_file="release-automation.yml",
                     since=marker,
+                    expected_display_title="Release for r1.2",
                     attempts=1,
                     interval=0.0,
                 )
@@ -306,6 +343,7 @@ class TestFindRecentCallerRun:
             {
                 "databaseId": 1,
                 "createdAt": "not-a-timestamp",
+                "displayTitle": "Release for r1.2",
                 "status": "queued",
                 "conclusion": None,
                 "url": "https://x/1",
@@ -313,6 +351,7 @@ class TestFindRecentCallerRun:
             {
                 "databaseId": 2,
                 "createdAt": "2026-04-22T10:05:00Z",
+                "displayTitle": "Release for r1.2",
                 "status": "queued",
                 "conclusion": None,
                 "url": "https://x/2",
@@ -326,10 +365,83 @@ class TestFindRecentCallerRun:
                 "o/r",
                 workflow_file="release-automation.yml",
                 since=marker,
+                expected_display_title="Release for r1.2",
                 attempts=1,
                 interval=0.0,
             )
         assert run["databaseId"] == 2
+
+    def test_rejects_non_matching_display_title(self):
+        # Session-87 repro: a stray issue_comment on a different issue/PR
+        # creates a same-named workflow run within the time window. Without
+        # the displayTitle filter, the runner would pick the wrong (newer)
+        # run; with the filter it must pick the matching-title run instead.
+        marker = datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc)
+        runs = [
+            # The slash-command run on the Release Issue.
+            {
+                "databaseId": 1001,
+                "createdAt": "2026-04-22T10:00:30Z",
+                "displayTitle": "Release for r1.2",
+                "status": "queued",
+                "conclusion": None,
+                "url": "https://x/1001",
+            },
+            # A skipped run from an unrelated comment on the Release
+            # Review PR — newer than the slash-command run, same workflow.
+            {
+                "databaseId": 1002,
+                "createdAt": "2026-04-22T10:00:45Z",
+                "displayTitle": "[wip] Release for r1.2",
+                "status": "completed",
+                "conclusion": "skipped",
+                "url": "https://x/1002",
+            },
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=runs,
+        ):
+            run = find_recent_caller_run(
+                "o/r",
+                workflow_file="release-automation.yml",
+                since=marker,
+                expected_display_title="Release for r1.2",
+                attempts=1,
+                interval=0.0,
+            )
+        assert run["databaseId"] == 1001
+
+    def test_raises_when_only_non_matching_titles(self):
+        # Only candidates with non-matching displayTitle exist; the runner
+        # must time out rather than pick one as a fallback.
+        marker = datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc)
+        runs = [
+            {
+                "databaseId": 1,
+                "createdAt": "2026-04-22T10:01:00Z",
+                "displayTitle": "[wip] Release for r1.2",
+                "status": "completed",
+                "conclusion": "skipped",
+                "url": "https://x/1",
+            },
+        ]
+        with patch(
+            "release_automation.scripts.regression_runner.gh",
+            return_value=runs,
+        ):
+            with pytest.raises(
+                InfrastructureError,
+                match="displayTitle='Release for r1.2'",
+            ):
+                find_recent_caller_run(
+                    "o/r",
+                    workflow_file="release-automation.yml",
+                    since=marker,
+                    expected_display_title="Release for r1.2",
+                    attempts=1,
+                    interval=0.0,
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -946,11 +1058,13 @@ class TestPhaseFireCreateSnapshotPolished:
         caller_run = {
             "databaseId": 999,
             "createdAt": "2026-04-23T05:00:10Z",
+            "displayTitle": "Release for r1.2",
             "status": "completed",
             "conclusion": "success",
             "url": "https://x/run/999",
         }
         responses = [
+            ("{title: .title}", {"title": "Release for r1.2"}),  # get_issue_title
             ("issue comment", ""),  # post_issue_comment
             ("run list", [caller_run]),  # find_recent_caller_run
             ("run view", {"status": "completed", "conclusion": "success"}),  # poll_run
@@ -991,11 +1105,13 @@ class TestPhaseFireCreateSnapshotPolished:
         caller_run = {
             "databaseId": 999,
             "createdAt": "2026-04-23T05:00:10Z",
+            "displayTitle": "Release for r1.2",
             "status": "completed",
             "conclusion": "success",
             "url": "https://x/run/999",
         }
         responses = [
+            ("{title: .title}", {"title": "Release for r1.2"}),
             ("issue comment", ""),
             ("run list", [caller_run]),
             ("run view", {"status": "completed", "conclusion": "success"}),
@@ -1028,11 +1144,13 @@ class TestPhaseFireCreateSnapshotPolished:
         caller_run = {
             "databaseId": 999,
             "createdAt": "2026-04-23T05:00:10Z",
+            "displayTitle": "Release for r1.2",
             "status": "completed",
             "conclusion": "failure",
             "url": "https://x/run/999",
         }
         responses = [
+            ("{title: .title}", {"title": "Release for r1.2"}),
             ("issue comment", ""),
             ("run list", [caller_run]),
             ("run view", {"status": "completed", "conclusion": "failure"}),
@@ -1062,11 +1180,13 @@ class TestPhaseFireCreateSnapshotPolished:
         caller_run = {
             "databaseId": 999,
             "createdAt": "2026-04-23T05:00:10Z",
+            "displayTitle": "Release for r1.2",
             "status": "completed",
             "conclusion": "success",
             "url": "https://x/run/999",
         }
         responses = [
+            ("{title: .title}", {"title": "Release for r1.2"}),
             ("issue comment", ""),
             ("run list", [caller_run]),
             ("run view", {"status": "completed", "conclusion": "success"}),


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Closes a false-failure mode in the Release Automation regression canary.

`find_recent_caller_run` filters caller workflow runs by `event=issue_comment` + `createdAt >= since` only. When an unrelated `issue_comment` (e.g. a validation-bot result comment on the Release Review PR) creates a same-named `CAMARA Release Automation` run that immediately skips via the workflow's `if:` filter, the runner could grab that skipped run instead of the slash-command run.

Concrete repro from a recent canary failure: the runner reported `/discard-snapshot` failed when it had succeeded — it had picked a `skipped` run triggered by a validation-bot comment on the Release Review PR, while the real `/discard` run on the Release Issue concluded `success`.

The fix filters run-list candidates by `displayTitle` matching the Release Issue's title. For `issue_comment` events GitHub sets the run's `display_title` to the title of the issue/PR where the comment was posted, so the wrong run (PR title) and the right run (issue title) no longer collide.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

- New `get_issue_title` helper fetches the title once before posting the slash command; one extra `gh api` call per fire phase, negligible overhead.
- Test additions cover the session-87 repro shape (matching + non-matching candidates, matching one wins) plus the no-matching-title timeout path.
- Full RA test suite green: `python3 -m pytest release_automation/tests/ -q` → 670 passed.

#### Changelog input

```
 release-note
None — internal canary infrastructure only; no user-visible behavior change.

```

#### Additional documentation

```
docs
None.

```