### PR TITLE
Add P-026..P-030: mandatory info.description content validation

### DIFF
--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -8,6 +8,7 @@ from ._types import CheckDescriptor, CheckScope
 
 from .error_code_checks import check_conflict_deprecated, check_contextcode_format
 from .filename_checks import check_filename_kebab_case, check_filename_matches_api_name
+from .info_description_checks import check_info_description_templates
 from .metadata_checks import check_commonalities_version
 from .readme_checks import check_readme_placeholder_removal
 from .common_cache_checks import check_common_cache_sync
@@ -55,6 +56,11 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-cloudevent-via-ref", CheckScope.API, check_cloudevent_via_ref),
     CheckDescriptor("check-conflict-deprecated", CheckScope.API, check_conflict_deprecated),
     CheckDescriptor("check-contextcode-format", CheckScope.API, check_contextcode_format),
+    CheckDescriptor(
+        "check-info-description-mandatory-missing",
+        CheckScope.API,
+        check_info_description_templates,
+    ),
     # --- Repo-level checks (run once) ---
     CheckDescriptor("check-test-directory-exists", CheckScope.REPO, check_test_directory_exists),
     CheckDescriptor("check-release-plan-semantics", CheckScope.REPO, check_release_plan_semantics),

--- a/validation/engines/python_checks/info_description_checks.py
+++ b/validation/engines/python_checks/info_description_checks.py
@@ -1,0 +1,571 @@
+"""Mandatory ``info.description`` content validation (P-026..P-030).
+
+Enforces the BEGIN/END marker mechanism described in
+``validation/docs/CAMARA-Validation-Framework-Info-Description-Design.md``.
+
+A canonical YAML file ``code/common/info-description-templates.yaml`` (synced
+from Commonalities by the cache-common feature) declares, per template name,
+the mandatory text that an API spec MUST embed verbatim between
+``<!-- CAMARA:MANDATORY:<template-name>:BEGIN -->`` and
+``<!-- CAMARA:MANDATORY:<template-name>:END -->`` markers inside its
+``info.description``.
+
+A single function emits findings under five distinct ``engine_rule`` values:
+
+* ``check-info-description-mandatory-missing`` (P-026, universal templates only)
+* ``check-info-description-mandatory-drift`` (P-027)
+* ``check-info-description-mandatory-duplicate`` (P-028)
+* ``check-info-description-mandatory-unknown-template-name`` (P-029)
+* ``check-info-description-folded-scalar`` (P-030)
+
+Only the first is registered as a :class:`CheckDescriptor` — the others are
+satellite ``engine_rule`` values that the post-filter maps to their own
+metadata entries.  Same pattern as the P-007 / P-024 split in
+``test_checks.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+from validation.context import ValidationContext
+
+from ._types import make_finding
+
+logger = logging.getLogger(__name__)
+
+
+_CANONICAL_REL_PATH = "code/common/info-description-templates.yaml"
+
+# Universal templates: a finding fires when any of these is absent from
+# info.description.  The two Appendix A templates are opt-in (codeowner
+# judgement of the auth model) and absence is not a finding.
+_UNIVERSAL_TEMPLATES = frozenset(
+    {
+        "authorization-and-authentication",
+        "additional-error-responses",
+        "request-body-strictness",
+    }
+)
+
+# A marker line.  Group 1 is the template name (kebab-case), group 2 the
+# BEGIN/END side.  Tolerant of internal whitespace inside the comment.
+_MARKER_RE = re.compile(
+    r"<!--\s*CAMARA:MANDATORY:([a-z][a-z0-9-]*):(BEGIN|END)\s*-->"
+)
+
+# engine_rule values emitted by this module.
+_RULE_MISSING = "check-info-description-mandatory-missing"
+_RULE_DRIFT = "check-info-description-mandatory-drift"
+_RULE_DUPLICATE = "check-info-description-mandatory-duplicate"
+_RULE_UNKNOWN = "check-info-description-mandatory-unknown-template-name"
+_RULE_FOLDED = "check-info-description-folded-scalar"
+
+
+# ---------------------------------------------------------------------------
+# Canonical loading
+# ---------------------------------------------------------------------------
+
+
+# Cache: { canonical_path: (mtime_ns, {template_name: [normalised_paragraph, ...]}) }
+_canonical_cache: Dict[Path, Tuple[int, Dict[str, List[str]]]] = {}
+
+
+def _load_canonical(repo_path: Path) -> Optional[Dict[str, List[str]]]:
+    """Load and paragraph-normalise the canonical templates.
+
+    Returns ``{template_name: [normalised_paragraph, ...]}`` or ``None`` if
+    the canonical file does not exist (e.g. r4.2 repo, or a release-review
+    branch after the snapshot bundling step has cleared ``code/common/``).
+
+    Cached by (path, mtime_ns) so the file is read at most once per
+    validation run regardless of how many specs the repo contains.
+    """
+    canonical_path = (repo_path / _CANONICAL_REL_PATH).resolve()
+    try:
+        mtime = canonical_path.stat().st_mtime_ns
+    except FileNotFoundError:
+        return None
+
+    cached = _canonical_cache.get(canonical_path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    try:
+        data = yaml.safe_load(canonical_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        logger.warning(
+            "Canonical templates file is not valid YAML: %s", canonical_path
+        )
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    result: Dict[str, List[str]] = {}
+    for name, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
+        content = entry.get("content")
+        if not isinstance(content, str):
+            continue
+        body = _strip_markers(content, name)
+        if body is None:
+            continue
+        result[name] = _normalize_paragraphs(body)
+
+    _canonical_cache[canonical_path] = (mtime, result)
+    return result
+
+
+def _strip_markers(content: str, template_name: str) -> Optional[str]:
+    """Remove the BEGIN/END marker lines surrounding the canonical content.
+
+    Returns the inner body, or ``None`` if either marker is missing for the
+    given template name.  The canonical file is expected to wrap each
+    ``content`` value with its own markers so that block-paste-into-spec
+    works without fix-up.
+    """
+    begin_marker = f"<!-- CAMARA:MANDATORY:{template_name}:BEGIN -->"
+    end_marker = f"<!-- CAMARA:MANDATORY:{template_name}:END -->"
+    if begin_marker not in content or end_marker not in content:
+        return None
+    after_begin = content.split(begin_marker, 1)[1]
+    body = after_begin.split(end_marker, 1)[0]
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Paragraph normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalize_paragraphs(text: str) -> List[str]:
+    """Split *text* on blank lines, normalise whitespace within paragraphs.
+
+    Per design doc §4.2: within a paragraph runs of whitespace (including
+    newlines) are collapsed to a single space; paragraph boundaries (blank
+    lines) are preserved.  Empty paragraphs are dropped.
+    """
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    paragraphs = re.split(r"\n[ \t]*\n+", text)
+    result: List[str] = []
+    for para in paragraphs:
+        normalised = re.sub(r"\s+", " ", para).strip()
+        if normalised:
+            result.append(normalised)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Marker extraction from the spec's info.description
+# ---------------------------------------------------------------------------
+
+
+def _extract_markers(description: str) -> Tuple[List[Dict], List[Dict]]:
+    """Walk *description* and group BEGIN/END markers by template name.
+
+    Returns ``(blocks, anomalies)``:
+
+    * ``blocks`` — one dict per matched BEGIN/END pair, ordered by appearance:
+      ``{"name": str, "body": str, "begin_line": int, "end_line": int}``.
+    * ``anomalies`` — unmatched markers (BEGIN without END, or END without
+      preceding BEGIN), to be reported as ``unknown-template-name`` findings
+      with a clarifying message.  Unbalanced markers can produce silent
+      passes otherwise.
+    """
+    lines = description.splitlines()
+    blocks: List[Dict] = []
+    anomalies: List[Dict] = []
+    open_block: Optional[Dict] = None
+    for line_no, line in enumerate(lines, start=1):
+        match = _MARKER_RE.search(line)
+        if match is None:
+            continue
+        name, side = match.group(1), match.group(2)
+        if side == "BEGIN":
+            if open_block is not None:
+                # A second BEGIN before the previous END — treat the
+                # dangling BEGIN as an anomaly and start fresh from here.
+                anomalies.append(
+                    {
+                        "name": open_block["name"],
+                        "line": open_block["begin_line"],
+                        "reason": "begin-without-end",
+                    }
+                )
+            open_block = {"name": name, "begin_line": line_no, "body_lines": []}
+        else:  # END
+            if open_block is None:
+                anomalies.append(
+                    {"name": name, "line": line_no, "reason": "end-without-begin"}
+                )
+                continue
+            if open_block["name"] != name:
+                # Mismatched END name — close the open block with a name
+                # mismatch anomaly, do not extract content.
+                anomalies.append(
+                    {
+                        "name": open_block["name"],
+                        "line": open_block["begin_line"],
+                        "reason": "name-mismatch",
+                    }
+                )
+                open_block = None
+                continue
+            blocks.append(
+                {
+                    "name": name,
+                    "body": "\n".join(open_block["body_lines"]),
+                    "begin_line": open_block["begin_line"],
+                    "end_line": line_no,
+                }
+            )
+            open_block = None
+            continue
+        # If we reach here a marker line was processed; we do not include
+        # the marker line itself in body_lines.
+
+    # Body capture: walk again, accumulating content lines between matched
+    # BEGIN/END.  Simpler than tracking inside the loop above given the
+    # anomaly handling.
+    blocks = []  # rebuild with bodies
+    open_block = None
+    for line_no, line in enumerate(lines, start=1):
+        match = _MARKER_RE.search(line)
+        if match is None:
+            if open_block is not None:
+                open_block["body_lines"].append(line)
+            continue
+        name, side = match.group(1), match.group(2)
+        if side == "BEGIN":
+            open_block = {"name": name, "begin_line": line_no, "body_lines": []}
+        else:  # END
+            if open_block is None or open_block["name"] != name:
+                # Anomaly already recorded above; skip.
+                open_block = None
+                continue
+            blocks.append(
+                {
+                    "name": name,
+                    "body": "\n".join(open_block["body_lines"]),
+                    "begin_line": open_block["begin_line"],
+                    "end_line": line_no,
+                }
+            )
+            open_block = None
+    return blocks, anomalies
+
+
+# ---------------------------------------------------------------------------
+# Folded-scalar detection (raw YAML AST)
+# ---------------------------------------------------------------------------
+
+
+# Cache: { spec_path: (mtime_ns, scalar_style_or_None) }
+_scalar_style_cache: Dict[Path, Tuple[int, Optional[str]]] = {}
+
+
+def _detect_info_description_style(spec_path: Path) -> Optional[str]:
+    """Return the YAML scalar style of ``$.info.description``, or ``None``.
+
+    Uses :func:`yaml.compose` to walk the node tree without value
+    resolution.  Scalar nodes carry a ``.style`` attribute: ``'|'`` for
+    block literal, ``'>'`` for block folded, ``''`` for plain, ``'"'`` or
+    ``"'"`` for quoted.
+
+    Returns ``None`` when ``info.description`` is missing or the file is
+    unreadable.
+    """
+    try:
+        mtime = spec_path.stat().st_mtime_ns
+    except FileNotFoundError:
+        return None
+
+    cached = _scalar_style_cache.get(spec_path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    try:
+        with spec_path.open("r", encoding="utf-8") as f:
+            root = yaml.compose(f, Loader=yaml.SafeLoader)
+    except (yaml.YAMLError, OSError):
+        _scalar_style_cache[spec_path] = (mtime, None)
+        return None
+
+    style = _scalar_style_at(root, ("info", "description"))
+    _scalar_style_cache[spec_path] = (mtime, style)
+    return style
+
+
+def _scalar_style_at(node, path: Tuple[str, ...]) -> Optional[str]:
+    """Walk a yaml.compose() node tree along *path* and return scalar .style."""
+    from yaml.nodes import MappingNode, ScalarNode
+
+    current = node
+    for key in path:
+        if not isinstance(current, MappingNode):
+            return None
+        next_node = None
+        for k_node, v_node in current.value:
+            if isinstance(k_node, ScalarNode) and k_node.value == key:
+                next_node = v_node
+                break
+        if next_node is None:
+            return None
+        current = next_node
+    if isinstance(current, ScalarNode):
+        return current.style or ""
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Check entry point
+# ---------------------------------------------------------------------------
+
+
+def check_info_description_templates(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate the mandatory ``info.description`` blocks for one API spec.
+
+    API-scoped (one invocation per API in ``context.apis``; the adapter
+    narrows ``context.apis`` to a single API before calling).
+
+    Returns findings tagged with five distinct ``engine_rule`` values
+    (see module docstring).  Returns ``[]`` when:
+
+    * the canonical file is absent (resolver safety; the
+      ``commonalities_release >= r4.3`` applicability gate in rule metadata
+      is the primary scope filter)
+    * the spec file is absent
+    * the spec lacks ``info.description`` entirely (covered by built-in
+      OAS rule S-201 ``info-description``)
+    """
+    if not context.apis:
+        return []
+    api = context.apis[0]
+    spec_path = repo_path / api.spec_file
+    if not spec_path.is_file():
+        return []
+
+    canonical = _load_canonical(repo_path)
+    if canonical is None:
+        return []
+
+    try:
+        spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        return []
+    if not isinstance(spec, dict):
+        return []
+
+    info = spec.get("info")
+    if not isinstance(info, dict):
+        return []
+    description = info.get("description")
+    if not isinstance(description, str) or not description.strip():
+        return []
+
+    findings: List[dict] = []
+    spec_file = api.spec_file
+
+    # Folded-scalar check (P-030).  When info.description uses folded
+    # style ('>' / '>-' / '>+') the YAML parser collapses line breaks
+    # into spaces, flattening the BEGIN/END markers into a paragraph.
+    style = _detect_info_description_style(spec_path)
+    if style == ">":
+        findings.append(
+            make_finding(
+                engine_rule=_RULE_FOLDED,
+                level="warn",
+                message=(
+                    "info.description uses YAML folded-scalar style "
+                    "('description: >'). Line-anchored BEGIN/END markers "
+                    "for mandatory templates are flattened by the parser "
+                    "and will not be detected."
+                ),
+                path=spec_file,
+                line=1,
+                api_name=api.api_name,
+            )
+        )
+
+    blocks, anomalies = _extract_markers(description)
+
+    # Anomaly findings (P-029).  Unbalanced markers point at an authoring
+    # mistake and would otherwise silently slip through.
+    for anomaly in anomalies:
+        if anomaly["reason"] == "begin-without-end":
+            msg = (
+                f"info.description has a BEGIN marker for template "
+                f"{anomaly['name']!r} without a matching END marker."
+            )
+        elif anomaly["reason"] == "end-without-begin":
+            msg = (
+                f"info.description has an END marker for template "
+                f"{anomaly['name']!r} without a preceding BEGIN marker."
+            )
+        else:  # name-mismatch
+            msg = (
+                f"info.description has mismatched BEGIN/END marker names "
+                f"around template {anomaly['name']!r}."
+            )
+        findings.append(
+            make_finding(
+                engine_rule=_RULE_UNKNOWN,
+                level="warn",
+                message=msg,
+                path=spec_file,
+                line=1,
+                api_name=api.api_name,
+            )
+        )
+
+    # Group blocks by template name to find duplicates.
+    by_name: Dict[str, List[Dict]] = {}
+    for block in blocks:
+        by_name.setdefault(block["name"], []).append(block)
+
+    # Unknown template names (P-029): block names that are not in the
+    # canonical catalog.  Reported once per distinct unknown name.
+    for name, occurrences in by_name.items():
+        if name in canonical:
+            continue
+        findings.append(
+            make_finding(
+                engine_rule=_RULE_UNKNOWN,
+                level="warn",
+                message=(
+                    f"info.description references unknown template "
+                    f"{name!r}. The canonical file "
+                    f"{_CANONICAL_REL_PATH!r} declares: "
+                    f"{sorted(canonical.keys())!r}."
+                ),
+                path=spec_file,
+                line=occurrences[0]["begin_line"],
+                api_name=api.api_name,
+            )
+        )
+
+    # Duplicates (P-028).  Same template name appearing more than once.
+    # Reported once per duplicated name; the message lists the line numbers.
+    for name, occurrences in by_name.items():
+        if name not in canonical:
+            continue
+        if len(occurrences) <= 1:
+            continue
+        line_list = ", ".join(str(o["begin_line"]) for o in occurrences)
+        findings.append(
+            make_finding(
+                engine_rule=_RULE_DUPLICATE,
+                level="error",
+                message=(
+                    f"info.description includes the mandatory template "
+                    f"{name!r} more than once (BEGIN markers at lines "
+                    f"{line_list}). Each template must appear at most once."
+                ),
+                path=spec_file,
+                line=occurrences[0]["begin_line"],
+                api_name=api.api_name,
+            )
+        )
+
+    # Drift (P-027).  For every known-template block that is present
+    # (whether universal or opt-in), compare paragraph-by-paragraph
+    # against the canonical.  Only fires once per name even on the
+    # duplicate path (use the first occurrence).
+    for name, occurrences in by_name.items():
+        if name not in canonical:
+            continue
+        block = occurrences[0]
+        found_paragraphs = _normalize_paragraphs(block["body"])
+        canonical_paragraphs = canonical[name]
+        if found_paragraphs == canonical_paragraphs:
+            continue
+        diff_msg = _format_drift_message(
+            name, canonical_paragraphs, found_paragraphs
+        )
+        findings.append(
+            make_finding(
+                engine_rule=_RULE_DRIFT,
+                level="warn",
+                message=diff_msg,
+                path=spec_file,
+                line=block["begin_line"],
+                api_name=api.api_name,
+            )
+        )
+
+    # Missing (P-026).  Universal templates not present at all.  Opt-in
+    # Appendix A templates are not reported when absent — codeowner
+    # judgement of the auth model.
+    for template_name in _UNIVERSAL_TEMPLATES:
+        if template_name in by_name:
+            continue
+        if template_name not in canonical:
+            # Canonical file present but missing this template — unusual
+            # but not a per-spec concern.  Self-test catches this.
+            continue
+        findings.append(
+            make_finding(
+                engine_rule=_RULE_MISSING,
+                level="warn",
+                message=(
+                    f"info.description is missing the mandatory template "
+                    f"{template_name!r}. Paste the BEGIN..END block from "
+                    f"{_CANONICAL_REL_PATH!r}."
+                ),
+                path=spec_file,
+                line=1,
+                api_name=api.api_name,
+            )
+        )
+
+    return findings
+
+
+def _format_drift_message(
+    template_name: str,
+    canonical_paragraphs: List[str],
+    found_paragraphs: List[str],
+) -> str:
+    """Build a drift finding message that names the first differing paragraph."""
+    if len(canonical_paragraphs) != len(found_paragraphs):
+        return (
+            f"info.description template {template_name!r} has "
+            f"{len(found_paragraphs)} paragraph(s); canonical has "
+            f"{len(canonical_paragraphs)}. Re-copy the BEGIN..END block "
+            f"from {_CANONICAL_REL_PATH!r}."
+        )
+    for idx, (canon, found) in enumerate(
+        zip(canonical_paragraphs, found_paragraphs), start=1
+    ):
+        if canon == found:
+            continue
+        return (
+            f"info.description template {template_name!r} has drifted from "
+            f"canonical at paragraph {idx}.\n"
+            f"  canonical: {_clip(canon)}\n"
+            f"  found:     {_clip(found)}\n"
+            f"Re-copy the BEGIN..END block from "
+            f"{_CANONICAL_REL_PATH!r}."
+        )
+    # Same paragraph count and all equal — caller should have skipped.
+    return (
+        f"info.description template {template_name!r} differs from "
+        f"canonical (no paragraph-level difference detected; check "
+        f"trailing whitespace)."
+    )
+
+
+def _clip(text: str, limit: int = 160) -> str:
+    """Truncate *text* to *limit* characters for inline diff display."""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -353,3 +353,100 @@
   short_title: "Feature-step URL version segment wrong"
   conditional_level:
     default: error
