### PR TITLE
fix(S-011): exclude components.callbacks from camara-properties-descriptions JSONPath

### DIFF
--- a/linting/config/.spectral-r3.4.yaml
+++ b/linting/config/.spectral-r3.4.yaml
@@ -196,7 +196,7 @@ rules:
     description: |
       This Spectral rule ensures that each propoerty within objects in the API specification has a descriptive and meaningful description.
     given:
-      - "$.components.*.*"
+      - "$.components[examples,headers,links,parameters,pathItems,requestBodies,responses,schemas,securitySchemes].*"
       - "$.components.*.*.properties.*"
     then:
       field: description

--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -218,7 +218,7 @@ rules:
     description: |
       This Spectral rule ensures that each propoerty within objects in the API specification has a descriptive and meaningful description.
     given:
-      - "$.components.*.*"
+      - "$.components[examples,headers,links,parameters,pathItems,requestBodies,responses,schemas,securitySchemes].*"
       - "$.components.*.*.properties.*"
     then:
       field: description

--- a/linting/config/.spectral.yaml
+++ b/linting/config/.spectral.yaml
@@ -194,7 +194,7 @@ rules:
     description: |
       This Spectral rule ensures that each propoerty within objects in the API specification has a descriptive and meaningful description.
     given:
-      - "$.components.*.*"
+      - "$.components[examples,headers,links,parameters,pathItems,requestBodies,responses,schemas,securitySchemes].*"
       - "$.components.*.*.properties.*"
     then:
       field: description

