### PR TITLE
Disable cancel-in-progress on RA regression canary

### DIFF
--- a/.github/workflows/release-automation-regression.yml
+++ b/.github/workflows/release-automation-regression.yml
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: release-automation-regression-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
**What type of PR is this?**

- [x] bug

**What this PR does / why we need it**
Sets `cancel-in-progress: false` on the RA regression canary so a newer run queues instead of cancelling an older one mid-snapshot. Cancellation does not stop the `/create-snapshot` dispatched against `camaraproject/ReleaseTest`, leaving its release issue in `snapshot-active` and requiring manual `/discard-snapshot` to recover.

**Which issue(s) this PR fixes**
Fixes #274

**Special notes for reviewers**
Scoped to `release-automation-regression.yml` only. Sister `validation-regression.yml` keeps `cancel-in-progress: true` — it diffs committed fixtures with no ReleaseTest side effect.

**Changelog input**
- Fix: queue concurrent RA regression canary runs instead of cancelling, to avoid stranding snapshot state on ReleaseTest.

**Additional documentation**
None.
