### PR TITLE
refactor(release-automation): fold validate-command and assemble-context into derive-state

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -413,6 +413,9 @@ jobs:
       common_cache_status: ${{ steps.cache-sync.outputs.common_cache_status }}
       common_cache_details: ${{ steps.cache-sync.outputs.common_cache_details }}
       common_sync_pr_url: ${{ steps.find-sync-pr.outputs.common_sync_pr_url }}
+      # Validate-command outputs (slash-command path; empty for non-slash triggers)
+      allowed: ${{ steps.validate.outputs.allowed }}
+      error_message: ${{ steps.validate.outputs.error_message }}
     steps:
       - name: Checkout tooling
         uses: actions/checkout@v6
@@ -532,6 +535,184 @@ jobs:
           else
             echo "No existing sync PR found"
           fi
+
+      # ── Validate command (slash-command path; skipped on config error) ──
+      - name: Validate Command
+        id: validate
+        if: |
+          needs.check-trigger.outputs.trigger_type == 'slash_command' &&
+          steps.state.outputs.config_error == ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const user = '${{ needs.check-trigger.outputs.user }}';
+            const command = '${{ needs.check-trigger.outputs.command }}';
+            const currentState = '${{ steps.state.outputs.state }}';
+
+            console.log(`Validating command: /${command}`);
+            console.log(`Current state: ${currentState}`);
+            console.log(`User: ${user}`);
+
+            // Define allowed commands per state
+            const allowedCommands = {
+              'planned': ['create-snapshot', 'sync-issue'],
+              'snapshot-active': ['discard-snapshot', 'sync-issue'],
+              'draft-ready': ['delete-draft', 'publish-release', 'sync-issue'],
+              'published': ['sync-issue'],
+              'not-planned': ['sync-issue']
+            };
+
+            // Check if command is allowed in current state
+            const allowed = allowedCommands[currentState] || [];
+            if (!allowed.includes(command)) {
+              const validCommands = allowed.length > 0
+                ? `Valid commands: ${allowed.map(c => '/' + c).join(', ')}`
+                : 'No commands available in this state';
+
+              core.setOutput('allowed', 'false');
+              core.setOutput('error_message', `Command /${command} is not allowed in state '${currentState}'. ${validCommands}`);
+              return;
+            }
+
+            // Block /create-snapshot when common file cache is stale
+            if (command === 'create-snapshot') {
+              const cacheStatus = '${{ steps.cache-sync.outputs.common_cache_status }}';
+              const cacheDetails = '${{ steps.cache-sync.outputs.common_cache_details }}';
+              const syncPrUrl = '${{ steps.find-sync-pr.outputs.common_sync_pr_url }}';
+              if (cacheStatus === 'stale') {
+                const prHint = syncPrUrl
+                  ? ` Merge the sync PR: ${syncPrUrl}`
+                  : ' Run workflow_dispatch to trigger sync, or close and reopen the Release Issue.';
+                core.setOutput('allowed', 'false');
+                core.setOutput('error_message',
+                  `Common file cache is stale: ${cacheDetails}.${prHint}`);
+                return;
+              }
+            }
+
+            // Check user permission (must be write or higher)
+            console.log('Checking user permission...');
+            let userPermission;
+
+            // Trusted CI bot identities. App bots don't register as collaborators,
+            // so getCollaboratorPermissionLevel returns 'none' for them; the write
+            // intent is established by the App installation on the target repo.
+            // Currently used by the Release Automation Regression canary in
+            // camaraproject/tooling, which posts slash commands as
+            // camara-validation[bot].
+            const TRUSTED_BOT_USERS = new Set(['camara-validation[bot]']);
+
+            if (TRUSTED_BOT_USERS.has(user)) {
+              userPermission = 'write';
+              console.log(`User ${user} is a trusted CI bot; treating as write`);
+            } else {
+              try {
+                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: user
+                });
+
+                userPermission = permission.permission;
+                console.log(`User permission: ${userPermission}`);
+              } catch (error) {
+                console.log(`Permission check failed: ${error.message}`);
+                // If we can't check permission, deny by default
+                core.setOutput('allowed', 'false');
+                core.setOutput('error_message', `Failed to verify permissions: ${error.message}`);
+                return;
+              }
+            }
+
+            const hasPermission = ['admin', 'maintain', 'write'].includes(userPermission);
+
+            if (!hasPermission) {
+              core.setOutput('allowed', 'false');
+              core.setOutput('error_message', `You must have write access or higher to run release commands. Your current permission: ${userPermission}`);
+              return;
+            }
+
+            // For /publish-release, additionally check CODEOWNERS membership
+            // Break glass: maintain and admin users bypass CODEOWNERS check
+            if (command === 'publish-release' && userPermission === 'write') {
+              console.log('Checking CODEOWNERS membership for publish-release (write-level user)...');
+
+              try {
+                // Fetch CODEOWNERS file from main branch
+                const { data: codeownersFile } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: 'CODEOWNERS',
+                  ref: 'main'
+                });
+
+                const codeownersContent = Buffer.from(codeownersFile.content, 'base64').toString('utf-8');
+                console.log('CODEOWNERS content fetched');
+
+                // Parse * pattern line to get codeowners
+                // Example: "* @hdamker @rartych"
+                const lines = codeownersContent.split('\n');
+                const codeowners = [];
+                for (const line of lines) {
+                  const trimmed = line.trim();
+                  // Skip comments and empty lines
+                  if (trimmed.startsWith('#') || !trimmed) continue;
+                  // Look for * pattern (applies to all files)
+                  if (trimmed.startsWith('* ') || trimmed === '*') {
+                    // Extract usernames (@user1 @user2)
+                    const matches = trimmed.match(/@(\S+)/g);
+                    if (matches) {
+                      for (const match of matches) {
+                        codeowners.push(match.substring(1).toLowerCase()); // Remove @ prefix
+                      }
+                    }
+                    break; // Only use first * pattern found
+                  }
+                }
+
+                console.log(`Codeowners: ${codeowners.join(', ')}`);
+
+                // Check if user is in codeowners list
+                if (codeowners.length > 0 && !codeowners.includes(user.toLowerCase())) {
+                  core.setOutput('allowed', 'false');
+                  core.setOutput('error_message', `Only codeowners or admins can publish releases. @${user} is not listed in CODEOWNERS.`);
+                  return;
+                }
+
+                console.log(`User ${user} is a codeowner`);
+              } catch (error) {
+                // CODEOWNERS file not found or other error
+                console.log(`Could not check CODEOWNERS: ${error.message}`);
+                if (error.status === 404) {
+                  // No CODEOWNERS file - fall back to permission-only check (already passed)
+                  console.log('No CODEOWNERS file found, skipping codeowner check');
+                } else {
+                  // For other errors, deny by default
+                  core.setOutput('allowed', 'false');
+                  core.setOutput('error_message', `Failed to verify codeowner status: ${error.message}`);
+                  return;
+                }
+              }
+            } else if (command === 'publish-release') {
+              // Maintain/admin user - bypass CODEOWNERS check (break glass)
+              console.log(`User ${user} has ${userPermission} permission - bypassing CODEOWNERS check`);
+            }
+
+            // For publish-release with --confirm, validate the tag matches
+            const confirmTag = '${{ needs.check-trigger.outputs.confirm_tag }}';
+            const releaseTag = '${{ steps.state.outputs.release_tag }}';
+            if (command === 'publish-release' && confirmTag) {
+              if (confirmTag !== releaseTag) {
+                core.setOutput('allowed', 'false');
+                core.setOutput('error_message', `Confirm tag \`${confirmTag}\` does not match expected release tag \`${releaseTag}\`. Use: /publish-release --confirm ${releaseTag}`);
+                return;
+              }
+            }
+
+            // All checks passed
+            console.log('Command validated successfully');
+            core.setOutput('allowed', 'true');
+            core.setOutput('error_message', '');
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Phase 2b: Handle configuration errors (if derive-state detected any)
@@ -679,12 +860,12 @@ jobs:
   # Phase 3: Post interim comment (for slash commands only)
   # ─────────────────────────────────────────────────────────────────────────────
   post-interim:
-    needs: [check-trigger, derive-state, assemble-context, validate-command]
+    needs: [check-trigger, derive-state, assemble-context]
     if: |
       needs.check-trigger.outputs.should_continue == 'true' &&
       needs.check-trigger.outputs.trigger_type == 'slash_command' &&
       needs.derive-state.outputs.config_error == '' &&
-      needs.validate-command.outputs.allowed == 'true'
+      needs.derive-state.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     outputs:
       comment_id: ${{ steps.post.outputs.comment_id }}
@@ -715,193 +896,9 @@ jobs:
           context: "{}"
           comment_id: ${{ needs.check-trigger.outputs.comment_id }}
 
-  # ─────────────────────────────────────────────────────────────────────────────
-  # Phase 4: Validate command (for slash commands only, skip on config error)
-  # ─────────────────────────────────────────────────────────────────────────────
-  validate-command:
-    needs: [check-trigger, derive-state]
-    if: |
-      needs.check-trigger.outputs.should_continue == 'true' &&
-      needs.check-trigger.outputs.trigger_type == 'slash_command' &&
-      needs.derive-state.outputs.config_error == ''
-    runs-on: ubuntu-latest
-    outputs:
-      allowed: ${{ steps.validate.outputs.allowed }}
-      error_message: ${{ steps.validate.outputs.error_message }}
-    steps:
-      - name: Validate Command
-        id: validate
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const user = '${{ needs.check-trigger.outputs.user }}';
-            const command = '${{ needs.check-trigger.outputs.command }}';
-            const currentState = '${{ needs.derive-state.outputs.state }}';
-
-            console.log(`Validating command: /${command}`);
-            console.log(`Current state: ${currentState}`);
-            console.log(`User: ${user}`);
-
-            // Define allowed commands per state
-            const allowedCommands = {
-              'planned': ['create-snapshot', 'sync-issue'],
-              'snapshot-active': ['discard-snapshot', 'sync-issue'],
-              'draft-ready': ['delete-draft', 'publish-release', 'sync-issue'],
-              'published': ['sync-issue'],
-              'not-planned': ['sync-issue']
-            };
-
-            // Check if command is allowed in current state
-            const allowed = allowedCommands[currentState] || [];
-            if (!allowed.includes(command)) {
-              const validCommands = allowed.length > 0
-                ? `Valid commands: ${allowed.map(c => '/' + c).join(', ')}`
-                : 'No commands available in this state';
-
-              core.setOutput('allowed', 'false');
-              core.setOutput('error_message', `Command /${command} is not allowed in state '${currentState}'. ${validCommands}`);
-              return;
-            }
-
-            // Block /create-snapshot when common file cache is stale
-            if (command === 'create-snapshot') {
-              const cacheStatus = '${{ needs.derive-state.outputs.common_cache_status }}';
-              const cacheDetails = '${{ needs.derive-state.outputs.common_cache_details }}';
-              const syncPrUrl = '${{ needs.derive-state.outputs.common_sync_pr_url }}';
-              if (cacheStatus === 'stale') {
-                const prHint = syncPrUrl
-                  ? ` Merge the sync PR: ${syncPrUrl}`
-                  : ' Run workflow_dispatch to trigger sync, or close and reopen the Release Issue.';
-                core.setOutput('allowed', 'false');
-                core.setOutput('error_message',
-                  `Common file cache is stale: ${cacheDetails}.${prHint}`);
-                return;
-              }
-            }
-
-            // Check user permission (must be write or higher)
-            console.log('Checking user permission...');
-            let userPermission;
-
-            // Trusted CI bot identities. App bots don't register as collaborators,
-            // so getCollaboratorPermissionLevel returns 'none' for them; the write
-            // intent is established by the App installation on the target repo.
-            // Currently used by the Release Automation Regression canary in
-            // camaraproject/tooling, which posts slash commands as
-            // camara-validation[bot].
-            const TRUSTED_BOT_USERS = new Set(['camara-validation[bot]']);
-
-            if (TRUSTED_BOT_USERS.has(user)) {
-              userPermission = 'write';
-              console.log(`User ${user} is a trusted CI bot; treating as write`);
-            } else {
-              try {
-                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  username: user
-                });
-
-                userPermission = permission.permission;
-                console.log(`User permission: ${userPermission}`);
-              } catch (error) {
-                console.log(`Permission check failed: ${error.message}`);
-                // If we can't check permission, deny by default
-                core.setOutput('allowed', 'false');
-                core.setOutput('error_message', `Failed to verify permissions: ${error.message}`);
-                return;
-              }
-            }
-
-            const hasPermission = ['admin', 'maintain', 'write'].includes(userPermission);
-
-            if (!hasPermission) {
-              core.setOutput('allowed', 'false');
-              core.setOutput('error_message', `You must have write access or higher to run release commands. Your current permission: ${userPermission}`);
-              return;
-            }
-
-            // For /publish-release, additionally check CODEOWNERS membership
-            // Break glass: maintain and admin users bypass CODEOWNERS check
-            if (command === 'publish-release' && userPermission === 'write') {
-              console.log('Checking CODEOWNERS membership for publish-release (write-level user)...');
-
-              try {
-                // Fetch CODEOWNERS file from main branch
-                const { data: codeownersFile } = await github.rest.repos.getContent({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  path: 'CODEOWNERS',
-                  ref: 'main'
-                });
-
-                const codeownersContent = Buffer.from(codeownersFile.content, 'base64').toString('utf-8');
-                console.log('CODEOWNERS content fetched');
-
-                // Parse * pattern line to get codeowners
-                // Example: "* @hdamker @rartych"
-                const lines = codeownersContent.split('\n');
-                const codeowners = [];
-                for (const line of lines) {
-                  const trimmed = line.trim();
-                  // Skip comments and empty lines
-                  if (trimmed.startsWith('#') || !trimmed) continue;
-                  // Look for * pattern (applies to all files)
-                  if (trimmed.startsWith('* ') || trimmed === '*') {
-                    // Extract usernames (@user1 @user2)
-                    const matches = trimmed.match(/@(\S+)/g);
-                    if (matches) {
-                      for (const match of matches) {
-                        codeowners.push(match.substring(1).toLowerCase()); // Remove @ prefix
-                      }
-                    }
-                    break; // Only use first * pattern found
-                  }
-                }
-
-                console.log(`Codeowners: ${codeowners.join(', ')}`);
-
-                // Check if user is in codeowners list
-                if (codeowners.length > 0 && !codeowners.includes(user.toLowerCase())) {
-                  core.setOutput('allowed', 'false');
-                  core.setOutput('error_message', `Only codeowners or admins can publish releases. @${user} is not listed in CODEOWNERS.`);
-                  return;
-                }
-
-                console.log(`User ${user} is a codeowner`);
-              } catch (error) {
-                // CODEOWNERS file not found or other error
-                console.log(`Could not check CODEOWNERS: ${error.message}`);
-                if (error.status === 404) {
-                  // No CODEOWNERS file - fall back to permission-only check (already passed)
-                  console.log('No CODEOWNERS file found, skipping codeowner check');
-                } else {
-                  // For other errors, deny by default
-                  core.setOutput('allowed', 'false');
-                  core.setOutput('error_message', `Failed to verify codeowner status: ${error.message}`);
-                  return;
-                }
-              }
-            } else if (command === 'publish-release') {
-              // Maintain/admin user - bypass CODEOWNERS check (break glass)
-              console.log(`User ${user} has ${userPermission} permission - bypassing CODEOWNERS check`);
-            }
-
-            // For publish-release with --confirm, validate the tag matches
-            const confirmTag = '${{ needs.check-trigger.outputs.confirm_tag }}';
-            const releaseTag = '${{ needs.derive-state.outputs.release_tag }}';
-            if (command === 'publish-release' && confirmTag) {
-              if (confirmTag !== releaseTag) {
-                core.setOutput('allowed', 'false');
-                core.setOutput('error_message', `Confirm tag \`${confirmTag}\` does not match expected release tag \`${releaseTag}\`. Use: /publish-release --confirm ${releaseTag}`);
-                return;
-              }
-            }
-
-            // All checks passed
-            console.log('Command validated successfully');
-            core.setOutput('allowed', 'true');
-            core.setOutput('error_message', '');
+  # validate-command was folded into derive-state (single runner; same setup).
+  # See the "Validate Command" step at the end of derive-state for the canonical
+  # location. Outputs are exposed as needs.derive-state.outputs.{allowed,error_message}.
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Phase 5a: Handle rejected command
@@ -911,12 +908,11 @@ jobs:
       [
         check-trigger,
         derive-state,
-        validate-command,
         assemble-context,
       ]
     if: |
       needs.check-trigger.outputs.trigger_type == 'slash_command' &&