+
+# P-026..P-030: mandatory info.description content validation.
+#
+# Five rules emitted by a single check function (check_info_description_templates)
+# in info_description_checks.py.  Only P-026's engine_rule is registered as a
+# CheckDescriptor — P-027..P-030 are satellite engine_rule values discovered
+# via emitted findings, same pattern as P-024 alongside P-007.
+#
+# Activation gated commonalities_release >= r4.3 at the rule-metadata layer.
+# Mechanism design: validation/docs/CAMARA-Validation-Framework-Info-Description-Design.md
+
+# P-026: a universal template's BEGIN/END pair is absent from info.description.
+- id: P-026
+  engine: python
+  engine_rule: check-info-description-mandatory-missing
+  short_title: "Mandatory info.description template missing"
+  applicability:
+    commonalities_release: ">=r4.3"
+  conditional_level:
+    default: warn
+    overrides:
+      - condition:
+          target_api_status: [alpha]
+        level: hint
+      - condition:
+          target_api_status: [public]
+        level: error
+  suggestion: >-
+    Paste the missing BEGIN..END block from
+    code/common/info-description-templates.yaml under the template name
+    reported in the message into info.description.
+
+# P-027: a template's delimiter pair is present but content has drifted
+# from canonical (paragraph-normalised diff).
+- id: P-027
+  engine: python
+  engine_rule: check-info-description-mandatory-drift
+  short_title: "info.description mandatory template content drift"
+  applicability:
+    commonalities_release: ">=r4.3"
+  conditional_level:
+    default: warn
+    overrides:
+      - condition:
+          target_api_status: [alpha]
+        level: hint
+      - condition:
+          target_api_status: [public]
+        level: error
+  suggestion: >-
+    Re-copy the BEGIN..END block from
+    code/common/info-description-templates.yaml to replace the drifted
+    content; the message identifies the first differing paragraph.
+
+# P-028: the same template name's BEGIN/END pair appears more than once
+# in info.description.  Always error — duplicate templates are a clear
+# authoring mistake regardless of API status.
+- id: P-028
+  engine: python
+  engine_rule: check-info-description-mandatory-duplicate
+  short_title: "Duplicate info.description mandatory template"
+  applicability:
+    commonalities_release: ">=r4.3"
+  conditional_level:
+    default: error
+  suggestion: >-
+    Remove the duplicate occurrences; each mandatory template appears at
+    most once in info.description.
+
+# P-029: a delimiter uses a template name not in the canonical catalog,
+# or marker pairs are unbalanced (BEGIN without END, etc.).  Warning —
+# the rule cannot infer whether the codeowner meant a different template
+# or intended a different mechanism entirely.
+- id: P-029
+  engine: python
+  engine_rule: check-info-description-mandatory-unknown-template-name
+  short_title: "Unknown info.description mandatory template name"
+  applicability:
+    commonalities_release: ">=r4.3"
+  conditional_level:
+    default: warn
+
+# P-030: info.description uses YAML folded scalar (>, >-, >+).  Folded
+# scalars collapse line breaks into spaces, flattening the BEGIN/END
+# markers into paragraphs and silencing the other four rules.  Warning,
+# always — independent of target_api_status.
+- id: P-030
+  engine: python
+  engine_rule: check-info-description-folded-scalar
+  short_title: "info.description uses YAML folded scalar"
+  applicability:
+    commonalities_release: ">=r4.3"
+  conditional_level:
+    default: warn
+  suggestion: >-
+    Change 'description: >' to 'description: |' so line-anchored
+    mandatory-template markers survive YAML parsing.

