### PR TITLE
validation: workflow-summary bullets and hint→suggestion rename

### DIFF
--- a/documentation/validation/problem-messages.md
+++ b/documentation/validation/problem-messages.md
@@ -16,11 +16,12 @@ code/API_definitions/sample-service.yaml  line 130
 [S-002] There must be no request body for Get and DELETE
 ```
 
-The same problem in the workflow summary appears as a row in a table:
+The same problem in the workflow summary appears as a bullet under a rule block. All hits of the same rule share one block, with one bold subject line and one bullet per occurrence. When the rule supplies a suggested fix, it is shown once at the end as a `Suggestion:` blockquote:
 
-| Rule | Path | Line | Message |
-|---|---|---|---|
-| S-002 | code/API_definitions/sample-service.yaml | 130 | There must be no request body for Get and DELETE |
+```markdown
+**[S-002] Request body present on GET / DELETE — 1 hit**
+- code/API_definitions/sample-service.yaml:130 — [S-002] There must be no request body for Get and DELETE
+```
 
 Both views show the same information in different ways. Across both, every problem carries:
 
@@ -28,7 +29,7 @@ Both views show the same information in different ways. Across both, every probl
 - a **rule code** in square brackets, for example `[S-002]`
 - a **source file and line**, when a single line applies
 - a one-sentence **message** describing the problem
-- sometimes a **suggested fix or link**, shown after a `Hint:` label in the annotation
+- sometimes a **suggested fix or link**, shown after a `Suggestion:` label
 
 Annotations also include a short title shown above the message.
 
@@ -46,7 +47,7 @@ Severity is a property of every problem, but the way it is shown depends on wher
 | **warning** | The check still passes, but the problem will need attention before a stable release. Plan to fix it. |
 | **hint** | Informational. May indicate a future requirement, an item to verify, or a benign pattern. Read the message before acting. |
 
-Note: the severity `hint` is unrelated to the `Hint:` label that may appear inside a problem message. The label introduces the suggested-fix line described above; the severity says how seriously to take the problem.
+Note: the severity `hint` is the rendered category for informational findings. The suggested-fix line described above is introduced by the separate `Suggestion:` label, which never appears as a severity. The underlying rule-metadata field that supplies the suggested-fix text is still named `hint` internally for backward compatibility, but it is no longer rendered with a `Hint:` prefix.
 
 Errors should not be left on `main` intentionally. During the pilot, GitHub may not technically block every pull request merge on validation errors, but errors will block `/create-snapshot` and the release process.
 

--- a/documentation/validation/problem-messages.md
+++ b/documentation/validation/problem-messages.md
@@ -47,8 +47,6 @@ Severity is a property of every problem, but the way it is shown depends on wher
 | **warning** | The check still passes, but the problem will need attention before a stable release. Plan to fix it. |
 | **hint** | Informational. May indicate a future requirement, an item to verify, or a benign pattern. Read the message before acting. |
 
-Note: the severity `hint` is the rendered category for informational findings. The suggested-fix line described above is introduced by the separate `Suggestion:` label, which never appears as a severity. The underlying rule-metadata field that supplies the suggested-fix text is still named `hint` internally for backward compatibility, but it is no longer rendered with a `Hint:` prefix.
-
 Errors should not be left on `main` intentionally. During the pilot, GitHub may not technically block every pull request merge on validation errors, but errors will block `/create-snapshot` and the release process.
 
 A few rules adjust severity by context. For example, missing test files are a hint on alpha releases but an error on stable releases. The FAQ entry for those rules explains when this happens.

--- a/documentation/validation/where-to-see-results.md
+++ b/documentation/validation/where-to-see-results.md
@@ -16,7 +16,7 @@ The check entry is named:
 CAMARA Validation / validation / Validate (pull_request)
 ```
 
-Click **Details** on the entry, then open the **Summary** tab on the run page. The workflow summary lists every problem in a table, grouped by check kind, with rule code, source file, line, message, and optional hint.
+Click **Details** on the entry, then open the **Summary** tab on the run page. The workflow summary lists every problem grouped by severity, with one block per rule: a bold subject line, one bullet per occurrence (`path:line — [rule-code] message`), and a single `Suggestion:` blockquote at the end carrying the suggested fix. The same findings are also written as `findings.tsv` and `findings.json` to the `validation-diagnostics` artifact attached to the workflow run, useful for spreadsheet review or pasting many rows at once.
 
 ![Single row from the workflow summary table showing rule S-002, the source file path, line 130, and the message "There must be no request body for Get and DELETE"](images/workflow-summary-row.png)
 

--- a/validation/orchestrator.py
+++ b/validation/orchestrator.py
@@ -419,11 +419,14 @@ def write_outputs(
     )
 
     # --- Workflow summary ---
+    # ``diagnostics_written=True`` because ``write_diagnostics`` is
+    # invoked unconditionally below in this same run.
     summary_result = generate_workflow_summary(
         post_filter_result,
         context,
         engine_statuses=engine_statuses,
         commit_sha=commit_sha,
+        diagnostics_written=True,
     )
     (output_dir / "summary.md").write_text(summary_result.markdown)
     if summary_result.truncated:

--- a/validation/output/annotations.py
+++ b/validation/output/annotations.py
@@ -98,7 +98,7 @@ def _build_command(finding: dict) -> str:
     message = f"[{rule_label}] {full_message}"
     hint = finding.get("hint")
     if hint:
-        message = f"{message} | Hint: {hint}"
+        message = f"{message} | Suggestion: {hint}"
 
     # Build parameter string
     params = f"file={path},line={line}"

--- a/validation/output/annotations.py
+++ b/validation/output/annotations.py
@@ -96,9 +96,9 @@ def _build_command(finding: dict) -> str:
     title = resolve_annotation_title(finding)
     full_message = finding.get("message", "")
     message = f"[{rule_label}] {full_message}"
-    hint = finding.get("hint")
-    if hint:
-        message = f"{message} | Suggestion: {hint}"
+    suggestion = finding.get("suggestion")
+    if suggestion:
+        message = f"{message} | Suggestion: {suggestion}"
 
     # Build parameter string
     params = f"file={path},line={line}"

--- a/validation/output/check_run.py
+++ b/validation/output/check_run.py
@@ -97,7 +97,7 @@ def _build_annotation(finding: dict) -> dict:
     message = f"[{rule_label}] {full_message}"
     hint = finding.get("hint")
     if hint:
-        message = f"{message}\n\nHint: {hint}"
+        message = f"{message}\n\nSuggestion: {hint}"
 
     return {
         "path": path,

--- a/validation/output/check_run.py
+++ b/validation/output/check_run.py
@@ -95,9 +95,9 @@ def _build_annotation(finding: dict) -> dict:
     title = resolve_annotation_title(finding)
     full_message = finding.get("message", "")
     message = f"[{rule_label}] {full_message}"
-    hint = finding.get("hint")
-    if hint:
-        message = f"{message}\n\nSuggestion: {hint}"
+    suggestion = finding.get("suggestion")
+    if suggestion:
+        message = f"{message}\n\nSuggestion: {suggestion}"
 
     return {
         "path": path,

--- a/validation/output/diagnostics.py
+++ b/validation/output/diagnostics.py
@@ -22,7 +22,7 @@ from validation.postfilter.engine import PostFilterResult
 from .formatting import count_findings, format_rule_label
 
 # TSV columns (header row + per-finding rows).
-_TSV_COLUMNS = ("rule", "file", "line", "level", "message", "hint")
+_TSV_COLUMNS = ("rule", "file", "line", "level", "message", "suggestion")
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def _write_findings_tsv(findings: List[dict], path: Path) -> None:
             f.get("line", 0),
             f.get("level", "") or "",
             f.get("message", "") or "",
-            f.get("hint", "") or "",
+            f.get("suggestion", "") or "",
         )
         lines.append("\t".join(_sanitize_tsv_field(v) for v in row))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/validation/output/diagnostics.py
+++ b/validation/output/diagnostics.py
@@ -1,9 +1,9 @@
 """Diagnostic artifact writing.
 
 Writes the full (untruncated) findings list, validation context, summary
-metadata, and optional engine reports to JSON files in a specified
-directory.  The workflow step uploads this directory via
-``actions/upload-artifact``.
+metadata, a tab-separated ``findings.tsv`` for spreadsheet review, and
+optional engine reports to a specified directory.  The workflow step
+uploads this directory via ``actions/upload-artifact``.
 
 Design doc references:
   - Section 9.5: diagnostic artifacts (always available regardless of token)
@@ -19,7 +19,10 @@ from typing import Any, Dict, List, Optional
 from validation.context import ValidationContext
 from validation.postfilter.engine import PostFilterResult
 
-from .formatting import count_findings
+from .formatting import count_findings, format_rule_label
+
+# TSV columns (header row + per-finding rows).
+_TSV_COLUMNS = ("rule", "file", "line", "level", "message", "hint")
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +41,7 @@ def write_diagnostics(
       - ``findings.json`` — full findings list (no truncation)
       - ``context.json`` — serialised validation context
       - ``summary.json`` — result, summary string, and aggregate counts
+      - ``findings.tsv`` — full findings as tab-separated rows
       - ``engine-reports.json`` — raw engine reports (only when provided)
 
     Args:
@@ -89,6 +93,11 @@ def write_diagnostics(
     )
     written.append(summary_path)
 
+    # findings.tsv
+    tsv_path = output_dir / "findings.tsv"
+    _write_findings_tsv(post_filter_result.findings, tsv_path)
+    written.append(tsv_path)
+
     # engine-reports.json (optional)
     if engine_reports is not None:
         reports_path = output_dir / "engine-reports.json"
@@ -100,3 +109,35 @@ def write_diagnostics(
 
     logger.info("Wrote %d diagnostic files to %s", len(written), output_dir)
     return written
+
+
+def _sanitize_tsv_field(value: Any) -> str:
+    """Return *value* with tab and newline characters replaced by spaces.
+
+    TSV has no quoting convention, so tabs and newlines in field values
+    must be flattened to keep the row alignment intact.
+    """
+    text = "" if value is None else str(value)
+    return text.replace("\t", " ").replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+
+
+def _write_findings_tsv(findings: List[dict], path: Path) -> None:
+    """Write the full findings list as a tab-separated table.
+
+    Header row matches :data:`_TSV_COLUMNS`.  Rule code uses
+    :func:`format_rule_label` (same as the workflow summary and
+    annotation surfaces).  Other fields come straight from each
+    finding dict; tabs and newlines inside fields are sanitized.
+    """
+    lines = ["\t".join(_TSV_COLUMNS)]
+    for f in findings:
+        row = (
+            format_rule_label(f),
+            f.get("path", "") or "",
+            f.get("line", 0),
+            f.get("level", "") or "",
+            f.get("message", "") or "",
+            f.get("hint", "") or "",
+        )
+        lines.append("\t".join(_sanitize_tsv_field(v) for v in row))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -181,11 +181,11 @@ def _render_rule_block(rule_id: str, findings: List[dict]) -> str:
         message = (f.get("message", "") or "").replace("\n", " ")
         out.append(f"- {location} — [{rule_id}] {message}")
 
-    hint = (findings[0].get("hint") or "").strip()
-    if hint:
-        hint_lines = hint.splitlines() or [hint]
-        out.append(f"> Suggestion: {hint_lines[0]}")
-        for cont in hint_lines[1:]:
+    suggestion = (findings[0].get("suggestion") or "").strip()
+    if suggestion:
+        suggestion_lines = suggestion.splitlines() or [suggestion]
+        out.append(f"> Suggestion: {suggestion_lines[0]}")
+        for cont in suggestion_lines[1:]:
             out.append(f"> {cont}")
 
     return "\n".join(out)

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -1,7 +1,8 @@
 """Workflow summary generation for ``$GITHUB_STEP_SUMMARY``.
 
 Produces a Markdown string with header, engine summary table, findings
-tables grouped by severity level, and footer.
+sections grouped by severity (rule-grouped bullets within each), an
+optional artifact footnote, and footer.
 Implements 900 KB truncation with priority ordering (errors are never
 truncated).
 
@@ -23,7 +24,9 @@ from .formatting import (
     REPO_LEVEL_LABEL,
     count_findings,
     count_findings_by_engine,
+    format_finding_location,
     format_rule_label,
+    resolve_annotation_title,
     sort_findings_by_priority,
 )
 
@@ -41,6 +44,8 @@ _RESULT_LABEL = {
     "error": "ERROR",
     "advisory": "ADVISORY",
 }
+
+_DIAGNOSTICS_ARTIFACT = "validation-diagnostics"
 
 # ---------------------------------------------------------------------------
 # Result type
@@ -146,31 +151,80 @@ def _render_engine_summary_table(
     return "\n".join(lines)
 
 
-def _render_findings_table(
+def _group_by_rule(findings: List[dict]) -> "Dict[str, List[dict]]":
+    """Group findings by ``rule_id`` (or engine_rule fallback).
+
+    Returns a dict in first-seen order — under the upstream
+    ``sort_findings_by_priority`` ordering this naturally clusters
+    each rule's hits together when one rule dominates a file.
+    """
+    groups: "Dict[str, List[dict]]" = {}
+    for f in findings:
+        rid = format_rule_label(f)
+        groups.setdefault(rid, []).append(f)
+    return groups
+
+
+def _render_rule_block(rule_id: str, findings: List[dict]) -> str:
+    """Render one rule's block: bold subject line, bullets, suggestion.
+
+    Spacing is intentional: no blank lines inside the block, so the
+    bullet list stays tight in the GitHub-flavoured Markdown renderer.
+    """
+    subject = resolve_annotation_title(findings[0])
+    n = len(findings)
+    plural = "hits" if n != 1 else "hit"
+
+    out: List[str] = [f"**[{rule_id}] {subject} — {n} {plural}**"]
+    for f in findings:
+        location = format_finding_location(f)
+        message = (f.get("message", "") or "").replace("\n", " ")
+        out.append(f"- {location} — [{rule_id}] {message}")
+
+    hint = (findings[0].get("hint") or "").strip()
+    if hint:
+        hint_lines = hint.splitlines() or [hint]
+        out.append(f"> Suggestion: {hint_lines[0]}")
+        for cont in hint_lines[1:]:
+            out.append(f"> {cont}")
+
+    return "\n".join(out)
+
+
+def _render_findings_section(
     findings: List[dict],
     level_label: str,
 ) -> str:
-    """Render a findings table for a single severity level.
+    """Render a findings section for a single severity level.
 
     Returns an empty string if there are no findings at this level.
     """
     if not findings:
         return ""
 
-    lines = [
-        f"\n### {level_label}\n",
-        "| Rule | File | Line | Message | Hint |",
-        "|------|------|------|---------|------|",
+    blocks = [
+        _render_rule_block(rid, group)
+        for rid, group in _group_by_rule(findings).items()
     ]
-    for f in findings:
-        rule = format_rule_label(f)
-        path = f.get("path", "")
-        line = f.get("line", 0)
-        message = f.get("message", "").replace("|", "\\|")
-        hint = (f.get("hint") or "").replace("|", "\\|")
-        lines.append(f"| {rule} | {path} | {line} | {message} | {hint} |")
-    lines.append("")
-    return "\n".join(lines)
+    return (
+        f"\n### {level_label} ({len(findings)})\n\n"
+        + "\n\n".join(blocks)
+        + "\n"
+    )
+
+
+def _render_artifact_footnote() -> str:
+    """Render the artifact-pointer footnote.
+
+    Tells the reader where to find the full TSV / JSON findings —
+    handy for spreadsheet review or pasting many rows at once.
+    """
+    return (
+        f"\n> Full findings are also available as `findings.tsv` and "
+        f"`findings.json` in the workflow's `{_DIAGNOSTICS_ARTIFACT}` "
+        f"artifact — useful for spreadsheet review or pasting many "
+        f"rows at once.\n"
+    )
 
 
 def _render_footer(
@@ -218,6 +272,7 @@ def generate_workflow_summary(
     context: ValidationContext,
     engine_statuses: Optional[Dict[str, str]] = None,
     commit_sha: str = "",
+    diagnostics_written: bool = False,
 ) -> SummaryResult:
     """Generate the full workflow summary Markdown.
 
@@ -230,6 +285,11 @@ def generate_workflow_summary(
         context: Unified validation context.
         engine_statuses: Optional mapping of engine name to status string.
         commit_sha: Full commit SHA (first 7 chars shown in footer).
+        diagnostics_written: When ``True`` the rendered summary includes
+            a footnote pointing at the diagnostics artifact.  The
+            orchestrator sets this when it calls
+            :func:`validation.output.diagnostics.write_diagnostics`
+            in the same run.
 
     Returns:
         :class:`SummaryResult` with the complete Markdown and truncation info.
@@ -245,10 +305,14 @@ def generate_workflow_summary(
     # Fixed sections (always rendered)
     header = _render_header(post_filter_result.result, context, findings)
     engine_summary = _render_engine_summary_table(findings, engine_statuses)
+    artifact_footnote = (
+        _render_artifact_footnote() if diagnostics_written else ""
+    )
     footer = _render_footer(context, commit_sha)
 
     fixed_size = sum(
-        _byte_size(s) for s in (header, engine_summary, footer)
+        _byte_size(s)
+        for s in (header, engine_summary, artifact_footnote, footer)
     )
 
     # Budget for findings sections
@@ -257,16 +321,18 @@ def generate_workflow_summary(
     truncation_note = ""
 
     # Errors section — never truncated
-    errors_section = _render_findings_table(errors, "Errors")
+    errors_section = _render_findings_section(errors, "Errors")
     budget -= _byte_size(errors_section)
 
     # Warnings section — truncated if over budget
-    warnings_section = _render_findings_table(warnings, "Warnings")
+    warnings_section = _render_findings_section(warnings, "Warnings")
     if budget - _byte_size(warnings_section) < 0 and warnings:
         # Find how many warnings fit
         shown = _fit_count(warnings, "Warnings", budget)
         if shown > 0:
-            warnings_section = _render_findings_table(warnings[:shown], "Warnings")
+            warnings_section = _render_findings_section(
+                warnings[:shown], "Warnings"
+            )
             warnings_section += _truncation_notice(
                 shown, len(warnings), "Warnings"
             )
@@ -277,11 +343,11 @@ def generate_workflow_summary(
     budget -= _byte_size(warnings_section)
 
     # Hints section — truncated if over budget
-    hints_section = _render_findings_table(hints, "Hints")
+    hints_section = _render_findings_section(hints, "Hints")
     if budget - _byte_size(hints_section) < 0 and hints:
         shown = _fit_count(hints, "Hints", budget)
         if shown > 0:
-            hints_section = _render_findings_table(hints[:shown], "Hints")
+            hints_section = _render_findings_section(hints[:shown], "Hints")
             hints_section += _truncation_notice(shown, len(hints), "Hints")
         else:
             hints_section = _truncation_notice(0, len(hints), "Hints")
@@ -298,6 +364,7 @@ def generate_workflow_summary(
         + errors_section
         + warnings_section
         + hints_section
+        + artifact_footnote
         + footer
     )
 
@@ -321,7 +388,7 @@ def _fit_count(
         return 0
 
     # Quick check: does the full section fit?
-    full = _render_findings_table(findings, level_label)
+    full = _render_findings_section(findings, level_label)
     if _byte_size(full) <= budget:
         return len(findings)
 
@@ -329,7 +396,7 @@ def _fit_count(
     lo, hi = 0, len(findings)
     while lo < hi:
         mid = (lo + hi + 1) // 2
-        section = _render_findings_table(findings[:mid], level_label)
+        section = _render_findings_section(findings[:mid], level_label)
         notice = _truncation_notice(mid, len(findings), level_label)
         if _byte_size(section) + _byte_size(notice) <= budget:
             lo = mid

--- a/validation/postfilter/engine.py
+++ b/validation/postfilter/engine.py
@@ -36,7 +36,7 @@ class PostFilterResult:
     """Result of post-filter processing.
 
     Attributes:
-        findings: Processed findings with resolved level, optional hint, blocks.
+        findings: Processed findings with resolved level, optional suggestion, blocks.
         result: Overall verdict — ``"pass"``, ``"fail"``, or ``"error"``.
         summary: Human-readable one-line summary.
     """
@@ -109,9 +109,9 @@ def _enrich_finding(
     When *resolved_level* is ``None`` (identity-only entry without
     ``conditional_level``), the engine's original level is preserved.
     When *message_override* is set, the finding's message is replaced.
-    When *hint* is set, it is added to the finding as additional guidance.
-    When neither is set, the engine's original message is preserved and
-    no hint is added.
+    When *suggestion* is set, it is added to the finding as additional
+    guidance.  When neither is set, the engine's original message is
+    preserved and no suggestion is added.
     """
     enriched = dict(finding)
     enriched["rule_id"] = rule.id
@@ -119,15 +119,15 @@ def _enrich_finding(
         enriched["level"] = resolved_level
     if rule.message_override is not None:
         enriched["message"] = rule.message_override
-    if rule.hint is not None:
-        enriched["hint"] = rule.hint
+    if rule.suggestion is not None:
+        enriched["suggestion"] = rule.suggestion
     if rule.short_title is not None:
         enriched["short_title"] = rule.short_title
     return enriched
 
 
 def _passthrough_finding(finding: dict) -> dict:
-    """Create a pass-through copy: keep engine level, no hint added."""
+    """Create a pass-through copy: keep engine level, no suggestion added."""
     return dict(finding)
 
 
@@ -210,10 +210,10 @@ def run_post_filter(
     2. Look up ``(engine, engine_rule)`` in the metadata index.
     3. **Mapped rule**: evaluate applicability (remove if not applicable),
        resolve conditional level (remove if ``"muted"``), enrich with
-       ``rule_id``, optional ``message_override``/``hint``, and
+       ``rule_id``, optional ``message_override``/``suggestion``, and
        adjusted ``level``.
     4. **Unmapped rule** (pass-through): keep engine severity and
-       message, no hint added.
+       message, no suggestion added.
     5. Apply profile blocking to all surviving findings.
     6. Compute overall result.
 

--- a/validation/postfilter/metadata_loader.py
+++ b/validation/postfilter/metadata_loader.py
@@ -74,8 +74,9 @@ class RuleMetadata:
         engine_rule: Native rule identifier within the engine.
         message_override: Replaces the engine's finding message.  ``None``
             means keep the engine message.
-        hint: Additional fix guidance shown alongside the message.  ``None``
-            means no extra hint.
+        suggestion: Additional fix guidance shown alongside the message
+            (rendered under a ``Suggestion:`` label).  ``None`` means
+            no extra guidance.
         applicability: Condition dict — omitted fields are unconstrained.
         conditional_level: Severity specification, or ``None`` to preserve
             engine-reported severity (identity mapping).
@@ -90,7 +91,7 @@ class RuleMetadata:
     engine: str
     engine_rule: str
     message_override: Optional[str]
-    hint: Optional[str]
+    suggestion: Optional[str]
     applicability: dict
     conditional_level: Optional[ConditionalLevel]
     short_title: Optional[str] = None
@@ -164,7 +165,7 @@ def parse_rule_metadata(raw: dict) -> RuleMetadata:
         engine=raw["engine"],
         engine_rule=raw["engine_rule"],
         message_override=raw.get("message_override"),
-        hint=raw.get("hint"),
+        suggestion=raw.get("suggestion"),
         applicability=raw.get("applicability", {}),
         conditional_level=conditional_level,
         short_title=raw.get("short_title"),

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -28,7 +28,7 @@
       - condition:
           target_api_status: [draft]
         level: hint
-  hint: >-
+  suggestion: >-
     Spec file not yet present. For draft entries this is acceptable;
     add the spec file before advancing target_api_status to alpha.
 
@@ -77,7 +77,7 @@
           target_api_maturity: [initial]
           target_release_type: [pre-release-rc, public-release]
         level: warn
-  hint: >-
+  suggestion: >-
     Test files are optional for alpha releases but expected before the
     first release candidate. On stable (>=1.x) APIs they are required
     at rc and public release; on initial (0.x) APIs they are strongly
@@ -192,7 +192,7 @@
       - condition:
           api_pattern: [implicit-subscription]
         level: warn
-  hint: >-
+  suggestion: >-
     Define a named event type schema (e.g. ApiEventType) that constrains
     the CloudEvent `type` value via allOf, rather than inlining the enum
     directly in CloudEvent.properties.type.enum. See the implicit-events
@@ -260,7 +260,7 @@
     is_release_review_pr: false
   conditional_level:
     default: warn
-  hint: >-
+  suggestion: >-
     Replace the local CloudEvent schema with
     `$ref: './CAMARA_event_common.yaml#/components/schemas/CloudEvent'`,
     or an allOf combining the $ref with an API-specific ApiEventType
@@ -285,7 +285,7 @@
       - condition:
           trigger_types: [release-automation]
         level: error
-  hint: >-
+  suggestion: >-
     `code/common/` is managed by the sync mechanism. If your PR diff
     includes manual edits to `code/common/`, revert them. If your branch
     is missing files that should be present, merge `main` into your
@@ -306,7 +306,7 @@
     release_plan_changed: true
   conditional_level:
     default: error
-  hint: >-
+  suggestion: >-
     Split this PR: keep release-plan.yaml changes in a dedicated PR,
     and move the other listed files to a separate PR.
 

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -127,7 +127,7 @@
   engine: spectral
   engine_rule: camara-response-403
   short_title: "Operation must document a 403 response"
-  hint: "All operations must document a 403 Forbidden response (CAMARA Design Guide section 3.2)."
+  suggestion: "All operations must document a 403 Forbidden response (CAMARA Design Guide section 3.2)."
 
 - id: S-025
   engine: spectral
@@ -262,7 +262,7 @@
   engine: spectral
   engine_rule: oas3-unused-component
   short_title: "Component may be unused"
-  hint: "Spectral does not follow discriminator mappings — verify the schema is truly unused."
+  suggestion: "Spectral does not follow discriminator mappings — verify the schema is truly unused."
   conditional_level:
     default: hint
 
@@ -357,7 +357,7 @@
   engine: spectral
   engine_rule: "owasp:api1:2023-no-numeric-ids"
   short_title: "Use non-numeric resource IDs"
-  hint: "Use non-numeric (e.g. string) resource identifiers to prevent enumeration attacks."
+  suggestion: "Use non-numeric (e.g. string) resource identifiers to prevent enumeration attacks."
 
 - id: S-301
   engine: spectral
@@ -393,7 +393,7 @@
   engine: spectral
   engine_rule: "owasp:api8:2023-define-error-responses-401"
   short_title: "Operation must document a 401 response"
-  hint: "All secured operations must document a 401 Unauthorized response (CAMARA Design Guide section 3.2)."
+  suggestion: "All secured operations must document a 401 Unauthorized response (CAMARA Design Guide section 3.2)."
 
 - id: S-308
   engine: spectral
@@ -404,31 +404,31 @@
   engine: spectral
   engine_rule: "owasp:api4:2023-array-limit"
   short_title: "Array must declare maxItems"
-  hint: "Add maxItems to constrain array size (CAMARA Design Guide section 2.2)."
+  suggestion: "Add maxItems to constrain array size (CAMARA Design Guide section 2.2)."
 
 - id: S-310
   engine: spectral
   engine_rule: "owasp:api4:2023-integer-format"
   short_title: "Integer must declare int32 or int64 format"
-  hint: "Add format: int32 or int64 to integer properties (CAMARA Design Guide section 2.2)."
+  suggestion: "Add format: int32 or int64 to integer properties (CAMARA Design Guide section 2.2)."
 
 - id: S-311
   engine: spectral
   engine_rule: "owasp:api4:2023-integer-limit-legacy"
   short_title: "Integer must declare minimum and maximum"
-  hint: "Add minimum and maximum to integer properties (CAMARA Design Guide section 2.2)."
+  suggestion: "Add minimum and maximum to integer properties (CAMARA Design Guide section 2.2)."
 
 - id: S-312
   engine: spectral
   engine_rule: "owasp:api4:2023-string-limit"
   short_title: "String must declare maxLength, enum, or const"
-  hint: "Add maxLength, enum, or const to string properties (CAMARA Design Guide section 2.2)."
+  suggestion: "Add maxLength, enum, or const to string properties (CAMARA Design Guide section 2.2)."
 
 - id: S-313
   engine: spectral
   engine_rule: "owasp:api4:2023-string-restricted"
   short_title: "String has no format/pattern/enum"
-  hint: "Acceptable if free-form field or implementation-dependent — no fix needed."
+  suggestion: "Acceptable if free-form field or implementation-dependent — no fix needed."
   conditional_level:
     default: hint
   # Known-unactionable locations in the Commonalities common library.
@@ -485,7 +485,7 @@
   engine: spectral
   engine_rule: "owasp:api8:2023-define-error-validation"
   short_title: "Operation must document a 400/422 response"
-  hint: "Document 400 or 422 error responses for input validation (CAMARA Design Guide section 3.2)."
+  suggestion: "Document 400 or 422 error responses for input validation (CAMARA Design Guide section 3.2)."
 
 - id: S-319
   engine: spectral

--- a/validation/schemas/rule-metadata-schema.yaml
+++ b/validation/schemas/rule-metadata-schema.yaml
@@ -61,12 +61,13 @@ properties:
       engine message is misleading or unhelpful.  Optional — when
       omitted, the engine message is preserved.
 
-  hint:
+  suggestion:
     type: string
     description: >
-      Additional fix guidance rendered alongside the finding message.
-      Optional — only set when there is "how to fix" guidance beyond
-      what the message already says.
+      Additional fix guidance rendered alongside the finding message
+      (under a `Suggestion:` label in annotations and the workflow
+      summary).  Optional — only set when there is "how to fix"
+      guidance beyond what the message already says.
 
   applicability:
     type: object

--- a/validation/tests/test_output_annotations.py
+++ b/validation/tests/test_output_annotations.py
@@ -163,12 +163,12 @@ class TestBuildCommand:
     def test_hint_appended(self):
         f = _make_finding(message="Bad path", hint="Use kebab-case")
         cmd = _build_command(f)
-        assert "Bad path | Hint%3A Use kebab-case" in cmd
+        assert "Bad path | Suggestion%3A Use kebab-case" in cmd
 
     def test_no_hint(self):
         f = _make_finding(message="Bad path")
         cmd = _build_command(f)
-        assert "Hint" not in cmd
+        assert "Suggestion" not in cmd
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_output_annotations.py
+++ b/validation/tests/test_output_annotations.py
@@ -23,7 +23,7 @@ def _make_finding(
     line: int = 10,
     column: int | None = None,
     message: str = "Something is wrong",
-    hint: str | None = None,
+    suggestion: str | None = None,
     rule_id: str | None = None,
     engine_rule: str = "some-rule",
     api_name: str | None = "quality-on-demand",
@@ -44,8 +44,8 @@ def _make_finding(
         f["column"] = column
     if rule_id is not None:
         f["rule_id"] = rule_id
-    if hint is not None:
-        f["hint"] = hint
+    if suggestion is not None:
+        f["suggestion"] = suggestion
     if short_title is not None:
         f["short_title"] = short_title
     return f
@@ -160,12 +160,12 @@ class TestBuildCommand:
         cmd = _build_command(f)
         assert "[camara-path-casing] Bad path" in cmd
 
-    def test_hint_appended(self):
-        f = _make_finding(message="Bad path", hint="Use kebab-case")
+    def test_suggestion_appended(self):
+        f = _make_finding(message="Bad path", suggestion="Use kebab-case")
         cmd = _build_command(f)
         assert "Bad path | Suggestion%3A Use kebab-case" in cmd
 
-    def test_no_hint(self):
+    def test_no_suggestion(self):
         f = _make_finding(message="Bad path")
         cmd = _build_command(f)
         assert "Suggestion" not in cmd

--- a/validation/tests/test_output_check_run.py
+++ b/validation/tests/test_output_check_run.py
@@ -47,7 +47,7 @@ def _make_finding(
     message: str = "Something is wrong",
     rule_id: str | None = None,
     engine_rule: str = "some-rule",
-    hint: str | None = None,
+    suggestion: str | None = None,
     short_title: str | None = None,
 ) -> dict:
     f: dict = {
@@ -62,8 +62,8 @@ def _make_finding(
     }
     if rule_id is not None:
         f["rule_id"] = rule_id
-    if hint is not None:
-        f["hint"] = hint
+    if suggestion is not None:
+        f["suggestion"] = suggestion
     if short_title is not None:
         f["short_title"] = short_title
     return f
@@ -222,8 +222,8 @@ class TestAnnotationContent:
         )
         assert "Bad pattern" in payload.annotations[0]["message"]
 
-    def test_hint_appended_to_message(self):
-        findings = [_make_finding(message="Bad", hint="Use kebab-case")]
+    def test_suggestion_appended_to_message(self):
+        findings = [_make_finding(message="Bad", suggestion="Use kebab-case")]
         payload = generate_check_run_payload(
             _make_result(findings), _make_context(),
         )

--- a/validation/tests/test_output_check_run.py
+++ b/validation/tests/test_output_check_run.py
@@ -229,7 +229,7 @@ class TestAnnotationContent:
         )
         msg = payload.annotations[0]["message"]
         assert "Bad" in msg
-        assert "Hint: Use kebab-case" in msg
+        assert "Suggestion: Use kebab-case" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_output_diagnostics.py
+++ b/validation/tests/test_output_diagnostics.py
@@ -73,7 +73,12 @@ class TestWriteDiagnostics:
         out = tmp_path / "output"
         paths = write_diagnostics(_make_result(), _make_context(), out)
         names = {p.name for p in paths}
-        assert names == {"findings.json", "context.json", "summary.json"}
+        assert names == {
+            "findings.json",
+            "context.json",
+            "summary.json",
+            "findings.tsv",
+        }
 
     def test_findings_json_content(self, tmp_path: Path):
         findings = [_make_finding(level="error"), _make_finding(level="warn")]
@@ -123,7 +128,7 @@ class TestWriteDiagnostics:
         out = tmp_path / "output"
         paths = write_diagnostics(_make_result(), _make_context(), out)
         assert not (out / "engine-reports.json").exists()
-        assert len(paths) == 3
+        assert len(paths) == 4
 
     def test_empty_findings(self, tmp_path: Path):
         out = tmp_path / "output"
@@ -143,3 +148,122 @@ class TestWriteDiagnostics:
         paths = write_diagnostics(_make_result(), _make_context(), out)
         assert all(isinstance(p, Path) for p in paths)
         assert all(p.exists() for p in paths)
+
+
+class TestFindingsTsv:
+    def test_header_row(self, tmp_path: Path):
+        out = tmp_path / "output"
+        write_diagnostics(_make_result(), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        first_line = text.splitlines()[0]
+        assert first_line == "rule\tfile\tline\tlevel\tmessage\thint"
+
+    def test_row_per_finding(self, tmp_path: Path):
+        findings = [
+            _make_finding(level="error"),
+            _make_finding(level="warn"),
+            _make_finding(level="hint"),
+        ]
+        out = tmp_path / "output"
+        write_diagnostics(_make_result(findings), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        # Header + 3 rows + trailing newline → 4 non-empty lines
+        rows = [line for line in text.splitlines() if line.strip()]
+        assert len(rows) == 4
+
+    def test_field_values_present(self, tmp_path: Path):
+        findings = [
+            {
+                "engine": "spectral",
+                "engine_rule": "camara-x",
+                "rule_id": "S-042",
+                "level": "error",
+                "message": "Bad path",
+                "path": "spec.yaml",
+                "line": 47,
+                "api_name": None,
+                "blocks": True,
+                "hint": "Use kebab-case",
+            }
+        ]
+        out = tmp_path / "output"
+        write_diagnostics(_make_result(findings), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        # Row carries each column value, tab-separated
+        assert "S-042\tspec.yaml\t47\terror\tBad path\tUse kebab-case" in text
+
+    def test_tab_in_field_sanitized(self, tmp_path: Path):
+        findings = [
+            {
+                "engine": "spectral",
+                "engine_rule": "camara-x",
+                "rule_id": "S-001",
+                "level": "warn",
+                "message": "left\tright",
+                "path": "a.yaml",
+                "line": 10,
+                "api_name": None,
+                "blocks": False,
+            }
+        ]
+        out = tmp_path / "output"
+        write_diagnostics(_make_result(findings), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        # Tab inside the message must be flattened to a single space —
+        # the row must still split into exactly 6 columns on `\t`.
+        data_row = text.splitlines()[1]
+        assert data_row.count("\t") == 5
+        assert "left right" in data_row
+
+    def test_newline_in_field_sanitized(self, tmp_path: Path):
+        findings = [
+            {
+                "engine": "spectral",
+                "engine_rule": "camara-x",
+                "rule_id": "S-001",
+                "level": "warn",
+                "message": "first\nsecond",
+                "path": "a.yaml",
+                "line": 10,
+                "api_name": None,
+                "blocks": False,
+            }
+        ]
+        out = tmp_path / "output"
+        write_diagnostics(_make_result(findings), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        # Newline inside message must not break the row — header + 1 data row.
+        rows = [line for line in text.splitlines() if line.strip()]
+        assert len(rows) == 2
+        assert "first second" in rows[1]
+
+    def test_empty_findings(self, tmp_path: Path):
+        out = tmp_path / "output"
+        write_diagnostics(_make_result([]), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        # Header only.
+        rows = [line for line in text.splitlines() if line.strip()]
+        assert len(rows) == 1
+        assert rows[0] == "rule\tfile\tline\tlevel\tmessage\thint"
+
+    def test_missing_optional_fields(self, tmp_path: Path):
+        # Finding without `hint` field — TSV row writes empty string.
+        findings = [
+            {
+                "engine": "spectral",
+                "engine_rule": "camara-x",
+                "level": "warn",
+                "message": "msg",
+                "path": "a.yaml",
+                "line": 10,
+                "api_name": None,
+                "blocks": False,
+            }
+        ]
+        out = tmp_path / "output"
+        write_diagnostics(_make_result(findings), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        data_row = text.splitlines()[1]
+        # 5 tabs → 6 columns, last column (hint) is empty.
+        assert data_row.count("\t") == 5
+        assert data_row.endswith("msg\t")

--- a/validation/tests/test_output_diagnostics.py
+++ b/validation/tests/test_output_diagnostics.py
@@ -156,7 +156,7 @@ class TestFindingsTsv:
         write_diagnostics(_make_result(), _make_context(), out)
         text = (out / "findings.tsv").read_text(encoding="utf-8")
         first_line = text.splitlines()[0]
-        assert first_line == "rule\tfile\tline\tlevel\tmessage\thint"
+        assert first_line == "rule\tfile\tline\tlevel\tmessage\tsuggestion"
 
     def test_row_per_finding(self, tmp_path: Path):
         findings = [
@@ -183,7 +183,7 @@ class TestFindingsTsv:
                 "line": 47,
                 "api_name": None,
                 "blocks": True,
-                "hint": "Use kebab-case",
+                "suggestion": "Use kebab-case",
             }
         ]
         out = tmp_path / "output"
@@ -244,10 +244,10 @@ class TestFindingsTsv:
         # Header only.
         rows = [line for line in text.splitlines() if line.strip()]
         assert len(rows) == 1
-        assert rows[0] == "rule\tfile\tline\tlevel\tmessage\thint"
+        assert rows[0] == "rule\tfile\tline\tlevel\tmessage\tsuggestion"
 
     def test_missing_optional_fields(self, tmp_path: Path):
-        # Finding without `hint` field — TSV row writes empty string.
+        # Finding without `suggestion` field — TSV row writes empty string.
         findings = [
             {
                 "engine": "spectral",
@@ -264,6 +264,6 @@ class TestFindingsTsv:
         write_diagnostics(_make_result(findings), _make_context(), out)
         text = (out / "findings.tsv").read_text(encoding="utf-8")
         data_row = text.splitlines()[1]
-        # 5 tabs → 6 columns, last column (hint) is empty.
+        # 5 tabs → 6 columns, last column (suggestion) is empty.
         assert data_row.count("\t") == 5
         assert data_row.endswith("msg\t")

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -52,7 +52,7 @@ def _make_finding(
     blocks: bool = False,
     rule_id: str | None = None,
     engine_rule: str = "some-rule",
-    hint: str | None = None,
+    suggestion: str | None = None,
 ) -> dict:
     f: dict = {
         "engine": "spectral",
@@ -66,8 +66,8 @@ def _make_finding(
     }
     if rule_id is not None:
         f["rule_id"] = rule_id
-    if hint is not None:
-        f["hint"] = hint
+    if suggestion is not None:
+        f["suggestion"] = suggestion
     return f
 
 
@@ -228,7 +228,7 @@ class TestFindingsSection:
                 path="spec.yaml",
                 line=47,
                 message="Bad path",
-                hint="Use kebab-case",
+                suggestion="Use kebab-case",
             )
         ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
@@ -270,7 +270,7 @@ class TestFindingsSection:
                 path="a.yaml",
                 line=10,
                 message="Missing 401",
-                hint="Add 401",
+                suggestion="Add 401",
             ),
             _make_finding(
                 level="error",
@@ -278,7 +278,7 @@ class TestFindingsSection:
                 path="a.yaml",
                 line=20,
                 message="Missing 401",
-                hint="Add 401",
+                suggestion="Add 401",
             ),
             _make_finding(
                 level="error",
@@ -286,7 +286,7 @@ class TestFindingsSection:
                 path="b.yaml",
                 line=30,
                 message="Missing 401",
-                hint="Add 401",
+                suggestion="Add 401",
             ),
         ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
@@ -304,11 +304,11 @@ class TestFindingsSection:
         findings = [
             _make_finding(
                 level="error", rule_id="S-001", path="a.yaml", line=10,
-                message="msg-a", hint="hint-a",
+                message="msg-a", suggestion="hint-a",
             ),
             _make_finding(
                 level="error", rule_id="S-002", path="b.yaml", line=20,
-                message="msg-b", hint="hint-b",
+                message="msg-b", suggestion="hint-b",
             ),
         ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
@@ -323,11 +323,11 @@ class TestFindingsSection:
         findings = [
             _make_finding(
                 level="error", rule_id="S-001", path="a.yaml", line=10,
-                message="msg", hint="hint",
+                message="msg", suggestion="hint",
             ),
             _make_finding(
                 level="error", rule_id="S-001", path="a.yaml", line=20,
-                message="msg", hint="hint",
+                message="msg", suggestion="hint",
             ),
         ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
@@ -383,7 +383,7 @@ class TestFindingsSection:
     def test_no_suggestion_when_hint_empty(self):
         findings = [
             _make_finding(
-                level="error", rule_id="S-001", message="msg", hint=None,
+                level="error", rule_id="S-001", message="msg", suggestion=None,
             )
         ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
@@ -393,7 +393,7 @@ class TestFindingsSection:
         findings = [
             _make_finding(
                 level="error", rule_id="S-001",
-                hint="first line\nsecond line\nthird line",
+                suggestion="first line\nsecond line\nthird line",
             )
         ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -196,28 +196,31 @@ class TestEngineSummaryTable:
 
 
 # ---------------------------------------------------------------------------
-# Findings tables
+# Findings sections (rule-grouped bullets)
 # ---------------------------------------------------------------------------
 
 
-class TestFindingsTables:
-    def test_errors_section(self):
+class TestFindingsSection:
+    def test_errors_section_with_count(self):
         findings = [_make_finding(level="error", rule_id="S-001")]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
-        assert "### Errors" in sr.markdown
-        assert "S-001" in sr.markdown
+        assert "### Errors (1)" in sr.markdown
+        assert "[S-001]" in sr.markdown
 
-    def test_warnings_section(self):
-        findings = [_make_finding(level="warn")]
+    def test_warnings_section_with_count(self):
+        findings = [
+            _make_finding(level="warn", rule_id="S-001"),
+            _make_finding(level="warn", rule_id="S-002", line=20),
+        ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
-        assert "### Warnings" in sr.markdown
+        assert "### Warnings (2)" in sr.markdown
 
-    def test_hints_section(self):
+    def test_hints_section_with_count(self):
         findings = [_make_finding(level="hint")]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
-        assert "### Hints" in sr.markdown
+        assert "### Hints (1)" in sr.markdown
 
-    def test_table_columns(self):
+    def test_bullet_shape(self):
         findings = [
             _make_finding(
                 level="error",
@@ -229,17 +232,195 @@ class TestFindingsTables:
             )
         ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
-        assert "| Rule | File | Line | Message | Hint |" in sr.markdown
-        assert "S-042" in sr.markdown
-        assert "spec.yaml" in sr.markdown
-        assert "47" in sr.markdown
-        assert "Bad path" in sr.markdown
-        assert "Use kebab-case" in sr.markdown
+        # Bold subject line: "**[<RULE>] <subject> — <N> hit(s)**"
+        assert "**[S-042]" in sr.markdown
+        assert "— 1 hit**" in sr.markdown
+        # Bullet: "- <path>:<line> — [<RULE>] <message>"
+        assert "- spec.yaml:47 — [S-042] Bad path" in sr.markdown
+        # Suggestion blockquote
+        assert "> Suggestion: Use kebab-case" in sr.markdown
 
-    def test_pipe_in_message_escaped(self):
-        findings = [_make_finding(message="a|b")]
+    def test_subject_line_uses_short_title_when_present(self):
+        f = _make_finding(
+            level="error",
+            rule_id="S-042",
+            message="some long verbose message text",
+        )
+        f["short_title"] = "Bad path casing"
+        sr = generate_workflow_summary(_make_result([f]), _make_context())
+        assert "**[S-042] Bad path casing — 1 hit**" in sr.markdown
+
+    def test_subject_line_falls_back_to_message(self):
+        # No short_title → falls back to the finding message
+        findings = [
+            _make_finding(
+                level="error",
+                rule_id="S-042",
+                message="Bad path casing",
+            )
+        ]
         sr = generate_workflow_summary(_make_result(findings), _make_context())
-        assert "a\\|b" in sr.markdown
+        assert "**[S-042] Bad path casing — 1 hit**" in sr.markdown
+
+    def test_multiple_hits_one_rule_block(self):
+        findings = [
+            _make_finding(
+                level="error",
+                rule_id="S-307",
+                path="a.yaml",
+                line=10,
+                message="Missing 401",
+                hint="Add 401",
+            ),
+            _make_finding(
+                level="error",
+                rule_id="S-307",
+                path="a.yaml",
+                line=20,
+                message="Missing 401",
+                hint="Add 401",
+            ),
+            _make_finding(
+                level="error",
+                rule_id="S-307",
+                path="b.yaml",
+                line=30,
+                message="Missing 401",
+                hint="Add 401",
+            ),
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        # One subject line with the plural count
+        assert sr.markdown.count("**[S-307]") == 1
+        assert "— 3 hits**" in sr.markdown
+        # Three bullets
+        assert "- a.yaml:10 — [S-307] Missing 401" in sr.markdown
+        assert "- a.yaml:20 — [S-307] Missing 401" in sr.markdown
+        assert "- b.yaml:30 — [S-307] Missing 401" in sr.markdown
+        # Suggestion blockquote rendered exactly once for the rule
+        assert sr.markdown.count("> Suggestion: Add 401") == 1
+
+    def test_multiple_rules_separate_blocks(self):
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=10,
+                message="msg-a", hint="hint-a",
+            ),
+            _make_finding(
+                level="error", rule_id="S-002", path="b.yaml", line=20,
+                message="msg-b", hint="hint-b",
+            ),
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "**[S-001]" in sr.markdown
+        assert "**[S-002]" in sr.markdown
+        assert "> Suggestion: hint-a" in sr.markdown
+        assert "> Suggestion: hint-b" in sr.markdown
+
+    def test_no_blank_lines_inside_rule_block(self):
+        # Subject line, bullets, and suggestion blockquote run together
+        # (no blank lines) so the bullet list stays tight in GFM.
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=10,
+                message="msg", hint="hint",
+            ),
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=20,
+                message="msg", hint="hint",
+            ),
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        # Locate the rule block and its constituent lines.
+        idx_subject = sr.markdown.index("**[S-001]")
+        idx_first_bullet = sr.markdown.index("- a.yaml:10")
+        idx_last_bullet = sr.markdown.index("- a.yaml:20")
+        idx_suggestion = sr.markdown.index("> Suggestion: hint")
+        # No blank line between subject and first bullet
+        between_subject_and_bullet = sr.markdown[idx_subject:idx_first_bullet]
+        assert "\n\n" not in between_subject_and_bullet
+        # No blank line between bullets
+        between_bullets = sr.markdown[idx_first_bullet:idx_last_bullet]
+        assert "\n\n" not in between_bullets
+        # No blank line between last bullet and suggestion
+        between_bullet_and_suggestion = sr.markdown[idx_last_bullet:idx_suggestion]
+        assert "\n\n" not in between_bullet_and_suggestion
+
+    def test_blank_line_between_rule_blocks(self):
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=10,
+                message="msg-a",
+            ),
+            _make_finding(
+                level="error", rule_id="S-002", path="b.yaml", line=20,
+                message="msg-b",
+            ),
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        # The two rule blocks must have a blank line between them.
+        # Locate the end of block-1 (its last bullet) and the start of
+        # block-2 (its subject line) and assert exactly one blank line.
+        idx_end_block_1 = sr.markdown.index("- a.yaml:10")
+        idx_start_block_2 = sr.markdown.index("**[S-002]")
+        between = sr.markdown[idx_end_block_1:idx_start_block_2]
+        assert "\n\n" in between
+
+    def test_singular_hit(self):
+        findings = [_make_finding(level="error", rule_id="S-001")]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "— 1 hit**" in sr.markdown
+        assert "— 1 hits**" not in sr.markdown
+
+    def test_plural_hits(self):
+        findings = [
+            _make_finding(level="error", rule_id="S-001", line=10),
+            _make_finding(level="error", rule_id="S-001", line=20),
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "— 2 hits**" in sr.markdown
+
+    def test_no_suggestion_when_hint_empty(self):
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", message="msg", hint=None,
+            )
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "Suggestion:" not in sr.markdown
+
+    def test_multi_line_hint_blockquote_contiguous(self):
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001",
+                hint="first line\nsecond line\nthird line",
+            )
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "> Suggestion: first line" in sr.markdown
+        assert "> second line" in sr.markdown
+        assert "> third line" in sr.markdown
+
+    def test_newline_in_message_flattened(self):
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=10,
+                message="line one\nline two",
+            )
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "- a.yaml:10 — [S-001] line one line two" in sr.markdown
+
+    def test_pipe_in_message_not_escaped(self):
+        # No table → no pipe escaping needed.
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=10,
+                message="left|right",
+            )
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "- a.yaml:10 — [S-001] left|right" in sr.markdown
 
     def test_absent_levels_not_rendered(self):
         findings = [_make_finding(level="warn")]
@@ -303,8 +484,17 @@ class TestTruncation:
             for i in range(50)
         ]
         sr = generate_workflow_summary(_make_result(errors), _make_context())
-        # All 50 errors should appear
-        assert sr.markdown.count("| some-rule |") == 50
+        # All 50 errors should appear — every finding renders one bullet.
+        # Subject line carries the count.
+        assert "— 50 hits**" in sr.markdown
+        # Each finding renders one bullet; since findings share a path
+        # they all appear under one rule block with 50 bullets.
+        bullet_count = sum(
+            1
+            for line in sr.markdown.splitlines()
+            if line.startswith("- ") and "[some-rule]" in line
+        )
+        assert bullet_count == 50
 
     def test_hints_truncated_first(self):
         # Generate content that exceeds the budget.
@@ -352,6 +542,26 @@ class TestTruncation:
         assert "### Errors" in sr.markdown
         assert "### Warnings" in sr.markdown
         assert "### Hints" in sr.markdown
+
+
+# ---------------------------------------------------------------------------
+# Artifact footnote
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactFootnote:
+    def test_footnote_present_when_diagnostics_written(self):
+        sr = generate_workflow_summary(
+            _make_result(), _make_context(), diagnostics_written=True,
+        )
+        assert "validation-diagnostics" in sr.markdown
+        assert "findings.tsv" in sr.markdown
+        assert "findings.json" in sr.markdown
+
+    def test_footnote_absent_by_default(self):
+        sr = generate_workflow_summary(_make_result(), _make_context())
+        assert "validation-diagnostics" not in sr.markdown
+        assert "findings.tsv" not in sr.markdown
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -111,7 +111,7 @@ def _minimal_rule(
     engine: str = "spectral",
     engine_rule: str = "some-rule",
     message_override: str | None = None,
-    hint: str | None = None,
+    suggestion: str | None = None,
     default_level: str = "warn",
     applicability: dict | None = None,
     overrides: list[dict] | None = None,
@@ -126,8 +126,8 @@ def _minimal_rule(
     }
     if message_override is not None:
         rule["message_override"] = message_override
-    if hint is not None:
-        rule["hint"] = hint
+    if suggestion is not None:
+        rule["suggestion"] = suggestion
     if applicability:
         rule["applicability"] = applicability
     if overrides:
@@ -241,7 +241,7 @@ class TestRunPostFilter:
         f = result.findings[0]
         assert f["level"] == "warn"
         assert f["message"] == "Use kebab-case"
-        assert "hint" not in f
+        assert "suggestion" not in f
         assert f["blocks"] is False
         assert "rule_id" not in f  # unmapped → no rule_id
 
@@ -253,12 +253,12 @@ class TestRunPostFilter:
         assert result.findings[0]["blocks"] is True
 
     def test_mapped_rule_enrichment(self, tmp_path: Path):
-        """Mapped rules get rule_id, optional hint, and resolved level."""
+        """Mapped rules get rule_id, optional suggestion, and resolved level."""
         _write_rules(tmp_path, [
             _minimal_rule(
                 id="S-001",
                 engine_rule="some-rule",
-                hint="Do this instead.",
+                suggestion="Do this instead.",
                 default_level="error",
             )
         ])
@@ -270,7 +270,7 @@ class TestRunPostFilter:
         f = result.findings[0]
         assert f["rule_id"] == "S-001"
         assert f["message"] == "Original msg"  # engine message preserved
-        assert f["hint"] == "Do this instead."
+        assert f["suggestion"] == "Do this instead."
         assert f["level"] == "error"  # remapped from warn to error by metadata
         assert f["blocks"] is True
         # No short_title in metadata → not added to finding
@@ -497,7 +497,7 @@ class TestRunPostFilter:
                 id="P-001",
                 engine="python",
                 engine_rule="check-info-version-format",
-                hint="Use wip on main.",
+                suggestion="Use wip on main.",
                 default_level="error",
             )
         ], filename="python-rules.yaml")
@@ -515,7 +515,7 @@ class TestRunPostFilter:
         f = result.findings[0]
         assert f["rule_id"] == "P-001"
         assert f["level"] == "error"  # remapped by metadata
-        assert f["hint"] == "Use wip on main."
+        assert f["suggestion"] == "Use wip on main."
 
     def test_per_api_conditional_level(self, tmp_path: Path):
         """Different APIs get different levels based on their context."""
@@ -565,13 +565,13 @@ class TestRunPostFilter:
         # Per-API conditions with None api_context are unconstrained → applicable
         assert len(result.findings) == 1
 
-    def test_passthrough_preserves_existing_hint(self, tmp_path: Path):
-        """If a finding already has a hint, pass-through preserves it."""
+    def test_passthrough_preserves_existing_suggestion(self, tmp_path: Path):
+        """If a finding already has a suggestion, pass-through preserves it."""
         ctx = _make_context()
         finding = _make_finding()
-        finding["hint"] = "Pre-existing hint"
+        finding["suggestion"] = "Pre-existing suggestion"
         result = run_post_filter([finding], ctx, tmp_path)
-        assert result.findings[0]["hint"] == "Pre-existing hint"
+        assert result.findings[0]["suggestion"] == "Pre-existing suggestion"
 
     def test_result_summary_content(self, tmp_path: Path):
         """Summary string contains useful information."""
@@ -599,26 +599,26 @@ class TestRunPostFilter:
         assert f["rule_id"] == "S-018"
         assert f["level"] == "warn"  # engine level preserved
         assert f["message"] == "Engine message"
-        assert "hint" not in f  # no hint in metadata → no hint in output
+        assert "suggestion" not in f  # no suggestion in metadata → no suggestion in output
         assert f["blocks"] is False  # warn doesn't block in standard
 
-    def test_identity_entry_with_explicit_hint(self, tmp_path: Path):
-        """Identity entry with explicit hint uses the hint, not message."""
+    def test_identity_entry_with_explicit_suggestion(self, tmp_path: Path):
+        """Identity entry with explicit suggestion populates the suggestion field."""
         _write_rules(tmp_path, [{
             "id": "S-018",
             "engine": "spectral",
             "engine_rule": "some-rule",
-            "hint": "Custom guidance.",
+            "suggestion": "Custom guidance.",
         }])
         ctx = _make_context()
         findings = [_make_finding(message="Engine message")]
         result = run_post_filter(findings, ctx, tmp_path)
 
-        assert result.findings[0]["hint"] == "Custom guidance."
+        assert result.findings[0]["suggestion"] == "Custom guidance."
         assert result.findings[0]["rule_id"] == "S-018"
 
-    def test_mapped_rule_without_hint_preserves_message(self, tmp_path: Path):
-        """Rule without hint/message_override preserves engine message."""
+    def test_mapped_rule_without_suggestion_preserves_message(self, tmp_path: Path):
+        """Rule without suggestion/message_override preserves engine message."""
         _write_rules(tmp_path, [{
             "id": "S-001",
             "engine": "spectral",
@@ -633,7 +633,7 @@ class TestRunPostFilter:
         assert f["rule_id"] == "S-001"
         assert f["level"] == "error"  # from conditional_level
         assert f["message"] == "Engine says fix this"  # preserved
-        assert "hint" not in f  # no hint in metadata → no hint in output
+        assert "suggestion" not in f  # no suggestion in metadata → no suggestion in output
 
     def test_message_override_replaces_message(self, tmp_path: Path):
         """message_override replaces the engine message entirely."""
@@ -651,16 +651,16 @@ class TestRunPostFilter:
         f = result.findings[0]
         assert f["rule_id"] == "S-001"
         assert f["message"] == "Better description."
-        assert "hint" not in f
+        assert "suggestion" not in f
 
-    def test_message_override_with_hint(self, tmp_path: Path):
-        """Both message_override and hint can be set together."""
+    def test_message_override_with_suggestion(self, tmp_path: Path):
+        """Both message_override and suggestion can be set together."""
         _write_rules(tmp_path, [{
             "id": "S-001",
             "engine": "spectral",
             "engine_rule": "some-rule",
             "message_override": "Better description.",
-            "hint": "Fix by doing X.",
+            "suggestion": "Fix by doing X.",
             "conditional_level": {"default": "error"},
         }])
         ctx = _make_context()
@@ -669,7 +669,7 @@ class TestRunPostFilter:
 
         f = result.findings[0]
         assert f["message"] == "Better description."
-        assert f["hint"] == "Fix by doing X."
+        assert f["suggestion"] == "Fix by doing X."
 
 
 # ---------------------------------------------------------------------------
@@ -690,7 +690,7 @@ def _rule_with_suppress(
         engine=engine,
         engine_rule=engine_rule,
         message_override=None,
-        hint=None,
+        suggestion=None,
         applicability={},
         conditional_level=None,
         suppress_schema_paths=tuple(paths),

--- a/validation/tests/test_postfilter_levels.py
+++ b/validation/tests/test_postfilter_levels.py
@@ -77,7 +77,7 @@ def _make_rule(
         engine="spectral",
         engine_rule="test-rule",
         message_override=None,
-        hint="Fix it.",
+        suggestion="Fix it.",
         applicability={},
         conditional_level=ConditionalLevel(
             default=default,

--- a/validation/tests/test_postfilter_metadata.py
+++ b/validation/tests/test_postfilter_metadata.py
@@ -42,7 +42,7 @@ def _full_rule_dict(**overrides: object) -> dict:
         "engine": "spectral",
         "engine_rule": "camara-test-rule",
         "message_override": "Overridden message.",
-        "hint": "Fix this issue.",
+        "suggestion": "Fix this issue.",
         "conditional_level": {"default": "warn"},
     }
     base.update(overrides)
@@ -68,7 +68,7 @@ class TestParseRuleMetadata:
         assert rule.engine == "spectral"
         assert rule.engine_rule == "camara-test-rule"
         assert rule.message_override is None
-        assert rule.hint is None
+        assert rule.suggestion is None
         assert rule.applicability == {}
         assert rule.conditional_level is None
 
@@ -78,7 +78,7 @@ class TestParseRuleMetadata:
         assert rule.id == "S-001"
         assert rule.name == "test-rule"
         assert rule.message_override == "Overridden message."
-        assert rule.hint == "Fix this issue."
+        assert rule.suggestion == "Fix this issue."
         assert rule.conditional_level is not None
         assert rule.conditional_level.default == "warn"
         assert rule.conditional_level.overrides == ()
@@ -97,7 +97,7 @@ class TestParseRuleMetadata:
         raw = _minimal_rule_dict()
         rule = parse_rule_metadata(raw)
         assert rule.message_override is None
-        assert rule.hint is None
+        assert rule.suggestion is None
         assert rule.suppress_schema_paths == ()
 
     def test_suppress_schema_paths_parsed(self):
@@ -145,18 +145,18 @@ class TestParseRuleMetadata:
         rule = parse_rule_metadata(raw)
         assert rule.message_override == "Better message."
 
-    def test_explicit_hint(self):
-        raw = _minimal_rule_dict(hint="Do this instead.")
+    def test_explicit_suggestion(self):
+        raw = _minimal_rule_dict(suggestion="Do this instead.")
         rule = parse_rule_metadata(raw)
-        assert rule.hint == "Do this instead."
+        assert rule.suggestion == "Do this instead."
 
-    def test_both_message_override_and_hint(self):
+    def test_both_message_override_and_suggestion(self):
         raw = _minimal_rule_dict(
-            message_override="Overridden.", hint="Fix guidance."
+            message_override="Overridden.", suggestion="Fix guidance."
         )
         rule = parse_rule_metadata(raw)
         assert rule.message_override == "Overridden."
-        assert rule.hint == "Fix guidance."
+        assert rule.suggestion == "Fix guidance."
 
     def test_with_applicability(self):
         raw = _minimal_rule_dict(

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -297,18 +297,19 @@ class TestMetadataQuality:
         ]
         assert not missing, f"Python rules without conditional_level: {missing}"
 
-    def test_hints_are_exception_not_norm(self, all_rules):
-        """Hints and message overrides are rare — engine messages are primary.
+    def test_suggestions_are_exception_not_norm(self, all_rules):
+        """Suggestions and message overrides are rare — engine messages are primary.
 
         Engine messages are the primary fix guidance (design doc 8.4.1).
-        Explicit hints and message overrides should only exist when the
-        engine message is insufficient.  Update counts when adding in WS07.
+        Explicit suggestions and message overrides should only exist when
+        the engine message is insufficient.  Update counts when adding new
+        explicit suggestions.
         """
-        with_hints = [r.id for r in all_rules if r.hint is not None]
+        with_suggestions = [r.id for r in all_rules if r.suggestion is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_hints) == 16, (
-            f"Expected 16 explicit hints (update test if adding hints): "
-            f"{with_hints}"
+        assert len(with_suggestions) == 16, (
+            f"Expected 16 explicit suggestions (update test if adding "
+            f"suggestions): {with_suggestions}"
         )
         assert len(with_overrides) == 0, (
             f"Expected 0 message overrides (update test if adding overrides): "
@@ -330,8 +331,8 @@ class TestMetadataQuality:
         assert len(overrides) == 1
         assert overrides[0].condition == {"target_api_status": ["draft"]}
         assert overrides[0].level == "hint"
-        assert rule.hint is not None
-        assert "draft" in rule.hint.lower()
+        assert rule.suggestion is not None
+        assert "draft" in rule.suggestion.lower()
 
     def test_p015_conditional_on_api_pattern(self, rule_index):
         """P-015 stays error on explicit-subscription, warn on implicit.
@@ -349,8 +350,8 @@ class TestMetadataQuality:
             "api_pattern": ["implicit-subscription"],
         }
         assert overrides[0].level == "warn"
-        assert rule.hint is not None
-        assert "Commonalities#608" in rule.hint
+        assert rule.suggestion is not None
+        assert "Commonalities#608" in rule.suggestion
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -242,11 +242,11 @@ class TestNormalizeFinding:
         assert finding["line"] == 11
         assert "column" not in finding
 
-    def test_rule_id_and_hint_not_set(self):
-        """Adapter does not assign rule_id or hint — post-filter does."""
+    def test_rule_id_and_suggestion_not_set(self):
+        """Adapter does not assign rule_id or suggestion — post-filter does."""
         finding = normalize_finding(SAMPLE_SPECTRAL_FINDING)
         assert "rule_id" not in finding
-        assert "hint" not in finding
+        assert "suggestion" not in finding
 
     def test_schema_path_dot_joined(self):
         """Spectral's JSONPath array is dot-joined into finding['schema_path']."""


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Two commits implementing #254:

1. `40760fc` — Replaces the per-severity 5-column markdown findings table in the workflow summary with rule-grouped bullet blocks (bold subject line + `path:line — [RULE] message` bullets + a single `Suggestion:` blockquote per rule). Adds a `findings.tsv` companion to the `validation-diagnostics` artifact alongside `findings.json`. Renames the rendered `Hint:` label to `Suggestion:` across the workflow summary, GitHub Actions annotations, and Checks API.
2. `55258d7` — Renames the rule-metadata field `hint` to `suggestion` end-to-end (schema, `RuleMetadata` dataclass, post-filter propagation, 16 rule-YAML keys, output surfaces, TSV column header). Severity-level uses of `hint` (the `error` / `warn` / `hint` level) are unchanged. Removes the now-obsolete backward-compatibility note in `documentation/validation/problem-messages.md`.

The engine-level "Summary" count table at the top of the workflow summary is unchanged.

#### Which issue(s) this PR fixes:

Fixes #254

#### Special notes for reviewers:

- Two commits kept separate to make the field rename reviewable on its own; the rendered behaviour change is fully in commit 1.
- Touches `validation/` only — no `.github/workflows/`, `release_automation/`, `shared-actions/`, or `tooling_lib/` paths.
- Full validation test suite passes locally: 992/992.

#### Changelog input

```
 release-note
Validation workflow summary: replace per-finding tables with rule-grouped bullet blocks; add `findings.tsv` companion to the `validation-diagnostics` artifact; rename rule-metadata field `hint` to `suggestion` and the rendered label from `Hint:` to `Suggestion:` (severity-level `hint` unchanged).

```

#### Additional documentation

```
docs
- documentation/validation/problem-messages.md — workflow-summary example updated; obsolete severity-vs-label disambiguation note removed
- documentation/validation/where-to-see-results.md — prose updated to describe the new rendering and the TSV companion
```