-      needs.validate-command.outputs.allowed == 'false'
+      needs.derive-state.outputs.allowed == 'false'
     runs-on: ubuntu-latest
     steps:
       # No App token needed — rejection updates the ack comment using GITHUB_TOKEN
@@ -943,7 +939,7 @@ jobs:
           base_context: ${{ needs.assemble-context.outputs.base_context }}
           context: |
             {
-              "error_message": "${{ needs.validate-command.outputs.error_message }}"
+              "error_message": "${{ needs.derive-state.outputs.error_message }}"
             }
           comment_id: ${{ needs.check-trigger.outputs.comment_id }}
 
@@ -951,10 +947,10 @@ jobs:
   # Phase 5b: Execute create-snapshot command
   # ─────────────────────────────────────────────────────────────────────────────
   create-snapshot:
-    needs: [check-trigger, derive-state, validate-command]
+    needs: [check-trigger, derive-state]
     if: |
       needs.check-trigger.outputs.command == 'create-snapshot' &&
-      needs.validate-command.outputs.allowed == 'true'
+      needs.derive-state.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     outputs:
       success: ${{ steps.create.outputs.success || steps.validation-gate.outputs.success }}
@@ -1151,10 +1147,10 @@ jobs:
   # Phase 5c: Execute discard-snapshot command
   # ─────────────────────────────────────────────────────────────────────────────
   discard-snapshot:
-    needs: [check-trigger, derive-state, validate-command]
+    needs: [check-trigger, derive-state]
     if: |
       needs.check-trigger.outputs.command == 'discard-snapshot' &&
-      needs.validate-command.outputs.allowed == 'true'
+      needs.derive-state.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     outputs:
       success: ${{ steps.discard.outputs.success }}
@@ -1261,10 +1257,10 @@ jobs:
   # Phase 5d: Execute delete-draft command
   # ─────────────────────────────────────────────────────────────────────────────
   delete-draft:
-    needs: [check-trigger, derive-state, validate-command]
+    needs: [check-trigger, derive-state]
     if: |
       needs.check-trigger.outputs.command == 'delete-draft' &&
-      needs.validate-command.outputs.allowed == 'true'
+      needs.derive-state.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     outputs:
       success: ${{ steps.delete.outputs.success }}
@@ -1392,10 +1388,10 @@ jobs:
   # Phase 5e: Handle publish-release confirmation (no --confirm flag)
   # ─────────────────────────────────────────────────────────────────────────────
   publish-confirmation:
-    needs: [check-trigger, derive-state, assemble-context, post-interim, validate-command]
+    needs: [check-trigger, derive-state, assemble-context, post-interim]
     if: |
       needs.check-trigger.outputs.command == 'publish-release' &&