--- a/validation/tests/test_info_description_canonical_self.py
+++ b/validation/tests/test_info_description_canonical_self.py
@@ -1,0 +1,123 @@
+"""Self-test for the Commonalities canonical ``info-description-templates.yaml``.
+
+Validates that every entry in the canonical file wraps its ``content`` with a
+matching ``<!-- CAMARA:MANDATORY:<key>:BEGIN -->`` / ``:END -->`` pair where
+the template name in the markers matches the top-level YAML key.  Guards
+against accidental marker corruption in future Commonalities edits — the rule
+implementation relies on this invariant being upheld.
+
+Skipped when the upstream Commonalities mirror is not present, so developer
+environments without the workspace's full mirror can still run the test suite.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_MARKER_BEGIN_RE = re.compile(
+    r"<!--\s*CAMARA:MANDATORY:([a-z][a-z0-9-]*):BEGIN\s*-->"
+)
+_MARKER_END_RE = re.compile(
+    r"<!--\s*CAMARA:MANDATORY:([a-z][a-z0-9-]*):END\s*-->"
+)
+
+
+def _resolve_canonical_path() -> Path | None:
+    """Locate ``artifacts/common/info-description-templates.yaml`` in the workspace.
+
+    Honours ``CAMARA_WORKSPACE_ROOT`` when set; falls back to walking up from
+    this test file looking for ``upstream/traversals/Commonalities/``.
+    """
+    env_root = os.environ.get("CAMARA_WORKSPACE_ROOT")
+    candidates: list[Path] = []
+    if env_root:
+        candidates.append(
+            Path(env_root)
+            / "upstream/traversals/Commonalities/artifacts/common/info-description-templates.yaml"
+        )
+
+    # Walk up from this test file looking for a `upstream/traversals/Commonalities`
+    # sibling — handles running from a worktree under `worktrees/tooling/...`.
+    cursor = Path(__file__).resolve()
+    for _ in range(8):
+        cursor = cursor.parent
+        guess = (
+            cursor
+            / "upstream/traversals/Commonalities/artifacts/common/info-description-templates.yaml"
+        )
+        candidates.append(guess)
+
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+_CANONICAL_PATH = _resolve_canonical_path()
+
+
+@pytest.mark.skipif(
+    _CANONICAL_PATH is None,
+    reason=(
+        "Commonalities upstream mirror not present "
+        "(set CAMARA_WORKSPACE_ROOT or check out the workspace)"
+    ),
+)
+class TestInfoDescriptionTemplatesCanonical:
+    """Invariants on ``artifacts/common/info-description-templates.yaml``."""
+
+    @pytest.fixture(scope="class")
+    def canonical(self) -> dict:
+        assert _CANONICAL_PATH is not None
+        data = yaml.safe_load(_CANONICAL_PATH.read_text(encoding="utf-8"))
+        assert isinstance(data, dict), "canonical file root must be a mapping"
+        return data
+
+    def test_every_entry_has_content_field(self, canonical: dict) -> None:
+        for name, entry in canonical.items():
+            assert isinstance(entry, dict), (
+                f"template {name!r} is not a mapping"
+            )
+            assert isinstance(entry.get("content"), str), (
+                f"template {name!r} missing string `content` field"
+            )
+
+    def test_markers_match_key_and_appear_once(self, canonical: dict) -> None:
+        for name, entry in canonical.items():
+            content = entry["content"]
+            begins = _MARKER_BEGIN_RE.findall(content)
+            ends = _MARKER_END_RE.findall(content)
+            assert begins == [name], (
+                f"template {name!r}: BEGIN markers {begins!r} do not match "
+                f"single canonical name {name!r}"
+            )
+            assert ends == [name], (
+                f"template {name!r}: END markers {ends!r} do not match "
+                f"single canonical name {name!r}"
+            )
+
+    def test_begin_precedes_end(self, canonical: dict) -> None:
+        for name, entry in canonical.items():
+            content = entry["content"]
+            begin_match = _MARKER_BEGIN_RE.search(content)
+            end_match = _MARKER_END_RE.search(content)
+            assert begin_match is not None and end_match is not None
+            assert begin_match.start() < end_match.start(), (
+                f"template {name!r}: BEGIN marker appears after END marker"
+            )
+
+    def test_expected_universal_templates_present(self, canonical: dict) -> None:
+        """The three universal templates must exist in the canonical file."""
+        required = {
+            "authorization-and-authentication",
+            "additional-error-responses",
+            "request-body-strictness",
+        }
+        missing = required - set(canonical.keys())
+        assert not missing, f"canonical file missing universal templates: {missing}"

--- a/validation/tests/test_python_checks_info_description.py
+++ b/validation/tests/test_python_checks_info_description.py
@@ -1,0 +1,399 @@
+"""Unit tests for mandatory info.description content checks (P-026..P-030)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from validation.context import ApiContext, ValidationContext
+from validation.engines.python_checks.info_description_checks import (
+    _normalize_paragraphs,
+    check_info_description_templates,
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical fixture (one universal + one opt-in template — enough to exercise
+# missing / drift / duplicate / unknown-name behaviours).  Mirrors the shape
+# of code/common/info-description-templates.yaml in Commonalities.
+# ---------------------------------------------------------------------------
+
+
+_CANONICAL_YAML = textwrap.dedent(
+    """\
+    authorization-and-authentication:
+      content: |
+        <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+        # Authorization and authentication
+
+        Paragraph one of the authorization template.
+
+        Paragraph two of the authorization template.
+        <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
+
+    additional-error-responses:
+      content: |
+        <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+        # Additional CAMARA error responses
+
+        Error responses paragraph one.
+
+        Error responses paragraph two.
+        <!-- CAMARA:MANDATORY:additional-error-responses:END -->
+
+    request-body-strictness:
+      content: |
+        <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+        # Request body strictness
+
+        Strictness paragraph one.
+        <!-- CAMARA:MANDATORY:request-body-strictness:END -->
+
+    identifying-device-from-access-token:
+      content: |
+        <!-- CAMARA:MANDATORY:identifying-device-from-access-token:BEGIN -->
+        # Identifying the device from the access token
+
+        Appendix A paragraph one.
+
+        Appendix A paragraph two.
+        <!-- CAMARA:MANDATORY:identifying-device-from-access-token:END -->
+    """
+)
+
+
+# Block bodies (BEGIN/END plus inner content) used to compose spec
+# fixtures.  Indented to match column-4 inside an OAS description.
+_BLOCK_AUTH = textwrap.dedent(
+    """\
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+    # Authorization and authentication
+
+    Paragraph one of the authorization template.
+
+    Paragraph two of the authorization template.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->"""
+)
+
+_BLOCK_ERRORS = textwrap.dedent(
+    """\
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+    # Additional CAMARA error responses
+
+    Error responses paragraph one.
+
+    Error responses paragraph two.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->"""
+)
+
+_BLOCK_STRICTNESS = textwrap.dedent(
+    """\
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    # Request body strictness
+
+    Strictness paragraph one.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->"""
+)
+
+_BLOCK_DEVICE = textwrap.dedent(
+    """\
+    <!-- CAMARA:MANDATORY:identifying-device-from-access-token:BEGIN -->
+    # Identifying the device from the access token
+
+    Appendix A paragraph one.
+
+    Appendix A paragraph two.
+    <!-- CAMARA:MANDATORY:identifying-device-from-access-token:END -->"""
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_context(
+    api_name: str = "sample-service",
+    target_api_status: str = "rc",
+    commonalities_release: str = "r4.3",
+) -> ValidationContext:
+    api = ApiContext(
+        api_name=api_name,
+        target_api_version="0.1.0",
+        target_api_status=target_api_status,
+        target_api_maturity="initial",
+        api_pattern="request-response",
+        spec_file=f"code/API_definitions/{api_name}.yaml",
+    )
+    return ValidationContext(
+        repository="TestRepo",
+        branch_type="main",
+        trigger_type="dispatch",
+        profile="advisory",
+        stage="enabled",
+        target_release_type=None,
+        commonalities_release=commonalities_release,
+        commonalities_version=None,
+        icm_release=None,
+        base_ref=None,
+        is_release_review_pr=False,
+        release_plan_changed=None,
+        pr_number=None,
+        apis=(api,),
+        workflow_run_url="",
+        tooling_ref="",
+    )
+
+
+def _write_canonical(repo: Path, canonical_yaml: str = _CANONICAL_YAML) -> None:
+    common = repo / "code" / "common"
+    common.mkdir(parents=True, exist_ok=True)
+    (common / "info-description-templates.yaml").write_text(
+        canonical_yaml, encoding="utf-8"
+    )
+
+
+def _write_spec(
+    repo: Path,
+    api_name: str,
+    description_body: str,
+    scalar_style: str = "|",
+) -> None:
+    """Write a minimal spec with a block scalar ``info.description``.
+
+    *description_body* is the content inside ``description:`` — line-anchored
+    BEGIN/END markers and any prose, *without* leading indentation.  It is
+    indented to column 4 here so the OAS structure parses cleanly.
+
+    Avoids ``textwrap.dedent`` deliberately; the body has variable
+    indentation that would confuse dedent's common-prefix calculation.
+    """
+    # Pad body lines to column 4 (under "  description: |" at column 2).
+    # textwrap.indent skips otherwise-empty lines, which is what we want
+    # so blank-line paragraph separators stay blank.
+    indented = textwrap.indent(description_body, "    ")
+    spec = (
+        "openapi: 3.0.3\n"
+        "info:\n"
+        "  title: Test\n"
+        "  version: wip\n"
+        f"  description: {scalar_style}\n"
+        f"{indented}\n"
+        "paths: {}\n"
+    )
+    spec_dir = repo / "code" / "API_definitions"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / f"{api_name}.yaml").write_text(spec, encoding="utf-8")
+
+
+def _codes(findings: list[dict]) -> list[str]:
+    return [f["engine_rule"] for f in findings]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNS27InfoDescriptionMandatory:
+    """Behavioural tests for the five P-026..P-030 rules."""
+
+    def test_valid_spec_no_findings(self, tmp_path: Path) -> None:
+        _write_canonical(tmp_path)
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        assert findings == [], _codes(findings)
+
+    def test_missing_auth_fires_p026(self, tmp_path: Path) -> None:
+        _write_canonical(tmp_path)
+        body = "\n\n".join([_BLOCK_ERRORS, _BLOCK_STRICTNESS])  # auth dropped
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        codes = _codes(findings)
+        assert codes.count("check-info-description-mandatory-missing") == 1
+        # The missing-finding message names the missing template.
+        missing = [
+            f for f in findings
+            if f["engine_rule"] == "check-info-description-mandatory-missing"
+        ]
+        assert "authorization-and-authentication" in missing[0]["message"]
+
+    def test_missing_request_body_strictness_fires_p026(
+        self, tmp_path: Path
+    ) -> None:
+        _write_canonical(tmp_path)
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        assert any(
+            "request-body-strictness" in f["message"]
+            and f["engine_rule"] == "check-info-description-mandatory-missing"
+            for f in findings
+        )
+
+    def test_missing_additional_error_responses_fires_p026(
+        self, tmp_path: Path
+    ) -> None:
+        _write_canonical(tmp_path)
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        assert any(
+            "additional-error-responses" in f["message"]
+            and f["engine_rule"] == "check-info-description-mandatory-missing"
+            for f in findings
+        )
+
+    def test_optin_appendix_a_absence_not_flagged(self, tmp_path: Path) -> None:
+        """No Appendix A block present — P-026 must NOT fire for it."""
+        _write_canonical(tmp_path)
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        assert not any(
+            "identifying-device-from-access-token" in f["message"]
+            for f in findings
+        )
+
+    def test_drift_paragraph_change_fires_p027(self, tmp_path: Path) -> None:
+        _write_canonical(tmp_path)
+        drifted_auth = _BLOCK_AUTH.replace(
+            "Paragraph one of the authorization template.",
+            "Paragraph one with a WRONG word inserted here.",
+        )
+        body = "\n\n".join([drifted_auth, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        drift = [
+            f for f in findings
+            if f["engine_rule"] == "check-info-description-mandatory-drift"
+        ]
+        assert len(drift) == 1
+        assert "authorization-and-authentication" in drift[0]["message"]
+
+    def test_drift_whitespace_only_passes(self, tmp_path: Path) -> None:
+        """Reflowing a paragraph onto one line must not fire drift."""
+        _write_canonical(tmp_path)
+        reflowed_auth = _BLOCK_AUTH.replace(
+            "Paragraph one of the authorization template.",
+            "Paragraph one of  the\n    authorization template.",
+        )
+        body = "\n\n".join([reflowed_auth, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        drift = [
+            f for f in findings
+            if f["engine_rule"] == "check-info-description-mandatory-drift"
+        ]
+        assert drift == []
+
+    def test_duplicate_marker_pair_fires_p028(self, tmp_path: Path) -> None:
+        _write_canonical(tmp_path)
+        body = "\n\n".join(
+            [_BLOCK_AUTH, _BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS]
+        )
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        codes = _codes(findings)
+        assert codes.count("check-info-description-mandatory-duplicate") == 1
+        # Drift must not also fire on the duplicate — only the first
+        # occurrence is compared and it matches canonical.
+        assert "check-info-description-mandatory-drift" not in codes
+
+    def test_unknown_template_name_fires_p029(self, tmp_path: Path) -> None:
+        _write_canonical(tmp_path)
+        bogus = textwrap.dedent(
+            """\
+            <!-- CAMARA:MANDATORY:foo:BEGIN -->
+            # Foo
+
+            Whatever.
+            <!-- CAMARA:MANDATORY:foo:END -->"""
+        )
+        body = "\n\n".join(
+            [_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS, bogus]
+        )
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        unknown = [
+            f for f in findings
+            if f["engine_rule"]
+            == "check-info-description-mandatory-unknown-template-name"
+        ]
+        assert len(unknown) == 1
+        assert "foo" in unknown[0]["message"]
+
+    def test_folded_scalar_fires_p030(self, tmp_path: Path) -> None:
+        """info.description: > should fire folded-scalar regardless of body."""
+        _write_canonical(tmp_path)
+        # Any body — the markers would be flattened by the YAML parser
+        # anyway, but the rule fires on the scalar style alone.
+        body = _BLOCK_AUTH
+        _write_spec(tmp_path, "sample-service", body, scalar_style=">")
+        findings = check_info_description_templates(tmp_path, _make_context())
+        codes = _codes(findings)
+        assert "check-info-description-folded-scalar" in codes
+
+    def test_block_literal_passes(self, tmp_path: Path) -> None:
+        """info.description: | (default in fixtures) must not fire P-030."""
+        _write_canonical(tmp_path)
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        assert "check-info-description-folded-scalar" not in _codes(findings)
+
+    def test_canonical_absent_no_findings(self, tmp_path: Path) -> None:
+        """No canonical file present — all five rules are quiet."""
+        # Note: do NOT call _write_canonical.
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        assert findings == [], _codes(findings)
+
+    def test_appendix_a_drift_fires_when_present(self, tmp_path: Path) -> None:
+        """Opt-in template absent = no finding; opt-in template drifted = drift fires."""
+        _write_canonical(tmp_path)
+        drifted_device = _BLOCK_DEVICE.replace(
+            "Appendix A paragraph one.",
+            "Appendix A paragraph one — with extra prose.",
+        )
+        body = "\n\n".join(
+            [_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS, drifted_device]
+        )
+        _write_spec(tmp_path, "sample-service", body)
+        findings = check_info_description_templates(tmp_path, _make_context())
+        drift = [
+            f for f in findings
+            if f["engine_rule"] == "check-info-description-mandatory-drift"
+        ]
+        assert len(drift) == 1
+        assert "identifying-device-from-access-token" in drift[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Helper-function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParagraphNormalisation:
+    def test_collapse_internal_whitespace(self) -> None:
+        text = "Foo\n  bar\tbaz"
+        assert _normalize_paragraphs(text) == ["Foo bar baz"]
+
+    def test_preserve_paragraph_boundaries(self) -> None:
+        text = "Para one.\n\nPara two."
+        assert _normalize_paragraphs(text) == ["Para one.", "Para two."]
+
+    def test_drop_empty_paragraphs(self) -> None:
+        # Leading/trailing blank lines and double blank lines collapse to
+        # empty paragraphs which must be dropped (handles BEGIN/END line
+        # residue around real content).
+        text = "\n\nPara one.\n\n\nPara two.\n"
+        assert _normalize_paragraphs(text) == ["Para one.", "Para two."]
+
+    def test_crlf_normalised(self) -> None:
+        text = "Para one.\r\n\r\nPara two."
+        assert _normalize_paragraphs(text) == ["Para one.", "Para two."]

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 24
+        assert counts["python"] == 29
         assert counts["spectral"] == 85
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -307,8 +307,8 @@ class TestMetadataQuality:
         """
         with_suggestions = [r.id for r in all_rules if r.suggestion is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_suggestions) == 16, (
-            f"Expected 16 explicit suggestions (update test if adding "
+        assert len(with_suggestions) == 20, (
+            f"Expected 20 explicit suggestions (update test if adding "
             f"suggestions): {with_suggestions}"
         )
         assert len(with_overrides) == 0, (


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature


#### What this PR does / why we need it:

Implements the rule family for mandatory `info.description` content
validation per tooling#291. A canonical YAML at
`code/common/info-description-templates.yaml` (Commonalities-owned,
cache-common-synced) declares mandatory text per template name. Specs
embed each template verbatim between
`<!-- CAMARA:MANDATORY:<template>:BEGIN/END -->` markers inside
`info.description`.

| ID | engine_rule | Fires when |
|---|---|---|
| P-026 | `check-info-description-mandatory-missing` | A universal template is absent. Opt-in Appendix A absence is not a finding. |
| P-027 | `check-info-description-mandatory-drift` | Content differs from canonical (paragraph-normalised diff). |
| P-028 | `check-info-description-mandatory-duplicate` | A template name's pair appears more than once. |
| P-029 | `check-info-description-mandatory-unknown-template-name` | Unknown template name, or unbalanced markers. |
| P-030 | `check-info-description-folded-scalar` | `info.description` uses folded scalar (`>` / `>-`); markers would silently collapse. |

Applicability gated `commonalities_release >= r4.3`. P-026 / P-027 carry
severity-by-`target_api_status` (alpha→hint, rc→warn, public→error) per
the design doc §4.3.


#### Which issue(s) this PR fixes:

Part of #535 (RM umbrella).


#### Special notes for reviewers:

* One Python check emits findings tagged with five `engine_rule`
  values; only P-026 is a registered `CheckDescriptor` (same pattern as
  P-007 + P-024).
* Folded-scalar detection walks the YAML node tree via `yaml.compose()`
  — no new dependency.
* Engine choice: Python (not Spectral). Sibling-file read + raw scalar
  style inspection fit Python naturally. Follow-up tooling PR will
  update §5.1 of the design doc to match.


#### Changelog input

```
release-note
Validation framework: add five rules enforcing mandatory info.description
content (P-026..P-030). Gated commonalities_release >= r4.3.
```


#### Additional documentation 

```
docs
Mechanism: validation/docs/CAMARA-Validation-Framework-Info-Description-Design.md
```
