### PR TITLE
fix(release-automation): pass user-supplied reason via env to prevent shell injection

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -125,11 +125,11 @@ jobs:
               //
               // commandArgs is clamped to what follows on the SAME line as
               // the command. Anything after the first newline is treated
-              // as free-form context and ignored. No command consumes more
-              // than a single-token reason or a '--confirm <tag>' flag, so
-              // this also blocks shell-injection via backticks in multi-line
-              // bodies when command_args flows into downstream shell steps
-              // (e.g. post-result's Resolve Reason).
+              // as free-form context and ignored. This clamp is for length
+              // and tidiness only — it does NOT sanitise shell metacharacters
+              // such as backticks or $(). Downstream shell steps that consume
+              // command_args (e.g. post-result's Resolve Reason) must pass it
+              // via env: rather than ${{ ... }} interpolation.
               const firstLine = body.split(/\r?\n/, 1)[0];
 
               if (/^\/create-snapshot(?:\s|$)/.test(body)) {
@@ -2649,9 +2649,14 @@ jobs:
 
       - name: Resolve Reason
         id: reason
+        env:
+          COMMAND: ${{ needs.check-trigger.outputs.command }}
+          COMMAND_ARGS: ${{ needs.check-trigger.outputs.command_args }}
         run: |
-          COMMAND="${{ needs.check-trigger.outputs.command }}"
-          ARGS="${{ needs.check-trigger.outputs.command_args }}"
+          # Pass user-supplied reason text via env (not ${{ ... }}) so backticks,
+          # $(), and other shell metacharacters in slash-command arguments are
+          # treated as opaque text, not expanded by bash.
+          ARGS="$COMMAND_ARGS"
 
           # Default reason for discard/delete commands when none provided
           if [ -z "$ARGS" ] && { [ "$COMMAND" = "discard-snapshot" ] || [ "$COMMAND" = "delete-draft" ]; }; then
@@ -2662,10 +2667,13 @@ jobs:
 
       - name: Build Result Context
         id: context
+        env:
+          REASON: ${{ steps.reason.outputs.reason }}
         run: |
-          # Build delta context
+          # Build delta context — pass REASON via env to avoid shell-interpolating
+          # user-supplied text (same rationale as Resolve Reason above).
           CONTEXT=$(jq -n \
-            --arg reason "${{ steps.reason.outputs.reason }}" \
+            --arg reason "$REASON" \
             '{
               reason: $reason
             }')


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`Resolve Reason` and `Build Result Context` in `release-automation-reusable.yml` interpolated user-supplied slash-command arguments directly into bash via `${{ ... }}`. Backticks in `/discard-snapshot` reasons (e.g. schema names, code references) triggered command substitution and crashed the step with exit 127.

Fix: pass both inputs through `env:` and reference as `"$COMMAND_ARGS"` / `"$REASON"`. Also corrects the parser comment at L122-132 that incorrectly claimed the same-line clamp blocks backtick injection.

#### Which issue(s) this PR fixes:

Fixes #283

#### Special notes for reviewers:

Scope: `.github/workflows/` change → bundles into the next `@v1-rc` tag-move full manual E2E per the tag-move gate rules documented in [`release_automation/docs/branching-model.md`](https://github.com/camaraproject/tooling/blob/main/release_automation/docs/branching-model.md).

#### Changelog input

```
 release-note
fix(release-automation): pass user-supplied reason text through `env:` in `Resolve Reason` and `Build Result Context` to prevent shell-injection when `/discard-snapshot` or `/delete-draft` reasons contain backticks, `$()`, or other shell metacharacters.
```

#### Additional documentation 

This section can be blank.



```
docs

```