-      needs.validate-command.outputs.allowed == 'true' &&
+      needs.derive-state.outputs.allowed == 'true' &&
       needs.check-trigger.outputs.confirm_tag == ''
     runs-on: ubuntu-latest
     steps:
@@ -1447,11 +1443,11 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   publish-release:
     name: "Publish Release"
-    needs: [check-trigger, derive-state, validate-command]
+    needs: [check-trigger, derive-state]
     if: |
       needs.check-trigger.outputs.command == 'publish-release' &&
       needs.check-trigger.outputs.confirm_tag != '' &&
-      needs.validate-command.outputs.allowed == 'true'
+      needs.derive-state.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     outputs:
       success: ${{ steps.publish.outputs.success }}
@@ -1601,7 +1597,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   create-sync-pr:
     name: "Create Post-Release Sync PR"
-    needs: [check-trigger, derive-state, validate-command, publish-release]
+    needs: [check-trigger, derive-state, publish-release]
     if: |
       needs.publish-release.outputs.success == 'true'
     runs-on: ubuntu-latest
@@ -2581,7 +2577,6 @@ jobs:
         check-trigger,
         post-interim,
         derive-state,
-        validate-command,
         create-snapshot,
         discard-snapshot,
         delete-draft,
@@ -2593,7 +2588,7 @@ jobs:
     if: |
       always() &&
       needs.check-trigger.outputs.trigger_type == 'slash_command' &&
