### PR TITLE
validation: escape GFM inline syntax in workflow summary findings

### DIFF
--- a/validation/output/formatting.py
+++ b/validation/output/formatting.py
@@ -238,3 +238,28 @@ def format_finding_location(finding: dict) -> str:
     if column is not None:
         return f"{path}:{line}:{column}"
     return f"{path}:{line}"
+
+
+# Inline-syntax characters that GFM interprets specially.  Backslash is
+# handled separately and must run first to avoid double-escaping.
+_GFM_INLINE_CHARS = ("*", "_", "~", "`", "[", "]", "<")
+
+
+def escape_gfm_inline(text: str) -> str:
+    """Backslash-escape GFM inline-syntax characters in *text*.
+
+    Engine-emitted messages are not authored as Markdown — Spectral and
+    other linters can include regex quantifiers, RFC 6901 path
+    encoding, or bracketed identifiers that GFM otherwise parses as
+    emphasis, links, or code spans.  Apply this to messages before
+    interpolating them into a Markdown surface.
+
+    Out of scope: HTML entity escaping (the workflow summary is server-
+    rendered Markdown, not raw HTML — ``&`` and ``>`` need no special
+    handling), block-level constructs, and reference-link
+    disambiguation.  Inline-only is the documented contract.
+    """
+    text = text.replace("\\", "\\\\")
+    for ch in _GFM_INLINE_CHARS:
+        text = text.replace(ch, "\\" + ch)
+    return text

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -24,6 +24,7 @@ from .formatting import (
     REPO_LEVEL_LABEL,
     count_findings,
     count_findings_by_engine,
+    escape_gfm_inline,
     format_finding_location,
     format_rule_label,
     resolve_annotation_title,
@@ -179,6 +180,7 @@ def _render_rule_block(rule_id: str, findings: List[dict]) -> str:
     for f in findings:
         location = format_finding_location(f)
         message = (f.get("message", "") or "").replace("\n", " ")
+        message = escape_gfm_inline(message)
         out.append(f"- {location} — [{rule_id}] {message}")
 
     suggestion = (findings[0].get("suggestion") or "").strip()

--- a/validation/tests/test_output_formatting.py
+++ b/validation/tests/test_output_formatting.py
@@ -8,6 +8,7 @@ from validation.output.formatting import (
     count_findings,
     count_findings_by_api,
     deduplicate_findings,
+    escape_gfm_inline,
     format_finding_location,
     format_rule_label,
     resolve_annotation_title,
@@ -360,3 +361,68 @@ class TestResolveAnnotationTitle:
         # through, it is returned as-is (rather than silently truncated).
         long_short = "x" * 80
         assert resolve_annotation_title({"short_title": long_short}) == long_short
+
+
+# ---------------------------------------------------------------------------
+# escape_gfm_inline
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeGfmInline:
+    def test_no_op_on_plain_text(self):
+        assert escape_gfm_inline("Just a normal message.") == "Just a normal message."
+
+    def test_empty_string(self):
+        assert escape_gfm_inline("") == ""
+
+    def test_asterisk_escaped(self):
+        # S-008-shape: regex with `*` quantifiers
+        assert escape_gfm_inline("(-[a-z0-9]+)*") == r"(-\[a-z0-9\]+)\*"
+
+    def test_underscore_escaped(self):
+        assert escape_gfm_inline("snake_case_word") == r"snake\_case\_word"
+
+    def test_tilde_escaped(self):
+        # S-003-shape: RFC 6901 path encoding `~1`
+        assert escape_gfm_inline("~1resources~1") == r"\~1resources\~1"
+
+    def test_backtick_escaped(self):
+        assert escape_gfm_inline("a `b` c") == r"a \`b\` c"
+
+    def test_brackets_escaped(self):
+        assert escape_gfm_inline("[link](url)") == r"\[link\](url)"
+
+    def test_lt_escaped(self):
+        assert escape_gfm_inline("<tag>") == r"\<tag>"
+
+    def test_backslash_escaped_first(self):
+        # Backslash must be escaped before the others, otherwise the
+        # backslashes inserted by the per-char loop would themselves get
+        # re-escaped on a second pass and produce double-escaped output.
+        # Input containing a literal backslash followed by an asterisk:
+        #   raw: '\*'
+        #   expected: backslash escaped → '\\', then '*' → '\*'
+        #   result:  '\\\*'
+        assert escape_gfm_inline(r"\*") == r"\\\*"
+
+    def test_no_double_escape_of_already_escaped_special(self):
+        # Engine messages do not pre-escape, but be invariant if they do:
+        # '\\*' becomes '\\\\\\*' — backslash first, then '*' once.
+        # In Markdown this renders as a literal backslash followed by a
+        # literal asterisk (no italic).
+        result = escape_gfm_inline(r"\*foo\*")
+        assert result == r"\\\*foo\\\*"
+
+    def test_multiple_special_chars_in_one_string(self):
+        result = escape_gfm_inline("regex `(a*|b_)` matches [text]")
+        assert result == r"regex \`(a\*|b\_)\` matches \[text\]"
+
+    def test_pipe_left_alone(self):
+        # GFM only treats `|` as syntax inside tables; the bullet
+        # renderer is not a table, so leave `|` literal.
+        assert escape_gfm_inline("left|right") == "left|right"
+
+    def test_ampersand_left_alone(self):
+        # Workflow summary is server-rendered Markdown, not raw HTML —
+        # `&` and `>` need no escaping.
+        assert escape_gfm_inline("a & b > c") == "a & b > c"

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -428,6 +428,103 @@ class TestFindingsSection:
         assert "### Errors" not in sr.markdown
         assert "### Hints" not in sr.markdown
 
+    def test_message_regex_quantifier_escaped(self):
+        # S-008-shape: regex pattern with `*` quantifiers must not flip
+        # the trailing prose to italic.  Checks the bullet body — the
+        # subject line uses ``short_title`` from rule metadata and is
+        # author-controlled, deliberately not escaped.
+        f = _make_finding(
+            level="error", rule_id="S-008", path="a.yaml", line=10,
+            message="/foo is not kebab-case: ^/([a-z0-9]+(-[a-z0-9]+)*)?$",
+        )
+        f["short_title"] = "Path segments must be kebab-case"
+        sr = generate_workflow_summary(_make_result([f]), _make_context())
+        bullet = next(
+            ln for ln in sr.markdown.splitlines() if ln.startswith("- a.yaml:10")
+        )
+        # Both `*` quantifiers and the bracket pair are escaped in the
+        # bullet body, so GFM does not flip the trailing prose to italic.
+        assert r"+)\*)?$" in bullet
+        assert r"\[a-z0-9\]" in bullet
+        assert "+)*)?$" not in bullet
+
+    def test_message_tilde_pair_escaped(self):
+        # S-003-shape: RFC 6901 `~1` sequence pair would otherwise render
+        # as strikethrough.  Decode is intentionally NOT applied — only
+        # escape — so the encoded form stays visible but stops striking
+        # through the rest of the bullet.  Subject line uses
+        # ``short_title`` (author-controlled, not escaped).
+        f = _make_finding(
+            level="error", rule_id="S-003", path="a.yaml", line=10,
+            message=(
+                "Invalid HTTP method for "
+                "'#/paths/~1resources~1{id}/trace'."
+            ),
+        )
+        f["short_title"] = "Unsupported HTTP method on path"
+        sr = generate_workflow_summary(_make_result([f]), _make_context())
+        bullet = next(
+            ln for ln in sr.markdown.splitlines() if ln.startswith("- a.yaml:10")
+        )
+        assert r"\~1resources\~1" in bullet
+        assert "~1resources~1" not in bullet
+
+    def test_message_underscore_left_unitalicized(self):
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=10,
+                message="property snake_case_name is not camelCase",
+            )
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert r"snake\_case\_name" in sr.markdown
+
+    def test_message_brackets_escaped(self):
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", path="a.yaml", line=10,
+                message="see [section 5.7.4] of the design guide",
+            )
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        # Escaped brackets in the bullet body — would otherwise look like
+        # an unresolved reference link.
+        assert r"\[section 5.7.4\]" in sr.markdown
+
+    def test_subject_line_not_escaped(self):
+        # Subject line comes from rule metadata (short_title) or, as a
+        # fallback, the engine message — the renderer leaves it
+        # unescaped because rule metadata is author-controlled.  Verify
+        # the bold subject line still contains the literal short_title
+        # even when the engine message in the body is escape-laden.
+        f = _make_finding(
+            level="error", rule_id="S-008",
+            message="(-[a-z0-9]+)*",
+        )
+        f["short_title"] = "Path must use kebab-case (a*b)"
+        sr = generate_workflow_summary(_make_result([f]), _make_context())
+        # Subject line carries the literal short_title (asterisk
+        # included) — author-controlled, intentionally not escaped.
+        assert "**[S-008] Path must use kebab-case (a*b) — 1 hit**" in sr.markdown
+
+    def test_suggestion_not_escaped(self):
+        # Suggestion comes from rule metadata — author-controlled and
+        # may legitimately use Markdown (inline code spans, emphasis).
+        # Verify it passes through untouched even when the bullet body
+        # is escape-laden.
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-008", path="a.yaml", line=10,
+                message="(-[a-z0-9]+)*",
+                suggestion="Use kebab-case: `/my-resource` not `/myResource`.",
+            )
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert (
+            "> Suggestion: Use kebab-case: `/my-resource` not `/myResource`."
+            in sr.markdown
+        )
+
 
 # ---------------------------------------------------------------------------
 # Footer


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Engine-emitted messages render incorrectly in the workflow-summary bullet list when they contain GFM inline-syntax characters. Visible today on `[S-008]` (regex `*` quantifiers flip trailing prose to italic) and `[S-003]` (`~1...~1` from RFC 6901 path encoding renders as strikethrough).

