### PR TITLE
Delete release-review branch on /publish-release

### DIFF
--- a/release_automation/scripts/release_publisher.py
+++ b/release_automation/scripts/release_publisher.py
@@ -289,8 +289,9 @@ class ReleasePublisher:
     ) -> Dict[str, str]:
         """Clean up branches after publication.
 
-        Deletes the snapshot branch and renames the release-review branch
-        to indicate it has been published.
+        Deletes both the snapshot and release-review branches. The release tag
+        preserves the published commit, so the release-review branch carries
+        no information not already in the tag list.
 
         Args:
             snapshot_branch: e.g., "release-snapshot/r4.1-abc1234"
@@ -299,7 +300,7 @@ class ReleasePublisher:
         Returns:
             Dict with status for each operation:
             - "snapshot_deleted": "deleted", "not_found", or "error"
-            - "review_renamed": "renamed", "not_found", or "error"
+            - "review_deleted": "deleted", "not_found", or "error"
         """
         result: Dict[str, str] = {}
 
@@ -315,17 +316,16 @@ class ReleasePublisher:
             logger.error(f"Failed to delete {snapshot_branch}: {e}")
             result["snapshot_deleted"] = "error"
 
-        # Rename release-review branch to -published
-        new_review_branch = f"{release_review_branch}-published"
+        # Delete release-review branch
         try:
-            renamed = self.gh.rename_branch(release_review_branch, new_review_branch)
-            result["review_renamed"] = "renamed" if renamed else "not_found"
-            if renamed:
-                logger.info(f"Renamed {release_review_branch} to {new_review_branch}")
+            deleted = self.gh.delete_branch(release_review_branch)
+            result["review_deleted"] = "deleted" if deleted else "not_found"
+            if deleted:
+                logger.info(f"Deleted branch {release_review_branch}")
             else:
-                logger.warning(f"Branch {release_review_branch} not found (already renamed)")
+                logger.warning(f"Branch {release_review_branch} not found (already deleted)")
         except GitHubClientError as e:
-            logger.error(f"Failed to rename {release_review_branch}: {e}")
-            result["review_renamed"] = "error"
+            logger.error(f"Failed to delete {release_review_branch}: {e}")
+            result["review_deleted"] = "error"
 
         return result

--- a/release_automation/tests/test_release_publisher.py
+++ b/release_automation/tests/test_release_publisher.py
@@ -31,7 +31,6 @@ def mock_github_client():
     client.create_tag.return_value = {"ref": "refs/tags/source/r4.1"}
     # Branch cleanup methods
     client.delete_branch.return_value = True
-    client.rename_branch.return_value = True
     return client
 
 
@@ -381,7 +380,6 @@ class TestCleanupBranches:
     def test_cleanup_branches_success(self, publisher, mock_github_client):
         """Both operations succeed."""
         mock_github_client.delete_branch.return_value = True
-        mock_github_client.rename_branch.return_value = True
 
         result = publisher.cleanup_branches(
             "release-snapshot/r4.1-abc1234",
@@ -389,17 +387,14 @@ class TestCleanupBranches:
         )
 
         assert result["snapshot_deleted"] == "deleted"
-        assert result["review_renamed"] == "renamed"
-        mock_github_client.delete_branch.assert_called_once_with("release-snapshot/r4.1-abc1234")
-        mock_github_client.rename_branch.assert_called_once_with(
-            "release-review/r4.1-abc1234",
-            "release-review/r4.1-abc1234-published"
-        )
+        assert result["review_deleted"] == "deleted"
+        assert mock_github_client.delete_branch.call_count == 2
+        mock_github_client.delete_branch.assert_any_call("release-snapshot/r4.1-abc1234")
+        mock_github_client.delete_branch.assert_any_call("release-review/r4.1-abc1234")
 
     def test_cleanup_snapshot_already_deleted(self, publisher, mock_github_client):
         """Snapshot branch already deleted - reports not_found."""
-        mock_github_client.delete_branch.return_value = False
-        mock_github_client.rename_branch.return_value = True
+        mock_github_client.delete_branch.side_effect = [False, True]
 
         result = publisher.cleanup_branches(
             "release-snapshot/r4.1-abc1234",
@@ -407,12 +402,11 @@ class TestCleanupBranches:
         )
 
         assert result["snapshot_deleted"] == "not_found"
-        assert result["review_renamed"] == "renamed"
+        assert result["review_deleted"] == "deleted"
 
-    def test_cleanup_review_already_renamed(self, publisher, mock_github_client):
-        """Review branch already renamed - reports not_found."""
-        mock_github_client.delete_branch.return_value = True
-        mock_github_client.rename_branch.return_value = False
+    def test_cleanup_review_already_deleted(self, publisher, mock_github_client):
+        """Review branch already deleted - reports not_found."""
+        mock_github_client.delete_branch.side_effect = [True, False]
 
         result = publisher.cleanup_branches(
             "release-snapshot/r4.1-abc1234",
@@ -420,12 +414,11 @@ class TestCleanupBranches:
         )
 
         assert result["snapshot_deleted"] == "deleted"
-        assert result["review_renamed"] == "not_found"
+        assert result["review_deleted"] == "not_found"
 
     def test_cleanup_partial_failure(self, publisher, mock_github_client):
         """One operation fails - continues with other."""
-        mock_github_client.delete_branch.side_effect = GitHubClientError("API error")
-        mock_github_client.rename_branch.return_value = True
+        mock_github_client.delete_branch.side_effect = [GitHubClientError("API error"), True]
 
         result = publisher.cleanup_branches(
             "release-snapshot/r4.1-abc1234",
@@ -433,12 +426,11 @@ class TestCleanupBranches:
         )
 
         assert result["snapshot_deleted"] == "error"
-        assert result["review_renamed"] == "renamed"
+        assert result["review_deleted"] == "deleted"
 
     def test_cleanup_both_not_found(self, publisher, mock_github_client):
         """Both branches not found - idempotent behavior."""
         mock_github_client.delete_branch.return_value = False
-        mock_github_client.rename_branch.return_value = False
 
         result = publisher.cleanup_branches(
             "release-snapshot/r4.1-abc1234",
@@ -446,7 +438,7 @@ class TestCleanupBranches:
         )
 
         assert result["snapshot_deleted"] == "not_found"
-        assert result["review_renamed"] == "not_found"
+        assert result["review_deleted"] == "not_found"
 
 
 class TestCreatePointerBranch:


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

`/publish-release` now deletes the release-review branch instead of renaming it to `-published`. The release tag preserves the published commit, so the renamed branch carries no information not already in the tag list. First-time codeowners were confused by the leftover branch.

Scope: publish path only. `/discard-snapshot` and `/delete-draft` continue to rename (to `-discarded` / `-preserved`) — those branches carry abandoned-snapshot commits not preserved elsewhere.

Cross-references:
- camaraproject/ReleaseManagement#520 — codeowner-UX gap report
- camaraproject/ReleaseManagement#521 — companion docs update (lifecycle.md branch-cleanup table)

#### Which issue(s) this PR fixes:

(None in tooling — see cross-references above.)

#### Special notes for reviewers:

- `cleanup_branches` result key: `review_renamed` → `review_deleted`. Only consumer is `release-automation-reusable.yml` step 4 which iterates the dict generically (no key dependency).
- After this lands, the row for `release-review/rX.Y-<id>-published` in RM#521's branch-cleanup table can be dropped.
- All 670 `release_automation` tests pass.

#### Changelog input

```
release-note
release-automation: delete release-review branch on `/publish-release` (was renamed to `-published`).
```

#### Additional documentation 

```
docs

```