-      needs.validate-command.outputs.allowed == 'true' &&
+      needs.derive-state.outputs.allowed == 'true' &&
       needs.post-interim.result == 'success' &&
       needs.publish-confirmation.result != 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -416,6 +416,8 @@ jobs:
       # Validate-command outputs (slash-command path; empty for non-slash triggers)
       allowed: ${{ steps.validate.outputs.allowed }}
       error_message: ${{ steps.validate.outputs.error_message }}
+      # Assemble-context output (empty when config_error is set)
+      base_context: ${{ steps.assemble.outputs.base_context }}
     steps:
       - name: Checkout tooling
         uses: actions/checkout@v6
@@ -425,6 +427,7 @@ jobs:
           path: _tooling
           sparse-checkout: |
             release_automation/scripts
+            release_automation/templates
             shared-actions/derive-release-state
             tooling_lib
 
@@ -714,6 +717,35 @@ jobs:
             core.setOutput('allowed', 'true');
             core.setOutput('error_message', '');
 
+      # ── Assemble Context (skipped on config error) ──
+      - name: Assemble Context
+        id: assemble
+        if: steps.state.outputs.config_error == ''
+        run: |
+          python3 _tooling/release_automation/scripts/workflow_context.py
+        env:
+          CTX_COMMAND: ${{ needs.check-trigger.outputs.command }}
+          CTX_COMMAND_ARGS: ${{ needs.check-trigger.outputs.command_args }}
+          CTX_USER: ${{ needs.check-trigger.outputs.user }}
+          CTX_TRIGGER_TYPE: ${{ needs.check-trigger.outputs.trigger_type }}
+          CTX_RELEASE_TAG: ${{ steps.state.outputs.release_tag }}
+          CTX_STATE: ${{ steps.state.outputs.state }}
+          CTX_RELEASE_TYPE: ${{ steps.state.outputs.release_type }}
+          CTX_META_RELEASE: ${{ steps.state.outputs.meta_release }}
+          CTX_SNAPSHOT_ID: ${{ steps.state.outputs.snapshot_id }}
+          CTX_SNAPSHOT_BRANCH: ${{ steps.state.outputs.snapshot_branch }}
+          CTX_RELEASE_REVIEW_BRANCH: ${{ steps.state.outputs.release_review_branch }}
+          CTX_RELEASE_PR_NUMBER: ${{ steps.state.outputs.release_pr_number }}
+          CTX_SRC_COMMIT_SHA: ${{ steps.state.outputs.src_commit_sha }}
+          CTX_APIS_JSON: ${{ steps.state.outputs.apis_json }}
+          CTX_COMMONALITIES_RELEASE: ${{ steps.state.outputs.commonalities_release }}
+          CTX_IDENTITY_CONSENT_MANAGEMENT_RELEASE: ${{ steps.state.outputs.identity_consent_management_release }}
+          CTX_COMMON_CACHE_STATUS: ${{ steps.cache-sync.outputs.common_cache_status }}
+          CTX_COMMON_CACHE_DETAILS: ${{ steps.cache-sync.outputs.common_cache_details }}
+          CTX_TRIGGER_PR_NUMBER: ${{ needs.check-trigger.outputs.trigger_pr_number }}
+          CTX_TRIGGER_PR_URL: ${{ needs.check-trigger.outputs.trigger_pr_url }}
+          GITHUB_TOKEN: ${{ github.token }}
+
   # ─────────────────────────────────────────────────────────────────────────────
   # Phase 2b: Handle configuration errors (if derive-state detected any)
   # ─────────────────────────────────────────────────────────────────────────────
@@ -807,60 +839,15 @@ jobs:
           esac
           exit 1
 
