### PR TITLE
fix(validation): scope spectral demotion to code/common/ prefix

### DIFF
--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -41,6 +41,10 @@ SEVERITY_MAP: dict[int, str] = {
 
 DEFAULT_SPEC_GLOB = "code/API_definitions/*.yaml"
 
+# File-path prefixes whose findings are treated as non-actionable for the
+# API developer (Commonalities cache, synced from external repo).
+EXTERNAL_PATH_PREFIXES: tuple[str, ...] = ("code/common/",)
+
 # Fallback ruleset when version-specific file is not found.
 DEFAULT_RULESET = ".spectral.yaml"
 
@@ -188,9 +192,13 @@ def normalize_finding(raw: dict, repo_root: Optional[str] = None) -> dict:
     - ``raw["range"]["start"]["line"]`` is 0-indexed; add 1 for the framework.
     - ``raw["range"]["start"]["character"]`` is 0-indexed; add 1.
 
-    Findings on external files (e.g. ``code/common/CAMARA_common.yaml``)
-    that Spectral followed via ``$ref`` are downgraded to ``hint`` level
+    Findings whose ``source`` path falls under one of
+    :data:`EXTERNAL_PATH_PREFIXES` (the Commonalities cache, e.g.
+    ``code/common/CAMARA_common.yaml``) are downgraded to ``hint`` level
     since they are not directly actionable by the API developer.
+    Findings on repo-owned files reached via ``$ref`` (e.g. schema
+    fragments under ``code/modules/<Module>/<Module>.yaml`` in repos that
+    use that layout) keep their native Spectral severity.
 
     Args:
         raw: Single finding dict from Spectral JSON output.
@@ -199,10 +207,11 @@ def normalize_finding(raw: dict, repo_root: Optional[str] = None) -> dict:
     """
     source = _normalize_path(raw.get("source", ""), repo_root)
 
-    # Findings from external files that Spectral followed via $ref
-    # (e.g. code/common/CAMARA_common.yaml) are downgraded to hint —
-    # they are not directly actionable by the API developer.
-    from_external = bool(source and "API_definitions" not in source)
+    # Findings whose source falls under the Commonalities cache prefix
+    # (code/common/) are downgraded to hint — they are not directly
+    # actionable by the API developer.  Repo-owned files reached via $ref
+    # (e.g. schema fragments under code/modules/) keep native severity.
+    from_external = bool(source) and source.startswith(EXTERNAL_PATH_PREFIXES)
 
     start = raw.get("range", {}).get("start", {})
 

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -328,6 +328,40 @@ class TestNormalizeFinding:
         assert finding["level"] == "error"
         assert finding["path"] == ""
 
+    def test_module_file_keeps_severity(self):
+        """Findings on repo-owned schema fragments (e.g. NAM-style
+        code/modules/<Module>/<Module>.yaml reached via $ref) keep their
+        native Spectral severity — they are actionable by the API developer."""
+        raw = {
+            **SAMPLE_SPECTRAL_FINDING,
+            "source": "code/modules/Services/Services.yaml",
+        }
+        finding = normalize_finding(raw)
+        assert finding["level"] == "error"
+        assert finding["path"] == "code/modules/Services/Services.yaml"
+
+    def test_repo_owned_top_level_file_keeps_severity(self):
+        """Any path outside the Commonalities cache prefix keeps native
+        severity, regardless of whether it sits under code/API_definitions/."""
+        raw = {
+            **SAMPLE_SPECTRAL_WARN,
+            "source": "docs/foo.yaml",
+        }
+        finding = normalize_finding(raw)
+        assert finding["level"] == "warn"
+        assert finding["path"] == "docs/foo.yaml"
+
+    def test_external_absolute_path_demotes_after_normalisation(self):
+        """The cache-prefix check runs against the repo-relative path, so
+        absolute Spectral paths that resolve under code/common/ still demote."""
+        raw = {
+            **SAMPLE_SPECTRAL_FINDING,
+            "source": "/home/runner/work/R/R/code/common/CAMARA_event_common.yaml",
+        }
+        finding = normalize_finding(raw, repo_root="/home/runner/work/R/R")
+        assert finding["level"] == "hint"
+        assert finding["path"] == "code/common/CAMARA_event_common.yaml"
+
 
 # ---------------------------------------------------------------------------
 # TestParseSpectralOutput
@@ -413,6 +447,21 @@ class TestParseSpectralOutput:
         assert len(findings) == 2
         assert findings[0]["level"] == "error"  # original API finding
         assert findings[1]["level"] == "hint"   # external finding downgraded
+
+    def test_module_finding_not_downgraded(self):
+        """Findings on repo-owned schema fragments under code/modules/
+        (e.g. NAM-style layouts reached via $ref) keep native severity
+        end-to-end through the parse pipeline."""
+        module_finding = {
+            **SAMPLE_SPECTRAL_FINDING,
+            "source": "code/modules/Services/Services.yaml",
+            "code": "owasp:api1:2023-no-numeric-ids",
+        }
+        raw = json.dumps([module_finding])
+        findings = parse_spectral_output(raw)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "error"
+        assert findings[0]["path"] == "code/modules/Services/Services.yaml"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Replace the substring check at `validation/engines/spectral_adapter.py:205` with a prefix check against a new module-level constant `EXTERNAL_PATH_PREFIXES = ("code/common/",)`. Findings on repo-owned `$ref` targets under `code/modules/` now keep native Spectral severity at PR-time and pre-snapshot. Findings on `code/common/...` continue to demote to `hint`.

#### Which issue(s) this PR fixes:

Fixes #285

#### Special notes for reviewers:

**Behaviour change for `code/modules/` layouts** (local dry-run on current `main`):

| Repo | Total | Today warn/hint | After warn/hint | New errors |
|---|---|---|---|---|
| NetworkAccessManagement (r4.x) | 107 | 16 / 91 | 104 / 3 | 0 |
| CapabilitiesAndRuntimeRestrictions (r3.4) | 16 | 15 / 1 | 16 / 0 | 0 |

No PRs become newly blocked. NAM surfaces 88 new `warn` findings (all OWASP rules: `string-restricted`, `integer-format`, `integer-limit-legacy`, `array-limit`, `string-limit`) that already fire at the bundling stage today; this brings PR-time and pre-snapshot in line.

**Tests**: 80 passed (76 existing + 4 new in `test_spectral_adapter.py`).

**Out of scope**: `derive_api_name()` keeps the same `API_definitions` substring assumption — correct behaviour, since per CAMARA guideline only `code/API_definitions/` carries OAS root documents (the unit that defines `api_name`). A companion PR against `camaraproject/ReleaseManagement` tightens the design-doc §1.3 wording.

#### Changelog input

```
 release-note
fix(validation): Spectral findings on repo-owned schema fragments under
code/modules/ are no longer demoted to hint. Only files under code/common/
(Commonalities cache) are treated as non-actionable.
```

#### Additional documentation 

This section can be blank.

```
docs

```
