### PR TITLE
validation: scan early lines for Feature: in .feature test files

### DIFF
--- a/validation/engines/python_checks/test_checks.py
+++ b/validation/engines/python_checks/test_checks.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from validation.context import ValidationContext
 
@@ -121,23 +121,42 @@ def check_test_files_exist(
 #   "Feature: CAMARA QoD API, v1.0.0"                               → "v1.0.0"
 _FEATURE_VERSION_RE = re.compile(r"\s(v?wip|v\S+?)(?:\s+-\s|\s*$)")
 
+# Match a Gherkin Feature line, allowing the leading whitespace that some
+# files use. Comment lines (``#``), tag lines (``@…``), and blank lines
+# preceding the Feature line are valid Gherkin and are skipped during the
+# scan.
+_FEATURE_LINE_RE = re.compile(r"^\s*Feature\s*:")
 
-def _extract_feature_version(file_path: Path) -> Optional[str]:
-    """Read the first line and extract the version segment.
+# Cap the Feature-line scan to bound work on pathological inputs. Real-world
+# preambles (comment + tag + blanks) are at most a handful of lines.
+_FEATURE_LINE_SCAN_CAP = 50
 
-    Returns the version string (e.g. ``"vwip"``, ``"v2.2.0-alpha.5"``)
-    or ``None`` if no version could be parsed from the Feature line.
+
+def _extract_feature_version(
+    file_path: Path,
+) -> Tuple[Optional[str], Optional[int]]:
+    """Locate the Feature line and extract the version segment.
+
+    Scans the first ``_FEATURE_LINE_SCAN_CAP`` lines for a line beginning
+    with ``Feature:`` (skipping preceding comment, tag, and blank lines —
+    all valid Gherkin) and applies the version regex to that line.
+
+    Returns ``(version, line_number)`` when a Feature line is found and
+    the version regex matches; ``(None, line_number)`` when the Feature
+    line is found but carries no recognizable version token; and
+    ``(None, None)`` when no Feature line is present in the scan window.
     """
     try:
         with open(file_path, encoding="utf-8") as fh:
-            first_line = fh.readline().rstrip()
+            for lineno, line in enumerate(fh, start=1):
+                if lineno > _FEATURE_LINE_SCAN_CAP:
+                    break
+                if _FEATURE_LINE_RE.match(line):
+                    m = _FEATURE_VERSION_RE.search(line.rstrip())
+                    return (m.group(1) if m else None), lineno
     except (OSError, UnicodeDecodeError):
-        return None
-
-    m = _FEATURE_VERSION_RE.search(first_line)
-    if m:
-        return m.group(1)
-    return None
+        pass
+    return None, None
 
 
 def check_test_file_version(
@@ -196,25 +215,42 @@ def check_test_file_version(
 
     findings: List[dict] = []
     for test_file in matching:
-        actual_version = _extract_feature_version(test_file)
+        actual_version, feature_lineno = _extract_feature_version(test_file)
+
+        if feature_lineno is None:
+            # No Feature line found in the scan window — emitted under
+            # P-024 so its severity cannot be masked by P-007's
+            # conditional_level.
+            findings.append(
+                make_finding(
+                    engine_rule="check-test-file-feature-line-untransformable",
+                    level="error",
+                    message=(
+                        f"Test file '{test_file.name}' has no 'Feature:' "
+                        f"line in the first {_FEATURE_LINE_SCAN_CAP} lines "
+                        f"(expected '{expected_segment}')"
+                    ),
+                    path=f"{_TEST_DIR}/{test_file.name}",
+                    line=1,
+                    api_name=api.api_name,
+                )
+            )
+            continue
 
         if actual_version is None:
-            # No wip/vwip/v* token on the Feature line — T1b has nothing to
-            # replace and a release cut would carry the literal text into
-            # the snapshot. Emitted under a distinct rule ID (P-024) so its
-            # severity cannot be masked by P-007's conditional_level.
+            # Feature line found but no recognizable version token. Same
+            # P-024 rule, distinct message — points at the actual line.
             findings.append(
                 make_finding(
                     engine_rule="check-test-file-feature-line-untransformable",
                     level="error",
                     message=(
                         f"Test file '{test_file.name}' Feature line has no "
-                        f"'wip', 'vwip', or 'v{{version}}' token — nothing "
-                        f"for snapshot transformation to replace "
+                        f"'wip', 'vwip', or 'v{{version}}' token "
                         f"(expected '{expected_segment}')"
                     ),
                     path=f"{_TEST_DIR}/{test_file.name}",
-                    line=1,
+                    line=feature_lineno,
                     api_name=api.api_name,
                 )
             )
@@ -233,7 +269,7 @@ def check_test_file_version(
                         f"(on {context.branch_type} branch)"
                     ),
                     path=f"{_TEST_DIR}/{test_file.name}",
-                    line=1,
+                    line=feature_lineno,
                     api_name=api.api_name,
                 )
             )

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -326,14 +326,17 @@
     default: error
 
 # P-024: check-test-file-feature-line-untransformable
-# Fires when the Feature line of a test file has no `wip`, `vwip`, or
-# `v{version}` token — nothing for snapshot transformation T1b to
-# replace, so a release cut would carry the literal text into the
-# snapshot. Always error: distinct from P-007 (which covers the
-# "present but mismatched" case under conditional_level hint/warn).
-# P-007 and P-024 are mutually exclusive per the check's code path
-# (`continue` after the None branch prevents both from firing on the
-# same file).
+# Fires under either of two conditions in a `.feature` file:
+#   1. No `Feature:` line is present in the first 50 lines.
+#   2. The `Feature:` line is present but carries no `wip`, `vwip`, or
+#      `v{version}` token to indicate the API version.
+# Comment lines, feature-level tags, and blank lines preceding `Feature:`
+# are valid Gherkin and are skipped during the scan. The check emits a
+# distinct message per condition. Always error: distinct from P-007
+# (which covers the "version present but mismatched" case under
+# conditional_level hint/warn). P-007 and P-024 are mutually exclusive
+# per the check's code path (`continue` after each P-024 branch prevents
+# both from firing on the same file).
 - id: P-024
   engine: python
   engine_rule: check-test-file-feature-line-untransformable

--- a/validation/tests/test_python_checks_test.py
+++ b/validation/tests/test_python_checks_test.py
@@ -312,6 +312,124 @@ class TestCheckTestFileVersion:
             "check-test-file-feature-line-untransformable"
         )
 
+    # --- preamble lines before Feature line (comment / tag / blank) ---
+
+    def test_comment_line_before_feature_passes(self, tmp_path: Path):
+        """Line 1 is a Gherkin comment; Feature line is on line 2."""
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "qod.feature").write_text(
+            "# qod-createSession\n"
+            "Feature: CAMARA QoD API, vwip - Operation createSession\n"
+            "  Background: setup\n"
+        )
+        ctx = _make_context("qod", branch_type="main")
+        assert check_test_file_version(tmp_path, ctx) == []
+
+    def test_top_level_tag_before_feature_passes(self, tmp_path: Path):
+        """Line 1 is a feature-level Gherkin tag; Feature line is on line 2."""
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "qod.feature").write_text(
+            "@QoD_API\n"
+            "Feature: CAMARA QoD API, vwip - Operation createSession\n"
+            "  Background: setup\n"
+        )
+        ctx = _make_context("qod", branch_type="main")
+        assert check_test_file_version(tmp_path, ctx) == []
+
+    def test_indented_tag_before_feature_passes(self, tmp_path: Path):
+        """Indented tag on line 1; Feature line is on line 2."""
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "qod.feature").write_text(
+            "  @QoD_API\n"
+            "Feature: CAMARA QoD API, vwip - Operation createSession\n"
+            "  Background: setup\n"
+        )
+        ctx = _make_context("qod", branch_type="main")
+        assert check_test_file_version(tmp_path, ctx) == []
+
+    def test_blank_lines_and_multiple_preamble_lines_pass(
+        self, tmp_path: Path
+    ):
+        """Comment + blank + tag preamble before Feature — all skipped."""
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "qod.feature").write_text(
+            "# qod-createSession\n"
+            "\n"
+            "@QoD_API\n"
+            "Feature: CAMARA QoD API, vwip - Operation createSession\n"
+            "  Background: setup\n"
+        )
+        ctx = _make_context("qod", branch_type="main")
+        assert check_test_file_version(tmp_path, ctx) == []
+
+    def test_finding_reports_actual_feature_line_number(
+        self, tmp_path: Path
+    ):
+        """Mismatched version on line 2 — finding reports line=2."""
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "qod.feature").write_text(
+            "# qod-createSession\n"
+            "Feature: CAMARA QoD API, v1 - Operation createSession\n"
+        )
+        ctx = _make_context("qod", version="1.0.0", branch_type="main")
+        findings = check_test_file_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-test-file-version"
+        assert findings[0]["line"] == 2
+
+    def test_p024_when_no_feature_line_in_file(self, tmp_path: Path):
+        """File contains only comments and tags, no Feature: line."""
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "qod.feature").write_text(
+            "# qod-createSession\n"
+            "@QoD_API\n"
+        )
+        ctx = _make_context("qod", branch_type="main")
+        findings = check_test_file_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == (
+            "check-test-file-feature-line-untransformable"
+        )
+        assert findings[0]["level"] == "error"
+        assert findings[0]["line"] == 1
+        assert "no 'Feature:' line" in findings[0]["message"]
+
+    def test_p024_when_feature_line_has_no_version_token(
+        self, tmp_path: Path
+    ):
+        """Feature line on line 2 with no version token → P-024 at line=2."""
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "qod.feature").write_text(
+            "# qod-createSession\n"
+            "Feature: QoD API tests\n"
+        )
+        ctx = _make_context("qod", branch_type="main")
+        findings = check_test_file_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == (
+            "check-test-file-feature-line-untransformable"
+        )
+        assert findings[0]["line"] == 2
+        assert "has no 'wip', 'vwip'" in findings[0]["message"]
+
+    def test_feature_line_beyond_scan_cap_treated_as_missing(
+        self, tmp_path: Path
+    ):
+        """Feature line beyond the 50-line cap → 'no Feature line' variant."""
+        test_dir = _make_test_dir(tmp_path)
+        preamble = "\n" * 60
+        (test_dir / "qod.feature").write_text(
+            preamble
+            + "Feature: CAMARA QoD API, vwip - Operation createSession\n"
+        )
+        ctx = _make_context("qod", branch_type="main")
+        findings = check_test_file_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == (
+            "check-test-file-feature-line-untransformable"
+        )
+        assert "no 'Feature:' line" in findings[0]["message"]
+
     def test_no_test_dir(self, tmp_path: Path):
         ctx = _make_context("qod")
         assert check_test_file_version(tmp_path, ctx) == []


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`P-007` / `P-024` (`validation/engines/python_checks/test_checks.py`, `_extract_feature_version`) read only the first physical line of each `.feature` file. When line 1 is a Gherkin comment or a feature-level tag, the version regex finds no match and `P-024` fires as a hard error.

Both styles are valid Gherkin and consistent with `documentation/API-Testing-Guidelines.md` in `camaraproject/Commonalities`. A sweep across the 49 upstream API repositories with a `code/Test_definitions/` directory shows 25 files in 9 repositories with this layout (`DeviceIdentifier`, `DeviceStatus`, `DeviceReachabilityStatus`, `DeviceRoamingStatus`, `ConnectedNetworkType`, `ApplicationEndpointDiscovery`, `ApplicationEndpointRegistration`, `ApplicationProfiles`, `OptimalEdgeDiscovery`).

The release-time mechanical transformer is unaffected — `_apply_regex` runs `re.subn` on full file content, so it correctly transforms these files regardless of Feature-line position. The validation rule was the only thing flagging them.

This PR:

- Rewrites `_extract_feature_version()` to scan the first 50 lines for a line beginning with `Feature:` (skipping preceding comment, tag, and blank lines) and to return the actual Feature-line number alongside the version.
- Reports `P-007` / `P-024` findings at the actual Feature-line number rather than a hardcoded `line=1`.
- Splits `P-024` into two sub-cases with distinct messages: (1) no `Feature:` line in the scan window, (2) Feature line present but carrying no `wip` / `vwip` / `v{version}` token.
- Drops implementation-coupling "snapshot transformation T1b" phrasing from user-facing messages.
- Revises the `P-024` rule comment block in `validation/rules/python-rules.yaml`.

No release-automation changes. No regression-fixture recapture (the `regression/r4.2-broken-spec-test-files` `regression-expected.yaml` has no P-007/P-024 entries).

#### Which issue(s) this PR fixes:

Fixes #248

#### Special notes for reviewers:

Verified locally:

- 36/36 unit tests pass (`python3 -m pytest validation/tests/test_python_checks_test.py -v`), including 8 new cases covering comment/tag/blank-line preambles, the actual line number reported in findings, the two distinct P-024 sub-cases, and the 50-line scan cap.
- Direct check on the three real `DeviceIdentifier` feature files now resolves `('vwip', 2)` for each — the original false positive is gone.
- Sweep across all 9 affected upstream API repositories returns the expected version + line number for every one of the 25 files.

Tag-move scope: rule-metadata tier (`validation/engines/python_checks/**`, `validation/rules/python-rules.yaml`, `validation/tests/**`). Validation Regression canary green is sufficient — no full ReleaseTest E2E required.

#### Changelog input

```
 release-note
P-007 / P-024 now correctly handle `.feature` files where the `Feature:` line is preceded by Gherkin comments, feature-level tags, or blank lines. Findings report the actual Feature-line number instead of always line 1.
```

#### Additional documentation 

This section can be blank.



```
docs

```
