### PR TITLE
fix(deps): override fast-uri and fast-xml-builder to patched versions

### DIFF
--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -2226,9 +2226,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2240,21 +2240,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.3"
-      }
     },
     "node_modules/fast-xml-parser": {
       "version": "5.7.2",
@@ -2275,6 +2260,21 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fast-xml-parser/node_modules/fast-xml-builder": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
       }
     },
     "node_modules/fastq": {

--- a/validation/package.json
+++ b/validation/package.json
@@ -11,6 +11,8 @@
   "overrides": {
     "lodash": "^4.18.0",
     "postcss": "^8.5.10",
-    "protobufjs": "^7.5.5"
+    "protobufjs": "^7.5.5",
+    "fast-uri": "^3.1.2",
+    "fast-xml-builder": "~1.1.7"
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Closes 4 open Dependabot alerts on transitive dependencies in `validation/` by pinning `fast-uri` and `fast-xml-builder` to patched versions via `package.json` overrides.

| Alert | Package | CVE | Severity |
|---|---|---|---|
| [#15](https://github.com/camaraproject/tooling/security/dependabot/15) | fast-uri | CVE-2026-6322 (host confusion via percent-encoded `@` / `:`) | High |
| [#14](https://github.com/camaraproject/tooling/security/dependabot/14) | fast-uri | CVE-2026-6321 (path traversal via percent-encoded dot segments) | High |
| [#13](https://github.com/camaraproject/tooling/security/dependabot/13) | fast-xml-builder | CVE-2026-44665 (attribute-quote bypass) | High |
| [#12](https://github.com/camaraproject/tooling/security/dependabot/12) | fast-xml-builder | CVE-2026-44664 (comment-regex bypass) | Medium |

Both vulnerable packages are transitive — `fast-uri` under `ajv`, `fast-xml-builder` under `fast-xml-parser`. Parent ranges (`ajv "fast-uri": "^3.0.1"`, `fast-xml-parser "fast-xml-builder": "^1.1.5"`) already permit the patched versions but no upstream consumer release has shipped, so a `package.json` override is sufficient — no major bump of the direct deps needed. Same pattern as the existing `lodash` / `postcss` / `protobufjs` overrides added in [tooling#265](https://github.com/camaraproject/tooling/pull/265).

`fast-xml-builder` pinned to `~1.1.7` (not `^1.1.7`) to stay on the patched 1.1.x line — 1.2.0 would otherwise introduce a brand-new `xml-naming@0.1.0` transitive that the build has no use for.

#### Which issue(s) this PR fixes:

(no separate issue — Dependabot alerts auto-close on merge)

#### Special notes for reviewers:

Verification:

- `npm audit` reports 0 vulnerabilities
- 1011/1011 validation unit tests pass
- Redocly bundle smoke test on `ReleaseTest/sample-service.yaml` succeeds
- Same major versions of consumers (`ajv` 8.x, `fast-xml-parser` 5.7.x) — no behavior change expected

Should fold into the upcoming `@v1-rc` advance E2E alongside the other in-flight `validation/` changes.

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

```
docs
NONE
```
