### PR TITLE
Update caller-workflow header comments for mass-onboarding context

### DIFF
--- a/release_automation/workflows/release-automation-caller.yml
+++ b/release_automation/workflows/release-automation-caller.yml
@@ -1,9 +1,8 @@
-# Release Automation Caller Workflow
+# CAMARA Release Automation — Caller Workflow
 #
-# This workflow template should be copied to .github/workflows/ in API repositories
-# that want to use the CAMARA release automation.
-#
-# Copy this file as: .github/workflows/release-automation.yml
+# Installed in API repositories by the CAMARA onboarding campaign
+# (camaraproject/project-administration). No modification needed;
+# all configuration is centralized in camaraproject/tooling.
 #
 # Triggers:
 # - Slash commands: /create-snapshot, /discard-snapshot, /delete-draft, /publish-release

--- a/validation/workflows/validation-caller.yml
+++ b/validation/workflows/validation-caller.yml
@@ -1,11 +1,10 @@
 # CAMARA Validation Framework — Caller Workflow
 #
-# Copy this file to .github/workflows/camara-validation.yml in your
-# API repository.  No modification needed — all configuration is
-# centralized in the tooling repository.
+# Installed in API repositories by the CAMARA onboarding campaign
+# (camaraproject/project-administration). No modification needed;
+# all configuration is centralized in camaraproject/tooling.
 #
-# This replaces the v0 pr_validation_caller.yml for repositories that
-# have opted into the v1 validation framework.
+# Replaces the legacy pr_validation_caller.yml (v0 validation).
 
 name: CAMARA Validation
 


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Updates the header comments on both caller-workflow templates so they describe how the files actually land in API repositories now:

- Drops the "copy this file" instructions — the [onboarding campaign](https://github.com/camaraproject/project-administration/blob/main/.github/workflows/campaign-release-automation-onboarding.yml) in `camaraproject/project-administration` installs both files
- Drops the "opted into v1 validation" framing — the central default is `enabled`; validation is the standard, not opt-in
- Renames the release-automation caller header to match the validation caller's "CAMARA … — Caller Workflow" pattern

Comment-only changes; no functional impact.

#### Which issue(s) this PR fixes:

(no separate issue — sibling PR to [project-administration#230](https://github.com/camaraproject/project-administration/pull/230); both prepare the upcoming mass-dispatch onboarding round)

#### Special notes for reviewers:

The change will propagate to already-onboarded repositories via the next `campaign-release-automation-onboarding` run, producing a small comment-only update PR per repo (about 8 lines diff). Together with the existing `e92f65e` bot-filter fix, the next caller-update batch covers two improvements per repo.

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

```
docs
NONE
```