-  # ─────────────────────────────────────────────────────────────────────────────
-  # Phase 3: Assemble Golden Context
-  # ─────────────────────────────────────────────────────────────────────────────
-  assemble-context:
-    needs: [check-trigger, derive-state]
-    if: |
-      needs.check-trigger.outputs.should_continue == 'true' &&
-      needs.derive-state.outputs.config_error == ''
-    runs-on: ubuntu-latest
-    outputs:
-      base_context: ${{ steps.assemble.outputs.base_context }}
-    steps:
-      - name: Checkout tooling
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ needs.check-trigger.outputs.tooling_checkout_repo }}
-          ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
-          path: _tooling
-          sparse-checkout: |
-            release_automation/scripts
-            release_automation/templates
-
-      - name: Assemble Context
-        id: assemble
-        run: |
-          python3 _tooling/release_automation/scripts/workflow_context.py
-        env:
-          CTX_COMMAND: ${{ needs.check-trigger.outputs.command }}
-          CTX_COMMAND_ARGS: ${{ needs.check-trigger.outputs.command_args }}
-          CTX_USER: ${{ needs.check-trigger.outputs.user }}
-          CTX_TRIGGER_TYPE: ${{ needs.check-trigger.outputs.trigger_type }}
-          CTX_RELEASE_TAG: ${{ needs.derive-state.outputs.release_tag }}
-          CTX_STATE: ${{ needs.derive-state.outputs.state }}
-          CTX_RELEASE_TYPE: ${{ needs.derive-state.outputs.release_type }}
-          CTX_META_RELEASE: ${{ needs.derive-state.outputs.meta_release }}
-          CTX_SNAPSHOT_ID: ${{ needs.derive-state.outputs.snapshot_id }}
-          CTX_SNAPSHOT_BRANCH: ${{ needs.derive-state.outputs.snapshot_branch }}
-          CTX_RELEASE_REVIEW_BRANCH: ${{ needs.derive-state.outputs.release_review_branch }}
-          CTX_RELEASE_PR_NUMBER: ${{ needs.derive-state.outputs.release_pr_number }}
-          CTX_SRC_COMMIT_SHA: ${{ needs.derive-state.outputs.src_commit_sha }}
-          CTX_APIS_JSON: ${{ needs.derive-state.outputs.apis_json }}
-          CTX_COMMONALITIES_RELEASE: ${{ needs.derive-state.outputs.commonalities_release }}
-          CTX_IDENTITY_CONSENT_MANAGEMENT_RELEASE: ${{ needs.derive-state.outputs.identity_consent_management_release }}
-          CTX_COMMON_CACHE_STATUS: ${{ needs.derive-state.outputs.common_cache_status }}
-          CTX_COMMON_CACHE_DETAILS: ${{ needs.derive-state.outputs.common_cache_details }}
-          CTX_TRIGGER_PR_NUMBER: ${{ needs.check-trigger.outputs.trigger_pr_number }}
-          CTX_TRIGGER_PR_URL: ${{ needs.check-trigger.outputs.trigger_pr_url }}
-          GITHUB_TOKEN: ${{ github.token }}
+  # assemble-context was folded into derive-state (single runner; same setup).
+  # See the "Assemble Context" step at the end of derive-state for the canonical
+  # location. Output is exposed as needs.derive-state.outputs.base_context.
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Phase 3: Post interim comment (for slash commands only)
   # ─────────────────────────────────────────────────────────────────────────────
   post-interim:
-    needs: [check-trigger, derive-state, assemble-context]
+    needs: [check-trigger, derive-state]
     if: |
       needs.check-trigger.outputs.should_continue == 'true' &&
       needs.check-trigger.outputs.trigger_type == 'slash_command' &&
@@ -892,7 +879,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: interim_processing
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           context: "{}"
           comment_id: ${{ needs.check-trigger.outputs.comment_id }}
 
@@ -908,7 +895,6 @@ jobs:
       [
         check-trigger,
         derive-state,
-        assemble-context,
       ]
     if: |
       needs.check-trigger.outputs.trigger_type == 'slash_command' &&
