### PR TITLE
Accept allowlisted refs in tooling_ref_override (main, v1-rc, hotfix)

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -26,10 +26,17 @@ on:
         required: false
         default: ""
       tooling_ref_override:
-        description: "Optional tooling checkout ref override (40-char SHA)"
+        description: >-
+          Optional tooling checkout ref override. Accepts a 40-char SHA or one
+          of the refs listed in env.ALLOWED_TOOLING_REFS (workflow-level).
         type: string
         required: false
         default: ""
+
+env:
+  # Allowlist for tooling_ref_override beyond a 40-char SHA. Comma-separated.
+  # Each consuming caller's override input must match a SHA or one of these.
+  ALLOWED_TOOLING_REFS: "main,v1-rc,hotfix"
 
 permissions:
   contents: write
@@ -288,10 +295,15 @@ jobs:
         uses: actions/github-script@v9
         env:
           TOOLING_REF_OVERRIDE: ${{ inputs.tooling_ref_override }}
+          ALLOWED_TOOLING_REFS: ${{ env.ALLOWED_TOOLING_REFS }}
         with:
           script: |
             const overrideRef = (process.env.TOOLING_REF_OVERRIDE || '').trim();
             const shaPattern = /^[0-9a-f]{40}$/i;
+            const allowedRefs = new Set(
+              (process.env.ALLOWED_TOOLING_REFS || '')
+                .split(',').map(s => s.trim()).filter(Boolean)
+            );
             const workflowRefPattern =
               /^([^/]+\/[^/]+)\/\.github\/workflows\/release-automation-reusable\.yml@.+$/;
 
@@ -330,11 +342,16 @@ jobs:
             let checkoutRefSource = 'oidc_job_workflow_sha';
 
             if (overrideRef !== '') {
-              if (!shaPattern.test(overrideRef)) {
-                core.setFailed('tooling_ref_override must be a full 40-character SHA');
+              const isSha = shaPattern.test(overrideRef);
+              const isAllowedRef = allowedRefs.has(overrideRef);
+              if (!isSha && !isAllowedRef) {
+                const allowedList = [...allowedRefs].join(', ');
+                core.setFailed(
+                  `tooling_ref_override must be a 40-character SHA or one of: ${allowedList}`
+                );
                 return;
               }
-              checkoutRef = overrideRef.toLowerCase();
+              checkoutRef = isSha ? overrideRef.toLowerCase() : overrideRef;
               checkoutRefSource = 'override';
             }
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,8 +14,9 @@ on:
     inputs:
       tooling_ref_override:
         description: >-
-          40-character SHA to override the automatic tooling checkout ref.
-          Pilot / break-glass only.
+          Tooling checkout ref override. Accepts a 40-character SHA or one of
+          the refs listed in env.ALLOWED_TOOLING_REFS (workflow-level).
+          Pilot / break-glass / canary only.
         type: string
         required: false
         default: ""
@@ -33,6 +34,11 @@ on:
         type: string
         required: false
         default: ""
+
+env:
+  # Allowlist for tooling_ref_override beyond a 40-char SHA. Comma-separated.
+  # Each consuming caller's override input must match a SHA or one of these.
+  ALLOWED_TOOLING_REFS: "main,v1-rc,hotfix"
 
 permissions:
   checks: write
@@ -60,10 +66,15 @@ jobs:
         uses: actions/github-script@v9
         env:
           TOOLING_REF_OVERRIDE: ${{ inputs.tooling_ref_override }}
+          ALLOWED_TOOLING_REFS: ${{ env.ALLOWED_TOOLING_REFS }}
         with:
           script: |
             const overrideRef = (process.env.TOOLING_REF_OVERRIDE || '').trim();
             const shaPattern = /^[0-9a-f]{40}$/i;
+            const allowedRefs = new Set(
+              (process.env.ALLOWED_TOOLING_REFS || '')
+                .split(',').map(s => s.trim()).filter(Boolean)
+            );
             const workflowRefPattern =
               /^([^/]+\/[^/]+)\/\.github\/workflows\/validation\.yml@.+$/;
 
@@ -82,14 +93,20 @@ jobs:
 
             // Tier 1: Explicit override (highest priority)
             if (overrideRef) {
-              if (!shaPattern.test(overrideRef)) {
-                core.setFailed('tooling_ref_override must be a full 40-character SHA');
+              const isSha = shaPattern.test(overrideRef);
+              const isAllowedRef = allowedRefs.has(overrideRef);
+              if (!isSha && !isAllowedRef) {
+                const allowedList = [...allowedRefs].join(', ');
+                core.setFailed(
+                  `tooling_ref_override must be a 40-character SHA or one of: ${allowedList}`
+                );
                 return;
               }
+              const ref = isSha ? overrideRef.toLowerCase() : overrideRef;
               core.setOutput('tooling_checkout_repo', 'camaraproject/tooling');
-              core.setOutput('tooling_checkout_ref', overrideRef.toLowerCase());
+              core.setOutput('tooling_checkout_ref', ref);
               core.setOutput('tooling_ref_source', 'override');
-              core.info(`Tooling ref: override ${overrideRef.substring(0, 7)}`);
+              core.info(`Tooling ref: override ${isSha ? overrideRef.substring(0, 7) : overrideRef}`);
               return;
             }
 


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

`tooling_ref_override` on both reusable workflows (`validation.yml` and `release-automation-reusable.yml`) currently accepts only a 40-char SHA. The canary repository (`camaraproject/ReleaseTest`) pins its callers to `@main`; fork PRs against the canary fall back to `@v1-rc` on OIDC unavailability and break whenever `main` has moved past the tag. A SHA pin works once but has to be bumped on every `main` advance — the wrong shape for a canary.

This PR adds a small allowlist of named refs (`main`, `v1-rc`, `hotfix`) accepted in addition to a 40-char SHA. The allowlist lives in a workflow-level `env.ALLOWED_TOOLING_REFS` block (top of each file) so it's visible without diving into the `github-script` block.

`hotfix` covers the convention of a single in-flight hotfix branch in `tooling`: consumers pin `tooling_ref_override: hotfix` once and don't need to re-pin on every hotfix-branch commit.

#### Which issue(s) this PR fixes:

Fixes #289

#### Special notes for reviewers:

- No change to the OIDC tier or the fallback-tag tier — only the override tier is extended.
- Both reusable workflows updated for behavioural consistency (validation + release-automation share the same allowlist).
- actionlint clean (no new findings vs `main`).

#### Changelog input

```
 release-note
`tooling_ref_override` on validation and release-automation reusable workflows now accepts the named refs `main`, `v1-rc`, and `hotfix` in addition to a 40-character SHA.
```

#### Additional documentation 

This section can be blank.

```
docs
```
