### PR TITLE
chore: drop unused requests from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pyyaml~=6.0
 pystache~=0.6
 jsonschema~=4.26
 yamllint~=1.38
-requests~=2.32


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

`requests~=2.32` was carried forward into `requirements.txt` by #276 from a pre-existing inline `pip install` line, but no Python module or workflow step in the repo actually imports or invokes `requests` (verified by grep across `validation/`, `release_automation/`, `shared-actions/`, `tooling_lib/`, workflows, and composite actions). The first Dependabot `pip` PR (#278) surfaced this — the bump has no consumer to validate against. Dropping the line stops future Dependabot churn on a dead dep.

The four remaining entries in `requirements.txt` are all actively imported (`pyyaml` 29 sites, `pystache` 4 sites, `jsonschema` 3 sites) or invoked via subprocess (`yamllint` CLI in `validation/engines/yamllint_adapter.py`).

#### Which issue(s) this PR fixes:

N/A — housekeeping follow-up to #276.

#### Special notes for reviewers:

One-line removal in `requirements.txt`. No Python code or workflow changes. #278 will be closed without merge once this lands.

#### Changelog input

```
 release-note
 NONE

```

#### Additional documentation

This section can be blank.

```
 docs

```