@@ -936,7 +922,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: command_rejected
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           context: |
             {
               "error_message": "${{ needs.derive-state.outputs.error_message }}"
@@ -1388,7 +1374,7 @@ jobs:
   # Phase 5e: Handle publish-release confirmation (no --confirm flag)
   # ─────────────────────────────────────────────────────────────────────────────
   publish-confirmation:
-    needs: [check-trigger, derive-state, assemble-context, post-interim]
+    needs: [check-trigger, derive-state, post-interim]
     if: |
       needs.check-trigger.outputs.command == 'publish-release' &&
       needs.derive-state.outputs.allowed == 'true' &&
@@ -1430,7 +1416,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: publish_confirmation
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           context: |
             {
               "draft_release_url": "${{ steps.context.outputs.draft_release_url }}",
@@ -1829,7 +1815,7 @@ jobs:
   # Phase 5g: Handle PR merge (draft release creation)
   # ─────────────────────────────────────────────────────────────────────────────
   handle-pr-merge:
-    needs: [check-trigger, derive-state, assemble-context]
+    needs: [check-trigger, derive-state]
     if: needs.check-trigger.outputs.trigger_type == 'pr_merge'
     runs-on: ubuntu-latest
     outputs:
@@ -2054,7 +2040,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: draft_created
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
@@ -2068,10 +2054,11 @@ jobs:
   # Phase 5f: Handle issue close/reopen events
   # ─────────────────────────────────────────────────────────────────────────────
   handle-issue-event:
-    needs: [check-trigger, derive-state, assemble-context]
+    needs: [check-trigger, derive-state]
     if: |
       always() &&
-      needs.assemble-context.result == 'success' &&
+      needs.derive-state.result == 'success' &&
+      needs.derive-state.outputs.config_error == '' &&
       (needs.check-trigger.outputs.trigger_type == 'issue_close' ||
       needs.check-trigger.outputs.trigger_type == 'issue_reopen')
     runs-on: ubuntu-latest
@@ -2146,7 +2133,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: issue_reopened
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
@@ -2162,7 +2149,6 @@ jobs:
       [
         check-trigger,
         derive-state,
-        assemble-context,
         create-snapshot,
         discard-snapshot,
         delete-draft,
@@ -2484,7 +2470,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: state_not_planned
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
@@ -2501,7 +2487,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: issue_created
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
@@ -2526,7 +2512,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: config_drift_warning
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
@@ -2546,7 +2532,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: common_sync_pr_created
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: |
             {
@@ -2564,7 +2550,7 @@ jobs:
           release_tag: ${{ needs.derive-state.outputs.release_tag }}
           run_id: ${{ github.run_id }}
           template: common_sync_failed
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: '{}'
 
@@ -2583,7 +2569,6 @@ jobs:
         publish-release,
         create-sync-pr,
         publish-confirmation,
-        assemble-context,
       ]
     if: |
       always() &&
@@ -2810,7 +2795,7 @@ jobs:
           run_id: ${{ github.run_id }}
           template: ${{ steps.template.outputs.template }}
           # Use base_context + delta
-          base_context: ${{ needs.assemble-context.outputs.base_context }}
+          base_context: ${{ needs.derive-state.outputs.base_context }}
           github_token: ${{ steps.app-token.outputs.token || github.token }}
           context: ${{ steps.context.outputs.context }}
           comment_id: ${{ needs.post-interim.outputs.comment_id }}


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Folds two lightweight slash-command-path jobs (`validate-command`, `assemble-context`) into `derive-state`. Both already required the same sparse-checkout + Python setup that `derive-state` performs.

Two commits, one consolidation each:

- `validate-command` → `Validate Command` step. 9 `needs.validate-command.outputs.*` references and 8 `needs:` lists rewired.
- `assemble-context` → `Assemble Context` step. 11 `needs.assemble-context.outputs.base_context` references rewired; the single `needs.assemble-context.result == 'success'` becomes `needs.derive-state.result == 'success' && needs.derive-state.outputs.config_error == ''`.

Net job count: 17 → 15. No behavior change.

The third consolidation listed in #101 (`create-sync-pr` → `publish-release`) is intentionally deferred — rationale in [this comment](https://github.com/camaraproject/tooling/issues/101#issuecomment-4409718311). Closes #101 on merge.

#### Which issue(s) this PR fixes:

Fixes #101

#### Special notes for reviewers:

Tested E2E on `hdamker/TestRepo-QoD` ([run 25579540515](https://github.com/hdamker/TestRepo-QoD/actions/runs/25579540515)) — `derive-state` ran the two new steps in order; downstream jobs consumed the consolidated outputs correctly. Test suite 670/670 passing.

#### Changelog input

```
 release-note
Folded validate-command and assemble-context jobs into derive-state — same runner, same setup, no behavior change. Reusable workflow drops from 17 to 15 jobs.
```

#### Additional documentation

```
docs
```