--- a/validation/tests/test_spectral_s011_components.py
+++ b/validation/tests/test_spectral_s011_components.py
@@ -1,0 +1,231 @@
+"""Tests for S-011 `camara-properties-descriptions` JSONPath scope.
+
+Verifies that the rule's `given` excludes `components.callbacks.*` (Callback Objects
+have no `description` field; firing S-011 on them is the bug from tooling#296 — a
+codeowner who tries to satisfy it triggers the built-in `oas3-schema` error
+because the added key is interpreted as a runtime expression whose value must
+be a Path Item Object).
+
+Runs the real Spectral CLI against in-memory YAML, same pattern as
+test_spectral_gap_rules.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths & helpers (copied from test_spectral_gap_rules.py to keep this file
+# self-contained; the helpers are small enough that a shared conftest would
+# be more abstraction than the codebase currently uses)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_RULESET = _REPO_ROOT / "linting" / "config" / ".spectral-r4.yaml"
+_NODE_MODULES = _REPO_ROOT / "validation" / "node_modules"
+
+
+def _run_spectral(yaml_content: str) -> list[dict]:
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        tmp_path = f.name
+
+    env = {
+        "PATH": subprocess.os.environ.get("PATH", ""),
+        "NODE_PATH": str(_NODE_MODULES),
+        "HOME": subprocess.os.environ.get("HOME", ""),
+    }
+    result = subprocess.run(
+        [
+            "node",
+            str(_NODE_MODULES / ".bin" / "spectral"),
+            "lint",
+            tmp_path,
+            "-r", str(_RULESET),
+            "--format", "json",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    Path(tmp_path).unlink(missing_ok=True)
+    if result.stdout.strip():
+        return json.loads(result.stdout)
+    return []
+
+
+def _codes(findings: list[dict]) -> set[str]:
+    return {f["code"] for f in findings}
+
+
+def _findings_for(findings: list[dict], code: str) -> list[dict]:
+    return [f for f in findings if f["code"] == code]
+
+
+# ---------------------------------------------------------------------------
+# Spec template — fully described baseline so S-011 fires only on whatever we
+# deliberately leave broken in each test
+# ---------------------------------------------------------------------------
+
+_BASE_SPEC = """\
+openapi: 3.0.3
+info:
+  title: S-011 Components Test
+  description: Fixture for S-011 components scope
+  version: wip
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  x-camara-commonalities: 0.7.0
+externalDocs:
+  description: Product documentation at CAMARA
+  url: https://github.com/camaraproject/TestAPI
+servers:
+  - url: "{apiRoot}/test-api/vwip"
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: API root
+tags:
+  - name: Test API
+security:
+  - openId:
+    - test-api:read
+paths:
+  /test:
+    get:
+      tags:
+        - Test API
+      summary: Get test
+      description: Get test description
+      operationId: getTest
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorInfo"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorInfo"
+"""
+
+_COMPONENTS_BASE = """\
+components:
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      description: OpenID Connect security scheme
+  schemas:
+    ErrorInfo:
+      type: object
+      description: Error envelope
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: HTTP response status code
+        code:
+          type: string
+          maxLength: 96
+          description: A human-readable code to describe the error
+        message:
+          type: string
+          maxLength: 512
+          description: A human-readable description of what the event represents
+"""
+
+
+def test_callback_in_components_does_not_fire_s011():
+    """Named callbacks under `components.callbacks` must not trigger S-011.
+
+    Callback Objects (OAS 3.x) are maps of runtime expressions to Path Item
+    Objects — they have no `description` field. tooling#296.
+    """
+    spec = _BASE_SPEC + _COMPONENTS_BASE + """\
+  callbacks:
+    onResourceEvent:
+      "{$request.body#/sink}":
+        post:
+          summary: Notification
+          description: Notification callback
+          operationId: onResourceEvent
+          requestBody:
+            description: Notification body
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/ErrorInfo"
+          responses:
+            "204":
+              description: Acknowledged
+"""
+    findings = _run_spectral(spec)
+    s011 = _findings_for(findings, "camara-properties-descriptions")
+    callback_findings = [f for f in s011 if "callbacks" in f.get("path", [])]
+    assert callback_findings == [], (
+        f"S-011 must not fire on components.callbacks.*; got {callback_findings}"
+    )
+
+
+def test_schema_property_missing_description_still_fires_s011():
+    """Behavior preservation: a schema property without `description` still triggers S-011."""
+    spec = _BASE_SPEC + """\
+components:
+  schemas:
+    Foo:
+      type: object
+      description: Foo
+      properties:
+        bar:
+          type: string
+"""
+    findings = _run_spectral(spec)
+    assert "camara-properties-descriptions" in _codes(findings), (
+        "S-011 must still fire on schema properties missing description"
+    )
+
+
+def test_parameter_in_components_missing_description_still_fires_s011():
+    """Behavior preservation: a named parameter without `description` still triggers S-011.
+
+    Mirrors the existing regression-branch fixture for `components.parameters.ResourceId`.
+    """
+    spec = _BASE_SPEC + _COMPONENTS_BASE + """\
+  parameters:
+    MyParam:
+      name: myParam
+      in: path
+      required: true
+      schema:
+        type: string
+"""
+    findings = _run_spectral(spec)
+    s011 = _findings_for(findings, "camara-properties-descriptions")
+    param_findings = [
+        f for f in s011
+        if "parameters" in f.get("path", []) and "MyParam" in f.get("path", [])
+    ]
+    assert param_findings, (
+        f"S-011 must still fire on components.parameters.* lacking description; "
+        f"got S-011 findings = {s011}"
+    )


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Narrows the `camara-properties-descriptions` (S-011) JSONPath from `$.components.*.*` to the explicit set of OAS 3.0/3.1 component types that carry a `description` field, leaving `callbacks` out. Same edit in all three rulesets (`.spectral.yaml`, `.spectral-r3.4.yaml`, `.spectral-r4.yaml`). Adds a Spectral-CLI pytest covering the callback exclusion and pinning behavior preservation for schema properties and named parameters.

See #296 for the bug shape.

#### Which issue(s) this PR fixes:

Fixes #296

#### Special notes for reviewers:

- Companion regression fixture: camaraproject/ReleaseTest#185 (canary catches future regressions in this JSONPath).
- Full pytest suite green locally (1716 passed).

#### Changelog input

```
 release-note
fix(S-011): exclude components.callbacks from camara-properties-descriptions JSONPath; named callbacks no longer trip the S-011/S-209 conflict
```

#### Additional documentation

This section can be blank.

```
docs

```
