### PR TITLE
fix(release-automation): remove literal ${{ ... }} from comments inside script:/run: blocks

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -129,7 +129,8 @@ jobs:
               // and tidiness only — it does NOT sanitise shell metacharacters
               // such as backticks or $(). Downstream shell steps that consume
               // command_args (e.g. post-result's Resolve Reason) must pass it
-              // via env: rather than ${{ ... }} interpolation.
+              // through step-level env: rather than via GitHub Actions
+              // expression interpolation.
               const firstLine = body.split(/\r?\n/, 1)[0];
 
               if (/^\/create-snapshot(?:\s|$)/.test(body)) {
@@ -2653,9 +2654,10 @@ jobs:
           COMMAND: ${{ needs.check-trigger.outputs.command }}
           COMMAND_ARGS: ${{ needs.check-trigger.outputs.command_args }}
         run: |
-          # Pass user-supplied reason text via env (not ${{ ... }}) so backticks,
-          # $(), and other shell metacharacters in slash-command arguments are
-          # treated as opaque text, not expanded by bash.
+          # Pass user-supplied reason text via env (not via GitHub Actions
+          # expression interpolation) so backticks, $(), and other shell
+          # metacharacters in slash-command arguments are treated as opaque
+          # text, not expanded by bash.
           ARGS="$COMMAND_ARGS"
 
           # Default reason for discard/delete commands when none provided


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

#286 introduced two comments containing the illustrative-syntax string `${{ ... }}` inside `script:` and `run:` block scalars. GitHub Actions pre-expands `${{ ... }}` inside block scalars before the shell/JS body is interpreted, and `...` is not a valid expression token, so the workflow file is rejected at parse time:

```
Unexpected symbol: '...'. Located at position 1 within expression: ...
```

The parser reports the position of the containing block scalar (lines 82 and 2655 of `release-automation-reusable.yml`), not the offending comment lines, which is why the issue slipped past local `yaml.safe_load` and was only caught at GitHub Actions runtime.

Effect: `release-automation` runs that pin `@main` (e.g., ReleaseTest's caller) fail immediately at workflow-file validation with no jobs scheduled.

Fix: rephrase both comments to describe GitHub Actions expression interpolation in prose instead of inlining the brace syntax.

#### Which issue(s) this PR fixes:

Fixes regression introduced in #286.

#### Special notes for reviewers:

No behaviour change — comment-only edit. Verified by greping the workflow for any remaining `${{ ... }}` literal (none).

Pinned-`@main` callers (ReleaseTest) recover as soon as this lands. `@v1-rc` callers were never affected because the tag still points at `e25b6486`.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
