### PR TITLE
docs: fold two pilot-doc wording deviations into user-documentation guidelines

### DIFF
--- a/validation/docs/user-documentation-guidelines.md
+++ b/validation/docs/user-documentation-guidelines.md
@@ -226,7 +226,7 @@ Purpose: explain how and when to inspect bundled API definitions with resolved r
 
 Cover:
 
-- if bundled APIs are produced, the workflow exposes a `validation-bundled-specs` artifact containing the bundled files
+- if a source spec uses external `$ref`s, the workflow produces bundled files and exposes them as a `validation-bundled-specs` artifact
 - bundled files are useful to preview the resolved API definition that a reader or release artifact may show
 - validation problems are produced before the bundling step, based on source files
 - a problem message already contains the source file path, for example an API definition file or `code/common/CAMARA_event_common.yaml`
@@ -236,7 +236,7 @@ Cover:
 
 Key message:
 
-> Bundled API definitions are for previewing resolved `$ref`s, not for tracing validation problem provenance.
+> Bundled API definitions are for previewing resolved `$ref`s, not for finding the source of a validation problem.
 
 ### `problem-messages.md`
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Folds two pilot-doc wording deviations from #239 back into `validation/docs/user-documentation-guidelines.md`.

#### Which issue(s) this PR fixes:

Part of [ReleaseManagement#485](https://github.com/camaraproject/ReleaseManagement/issues/485) (documentation tracker, intentionally kept open).

#### Special notes for reviewers:

Two-line diff in a single file. No code or user-facing doc changes — only the internal guideline that future user-doc contributors consult.

#### Changelog input

```
 release-note
 NONE

```

#### Additional documentation

This section can be blank.

```
 docs

```
