### PR TITLE
ci: retarget regression workflows and dependabot to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,24 +16,9 @@ updates:
       - "github-actions"
     open-pull-requests-limit: 5
 
-  # GitHub Actions on validation-framework - until it merges into main
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "validation-framework"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    commit-message:
-      prefix: "chore(deps)"
-    labels:
-      - "dependencies"
-      - "github-actions"
-    open-pull-requests-limit: 5
-
-  # npm on validation-framework (validation/) - until it merges into main
+  # npm (validation/)
   - package-ecosystem: "npm"
     directory: "/validation"
-    target-branch: "validation-framework"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/release-automation-regression.yml
+++ b/.github/workflows/release-automation-regression.yml
@@ -21,7 +21,7 @@ name: Release Automation Regression
 
 on:
   push:
-    branches: [validation-framework]
+    branches: [main]
     paths:
       - '.github/workflows/release-automation-reusable.yml'
       - '.github/workflows/release-automation-regression.yml'

--- a/.github/workflows/validation-regression.yml
+++ b/.github/workflows/validation-regression.yml
@@ -1,9 +1,9 @@
 # CAMARA Validation Framework — Validation Regression (canary)
 #
 # Auto-dispatches validation/scripts/regression_runner.py against
-# camaraproject/ReleaseTest on every push to validation-framework, so
-# that "broken stays broken" and "clean stays clean" are verified
-# automatically before v1-rc is moved for the rest of the org.
+# camaraproject/ReleaseTest on every push to main, so that "broken
+# stays broken" and "clean stays clean" are verified automatically
+# before v1-rc is moved for the rest of the org.
 #
 # The runner dispatches camara-validation.yml on each branch matching
 # regression/* on ReleaseTest, waits for it to complete, downloads the
@@ -20,7 +20,7 @@ name: Validation Regression
 
 on:
   push:
-    branches: [validation-framework]
+    branches: [main]
     paths:
       - 'validation/**'
       - 'shared-actions/**'


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Step 3 + step 4 of the validation-framework branch retirement (#259):

- `.github/dependabot.yml`: drop the two `target-branch: validation-framework` overrides. The github-actions entry was a duplicate of the main entry; the npm `/validation` entry now targets the default branch.
- `.github/workflows/validation-regression.yml` and `.github/workflows/release-automation-regression.yml`: change the push trigger from `branches: [validation-framework]` to `branches: [main]` so the canary fires on main pushes after the branch is retired. Comment header on `validation-regression.yml` updated to match.

Sibling PR on ReleaseTest repoints the caller workflows from `@validation-framework` to `@main` (step 2). Verification (step 5), the manual App `external_url` update (step 6), and branch deletion (step 7) follow.

#### Which issue(s) this PR fixes:

Steps toward closing #259 (steps 3 + 4 of the 8-step sequence).

#### Special notes for reviewers:

CI-only changes. After merge, I'll dispatch a validation run + push a no-op trigger to confirm the regression workflows fire on main before deleting the `validation-framework` branch.

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

This section can be blank.
