### PR TITLE
Release Review PR template: apply RM#491 review follow-up

### DIFF
--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -23,10 +23,9 @@ Edit and review this PR before merging it into the release snapshot. After Codeo
 
 #### 2. Confirm API release readiness
 
-- [ ] API version numbers match the intent declared in `release-plan.yaml`
+- [ ] API version(s) used in all files match `release-plan.yaml`
 {{#is_alpha}}
-- [ ] API definitions are consistent with the declared API versions
-- [ ] API documentation (`info.description`) is up to date with the API definitions
+- [ ] API documentation (`info.description`) is up to date with the API definition
 {{/is_alpha}}
 {{#is_rc}}
 - [ ] API definitions comply with declared Commonalities version
@@ -72,15 +71,9 @@ M = Mandatory, O = Optional — [Full documentation](https://github.com/camarapr
 
 </details>
 
-### Temporary checks during automation introduction
+_During the automation introduction phase, please also verify the snapshot content: that `release-metadata.yaml` is correct, that the generated API version numbers and server URLs (and other version fields and references) are right, and that the README update reflects the release tag and version handling._
 
-These checks are only needed while the automation is being introduced.
-
-- [ ] `release-metadata.yaml` content is correct
-- [ ] API version numbers and applicable extensions were generated correctly, including server URLs, references, and version fields
-- [ ] README update looks correct, including release tag, versions, latest vs pre-release handling
-
-### Valid actions
+### Valid next actions for codeowners
 
 - **Merge this PR** when all Codeowner Actions and Release Management Actions are complete and the required approvals are present — creates the draft release
 - Use **`/discard-snapshot <reason>`** in the {{#release_issue_url}}[Release Issue]({{release_issue_url}}){{/release_issue_url}}{{^release_issue_url}}Release Issue{{/release_issue_url}} to discard this snapshot, return to `planned`, and update content on `main`

--- a/release_automation/tests/test_template_loader.py
+++ b/release_automation/tests/test_template_loader.py
@@ -33,15 +33,15 @@ class TestRenderTemplate:
         assert "| DeviceLocation | `v2.0.0` | rc |" in result
         assert "### Codeowner Actions" in result
         assert "### Release Management Actions" in result
-        assert "### Temporary checks during automation introduction" in result
+        assert "During the automation introduction phase" in result
         assert "#### 1. Update release notes" in result
         assert "#### 2. Confirm API release readiness" in result
         assert "CHANGELOG updated: copy all API-consumer-relevant changes" in result
         assert "declared Commonalities version" in result
         assert "Commonalities r3.4" in result
         assert "Mandatory release assets are present for each API according to its status" in result
-        assert "README update looks correct" in result
-        assert "### Valid actions" in result
+        assert "README update reflects the release tag" in result
+        assert "### Valid next actions for codeowners" in result
         assert "Snapshot: [`r4.1-abc1234`]" in result
         assert "<details>" in result
         assert "Required release assets per API status" in result
@@ -62,8 +62,8 @@ class TestRenderTemplate:
 
         assert "## Release Review: r3.2 alpha" in result
         assert "| NumberVerification | `v0.3.0-alpha.1` | alpha |" in result
-        assert "API definitions are consistent with the declared API versions" in result
-        assert "API documentation (`info.description`) is up to date" in result
+        assert "API version(s) used in all files match" in result
+        assert "API documentation (`info.description`) is up to date with the API definition" in result
         assert "CHANGELOG updated: copy all API-consumer-relevant changes" in result
         # Alpha should NOT have rc/public-specific items
         assert "Enhanced test cases" not in result


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Applies tanjadegroot's [review of ReleaseTest#136](https://github.com/camaraproject/ReleaseManagement/issues/491#issuecomment-4351505295) to `release_automation/templates/pr_bodies/release_review_pr.mustache`:

- §2: collapse two version checkboxes to "API version(s) used in all files match `release-plan.yaml`"; "definitions" → "definition" in the alpha info.description checkbox
- §3: replace the "Temporary checks" heading + 3 checkboxes with a short italicized reminder paragraph at the end of Release Management Actions (intentionally unassigned — reminder, not a checkpoint)
- §4: "Valid actions" → "Valid next actions for codeowners"

Tests in `test_template_loader.py` updated; 13/13 pass.

#### Which issue(s) this PR fixes:

References [camaraproject/ReleaseManagement#491](https://github.com/camaraproject/ReleaseManagement/issues/491) (kept open for further wording fixes).

#### Special notes for reviewers:

Template-only — `@v1-rc` stays at `a95f42a`. Pairs with a fresh ReleaseTest snapshot for visual review of the rendered PR.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

```
docs
NONE
```
