### PR TITLE
config: enable validation framework for onboarded repositories

### DIFF
--- a/config/validation-settings.yaml
+++ b/config/validation-settings.yaml
@@ -22,7 +22,35 @@ defaults:
   release_profile: standard
 
 repositories:
+  ClickToDial:
+    stage: enabled  # 2026-04-29
+  ConsentInfo:
+    stage: enabled  # 2026-04-29
+  ConsentManagement:
+    stage: enabled  # 2026-04-29
+  DedicatedNetworks:
+    stage: enabled  # 2026-04-29
+  DeviceIdentifier:
+    stage: enabled  # 2026-04-29 (pre-staged; effective when DeviceIdentifier#161 merges)
+  EdgeApplicationManagement:
+    stage: enabled  # 2026-04-29 (pre-staged; effective when EdgeApplicationManagement#20 merges)
+  IoTSIMFraudPrevention:
+    stage: enabled  # 2026-04-29
+  MultiPointVPN:
+    stage: enabled  # 2026-04-29
+  NetworkInsights:
+    stage: enabled  # 2026-04-29
+  NetworkSliceBooking:
+    stage: enabled  # 2026-04-29
+  QoSBooking:
+    stage: enabled  # 2026-04-29
+  QualityOnDemand:
+    stage: enabled  # 2026-04-29
   ReleaseTest:
-    stage: enabled
+    stage: enabled  # 2026-04-26 (centralized)
+  SessionInsights:
+    stage: enabled  # 2026-04-29
   SimpleEdgeDiscovery:
-    stage: enabled
+    stage: enabled  # 2026-04-26 (centralized)
+  WebRTC:
+    stage: enabled  # 2026-04-29


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Flips per-repo validation stage from `advisory` (central default) to `enabled`
for production repositories running the v1-rc validation framework, and
pre-stages two repositories with onboarding PRs in flight.

Effective immediately for the 12 repositories with `camara-validation.yml`
already installed. The entries for DeviceIdentifier and EdgeApplicationManagement
are pre-staged and become effective once their respective onboarding PRs merge.

Per-repo follow-ups outside this PR: disable the v0 caller workflows
(`pr_validation_caller.yml`, `spectral-oas-caller.yml`) via the Actions API
and file a tracking issue per repo for eventual file removal at v1 GA
(precedent: SimpleEdgeDiscovery#164).

#### Which issue(s) this PR fixes:

Tracked under camaraproject/ReleaseManagement#484.

#### Special notes for reviewers:

Schema is permissive (`additionalProperties: true`); pre-staged entries for
repositories without `camara-validation.yml` are inert until each repo's
onboarding PR merges.

Inline date comments (`# YYYY-MM-DD`) record when each entry was added so the
file's rollout timeline is readable without git-log spelunking.

#### Changelog input

```
 release-note
N/A — runtime configuration only.
```

#### Additional documentation

```
docs
N/A
```