### PR TITLE
feat(validation): flip central default stage from advisory to enabled

### DIFF
--- a/config/validation-settings.yaml
+++ b/config/validation-settings.yaml
@@ -22,7 +22,7 @@
 version: 1
 
 defaults:
-  stage: advisory
+  stage: enabled  # 2026-05-05 (was advisory; central flip per #261)
   pr_profile: standard
   release_profile: standard
 
@@ -34,11 +34,11 @@ repositories:
   ConsentManagement:
     stage: enabled  # 2026-04-29
   CustomerInsights:
-    stage: enabled  # 2026-04-30 (pre-staged; effective when CustomerInsights#70 merges)
+    stage: enabled  # 2026-04-30
   DedicatedNetworks:
     stage: enabled  # 2026-04-29
   DeviceIdentifier:
-    stage: enabled  # 2026-04-29 (pre-staged; effective when DeviceIdentifier#161 merges)
+    stage: enabled  # 2026-04-29
   EdgeApplicationManagement:
     stage: enabled  # 2026-04-29
   IoTSIMFraudPrevention:


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Flips the central default validation stage from `advisory` to `enabled` in `config/validation-settings.yaml`. Merging this PR is the formal central-default flip decision (#261).

Per-repo `advisory` and `disabled` overrides continue to work for opt-out; existing per-repo `enabled` entries become no-op overrides and can be cleaned up opportunistically.

#### Which issue(s) this PR fixes:

Fixes #261

#### Special notes for reviewers:

Single-line change. Tracker: ReleaseManagement#484.

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

This section can be blank.
