### PR TITLE
config: pre-stage CustomerInsights, finalize EdgeApplicationManagement

### DIFF
--- a/config/validation-settings.yaml
+++ b/config/validation-settings.yaml
@@ -35,7 +35,7 @@ repositories:
   DeviceIdentifier:
     stage: enabled  # 2026-04-29 (pre-staged; effective when DeviceIdentifier#161 merges)
   EdgeApplicationManagement:
-    stage: enabled  # 2026-04-29 (pre-staged; effective when EdgeApplicationManagement#20 merges)
+    stage: enabled  # 2026-04-29
   IoTSIMFraudPrevention:
     stage: enabled  # 2026-04-29
   MultiPointVPN:

--- a/config/validation-settings.yaml
+++ b/config/validation-settings.yaml
@@ -28,6 +28,8 @@ repositories:
     stage: enabled  # 2026-04-29
   ConsentManagement:
     stage: enabled  # 2026-04-29
+  CustomerInsights:
+    stage: enabled  # 2026-04-30 (pre-staged; effective when CustomerInsights#70 merges)
   DedicatedNetworks:
     stage: enabled  # 2026-04-29
   DeviceIdentifier:


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Two related cleanups on `config/validation-settings.yaml`:

1. Adds CustomerInsights at `stage: enabled` (pre-staged). Takes effect when the in-flight onboarding PR [CustomerInsights#70](https://github.com/camaraproject/CustomerInsights/pull/70) merges. Same pattern as the DeviceIdentifier and EdgeApplicationManagement entries from #245. The CustomerInsights onboarding PR opened after #245 had merged, so it was not included in that batch.
2. Drops the "(pre-staged; effective when EdgeApplicationManagement#20 merges)" annotation from the EAM entry. EAM#20 merged on 2026-04-29; the post-merge follow-up (v0 caller disable, tracking issue, dispatch confirmation) is complete.

DeviceIdentifier keeps its pre-staged annotation (DeviceIdentifier#161 still open).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Two-commit PR; both touch only `config/validation-settings.yaml`. No runtime paths exercised. The corresponding fallback copy on the `validation-framework` branch will be synced via a separate follow-up PR (mirrors #246).

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation 

This section can be blank.

```
docs
NONE
```
