### PR TITLE
fix(ra): skip workflow on repositories with Issues disabled

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -62,8 +62,21 @@ jobs:
       # Note: release_tag is NOT output here - it comes from derive-state job
       # which reads from authoritative sources (release-plan.yaml or release-metadata.yaml)
     steps:
+      - name: Fork Guard - Check Issues Enabled
+        id: fork-guard
+        env:
+          HAS_ISSUES: ${{ github.event.repository.has_issues }}
+        run: |
+          if [ "$HAS_ISSUES" = "true" ]; then
+            echo "issues_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "issues_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Issues disabled — Release Automation skipped::To use Release Automation here, enable Issues in repository Settings → General → Features. To stop Release Automation from running on this fork, disable the Release Automation workflow."
+          fi
+
       - name: Detect Trigger Type
         id: detect
+        if: steps.fork-guard.outputs.issues_enabled == 'true'
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Adds a fork guard at the entry of the `check-trigger` job in `release-automation-reusable.yml`. When `github.event.repository.has_issues` is `false`, the job emits a `::warning::` annotation and skips the workflow via the existing `should_continue` mechanism. Every downstream job is short-circuited.

Targets the failure pattern observed on personal forks of CAMARA repositories: forks default to Issues disabled, an upstream sync brings the `release-automation.yml` caller into the fork, and the path-watched `push` trigger fires the reusable workflow, which then errors out trying to create or sync the Release Issue. Sample: [hdamker/WebRTC run 25042204191](https://github.com/hdamker/WebRTC/actions/runs/25042204191).

Contributors who want to test Release Automation on a fork can opt in by enabling Issues there.

#### Which issue(s) this PR fixes:

Fixes #252

#### Special notes for reviewers:

- Single hunk, `+13 -0` lines. The new step runs first in `check-trigger`; the existing `Detect Trigger Type` step gains an `if:` so it skips when Issues are disabled, and the empty `should_continue` then short-circuits all 16 downstream jobs through their existing `needs:` gates.
- Manual verification path: after merge and `@v1-rc` advance, a path-watched commit on a fork with Issues disabled should produce a yellow run with the warning annotation and all downstream jobs skipped; enabling Issues on the same fork and repeating should produce normal behavior.

#### Changelog input

```
 release-note
RA workflow now skips with a warning annotation on repositories with GitHub Issues disabled (e.g. personal forks), instead of failing.
```

#### Additional documentation 

This section can be blank.

```
docs

```
