### PR TITLE
Centralize Python dependencies in requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,16 @@ updates:
       - "dependencies"
       - "javascript"
     open-pull-requests-limit: 5
+
+  # pip (requirements.txt at repo root, consumed by shared-actions and workflows)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5

--- a/.github/workflows/release-automation-regression.yml
+++ b/.github/workflows/release-automation-regression.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install runner dependencies
         run: |
           pip install --upgrade pip
-          pip install pyyaml
+          pip install --quiet -r requirements.txt
 
       - name: Mint validation app token
         id: app-token

--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -1016,7 +1016,7 @@ jobs:
       - name: Validate central settings against schema
         shell: bash
         run: |
-          pip install --quiet pyyaml==6.0.3 jsonschema==4.26.0
+          pip install --quiet -r _tooling/requirements.txt
           python3 - <<'PY'
           import sys
           from pathlib import Path
@@ -1458,7 +1458,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install pyyaml pystache requests
+        run: pip install --quiet -r _tooling/requirements.txt
 
       - name: Generate App Token
         id: app-token

--- a/.github/workflows/validation-regression.yml
+++ b/.github/workflows/validation-regression.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install runner dependencies
         run: |
           pip install --upgrade pip
-          pip install pyyaml jsonschema
+          pip install --quiet -r requirements.txt
 
       - name: Mint validation app token
         id: app-token

--- a/.github/workflows/validation-settings-ci.yml
+++ b/.github/workflows/validation-settings-ci.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install --quiet pyyaml==6.0.3 jsonschema==4.26.0
+        run: pip install --quiet -r requirements.txt
 
       - name: Schema validation
         run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -227,11 +227,11 @@ jobs:
       # why the orchestrator suppresses the Spectral + gherkin engines.
       # ICM has no common files to sync, so an ICM advance does not
       # trigger engine suppression.
-      - name: Install pyyaml for dependency resolver
+      - name: Install Python dependencies for dependency resolver
         if: >-
           github.event_name == 'pull_request'
           && steps.detect-changes.outputs.release_plan_changed == 'true'
-        run: pip install --quiet pyyaml==6.0.3
+        run: pip install --quiet -r .tooling/requirements.txt
 
       - name: Resolve dependency changes and declared tags
         id: detect-deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# Python runtime dependencies for the CAMARA tooling pipelines.
+# Compatible-release pins (~=) keep majors locked while letting Dependabot
+# propose minor / patch bumps. All shared-actions and workflow steps install
+# from this file so a bump touches one place.
+pyyaml~=6.0
+pystache~=0.6
+jsonschema~=4.26
+yamllint~=1.38
+requests~=2.32

--- a/shared-actions/create-snapshot/action.yml
+++ b/shared-actions/create-snapshot/action.yml
@@ -78,7 +78,7 @@ runs:
 
     - name: Install Python dependencies
       shell: bash
-      run: pip install --quiet pyyaml pystache
+      run: pip install --quiet -r "${{ github.action_path }}/../../requirements.txt"
 
     - name: Create Snapshot
       id: create

--- a/shared-actions/derive-release-state/action.yml
+++ b/shared-actions/derive-release-state/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install --quiet pyyaml
+      run: pip install --quiet -r "${{ github.action_path }}/../../requirements.txt"
 
     - name: Derive Release State
       id: derive

--- a/shared-actions/post-bot-comment/action.yml
+++ b/shared-actions/post-bot-comment/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install --quiet pystache
+      run: pip install --quiet -r "${{ github.action_path }}/../../requirements.txt"
 
     - name: Render Template
       id: render

--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -103,7 +103,7 @@ runs:
   steps:
     - name: Install Python dependencies
       shell: bash
-      run: pip install --quiet pyyaml==6.0.3 jsonschema==4.26.0 yamllint==1.38.0
+      run: pip install --quiet -r "${{ inputs.tooling_path }}/requirements.txt"
 
     - name: Install Node dependencies
       shell: bash

--- a/shared-actions/sync-release-issue/action.yml
+++ b/shared-actions/sync-release-issue/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install --quiet pyyaml pystache
+      run: pip install --quiet -r "${{ github.action_path }}/../../requirements.txt"
 
     - name: Sync Release Issue
       id: sync

--- a/shared-actions/validate-release-plan/action.yml
+++ b/shared-actions/validate-release-plan/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install --quiet pyyaml jsonschema
+      run: pip install --quiet -r "${{ github.action_path }}/../../requirements.txt"
 
     - name: Run validation
       id: validate


### PR DESCRIPTION
**What type of PR is this?**

- [x] enhancement

**What this PR does / why we need it**
Closes the gap noted in #151:

1. Adds `requirements.txt` at the repo root with compatible-release pins (`pyyaml~=6.0`, `pystache~=0.6`, `jsonschema~=4.26`, `yamllint~=1.38`, `requests~=2.32`).
2. Replaces 12 inline `pip install <pkgs>` lines (6 workflow steps + 6 shared-actions) with `pip install -r <requirements.txt>`. Path varies by context — workflow files reference their checkout location (`_tooling/`, `.tooling/`, or root); shared-actions use `${{ github.action_path }}/../..` except `run-validation` which takes a `tooling_path` input.
3. Adds the `pip` ecosystem to `.github/dependabot.yml`, mirroring the existing `github-actions` + `npm` entries (weekly Monday, `chore(deps)` prefix, `dependencies` + `python` labels).

After merge, Dependabot starts monitoring the five Python packages on `main`. The previously-pinned `==` versions (`pyyaml==6.0.3`, `jsonschema==4.26.0`, `yamllint==1.38.0`) widen to `~=` — minor bumps land via Dependabot, majors stay locked.

**Which issue(s) this PR fixes**
Fixes #151

**Special notes for reviewers**
- Cone-mode sparse-checkouts (used in RA reusable + validation workflows) always include root-level files, so `requirements.txt` is present even in the slim checkouts.
- `requests` and `yamllint` are now installed for every consumer even though only one caller each uses them. Tradeoff: single source of truth. Per-action sub-requirements files were considered and rejected as over-engineered for the dependency footprint.
- Both regression workflows keep their leading `pip install --upgrade pip` and gain `--quiet` on the dependency install for consistency with the rest of the codebase.

**Changelog input**
- Enhancement: centralize Python dependencies in `requirements.txt`; Dependabot now monitors the pip ecosystem.

**Additional documentation**
None.