Adds an `escape_gfm_inline` helper in `validation/output/formatting.py` and applies it in `_render_rule_block` to the bullet body only. Backslash-escapes `*`, `_`, `~`, `` ` ``, `[`, `]`, `<`, `\`. Subject lines (rule `short_title`) and `Suggestion:` blockquotes are author-controlled rule metadata and intentionally unaffected.

JSON-Pointer fragment decoding (S-003's `'#/paths/~1resources~1%7Bid%7D/trace'`) is intentionally out of scope per the updated issue scope — S-003 is the only rule emitting that shape and the encoded form is acceptable to read.

#### Which issue(s) this PR fixes:

Fixes #256

#### Special notes for reviewers:

- Sanitization is renderer-scoped — Checks API annotation `message` renders as plain text in the GitHub UI, so escaping there would inject visible backslashes; TSV writer keeps its own structural sanitization.
- 1011 tests pass; new tests cover each escaped char, backslash precedence, S-003/S-008-shape messages, and pass-through assertions for subject and suggestion.

#### Changelog input

```
release-note
Workflow summary: engine-emitted finding messages now backslash-escape GFM inline-syntax characters so regex quantifiers, RFC 6901 path encoding, and bracketed identifiers no longer flip surrounding prose to italic / strikethrough / link.
```

#### Additional documentation

This section can be blank.

```
docs

```
