### PR TITLE
Pin P-026..P-030 via regression/r4.3-broken-spec-info-description-mandatory

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 84
+  total_tested: 89
   by_engine:
     spectral: 85
     gherkin: 25
@@ -316,6 +316,11 @@ tested_rules:
   P-015: [regression/r4.2-broken-spec-subscriptions]
   P-016: [regression/r4.2-broken-spec-subscriptions]
   P-020: [regression/r4.2-broken-spec-subscriptions]
+  P-026: [regression/r4.3-broken-spec-info-description-mandatory]
+  P-027: [regression/r4.3-broken-spec-info-description-mandatory]
+  P-028: [regression/r4.3-broken-spec-info-description-mandatory]
+  P-029: [regression/r4.3-broken-spec-info-description-mandatory]
+  P-030: [regression/r4.3-broken-spec-info-description-mandatory]
   S-002: [regression/r4.2-broken-spec-routing]
   S-003: [regression/r4.2-broken-spec-routing]
   S-005: [regression/r4.2-broken-spec-yaml-fundamentals]


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Add `P-026`, `P-027`, `P-028`, `P-029`, `P-030` to `tested_rules` in `validation/rules/rule-inventory.yaml` and bump `total_tested` from 84 to 89.

The five rules are the mandatory `info.description` content family added by tooling#295 (P-026 missing / P-027 drift / P-028 duplicate / P-029 unknown-template-name / P-030 folded-scalar). The new regression branch `regression/r4.3-broken-spec-info-description-mandatory` on `camaraproject/ReleaseTest` introduces surgical edits across `sample-service.yaml` (P-026..P-029) and `sample-implicit-events.yaml` (P-030 + cascade) that exercise all five engine_rule values. Fixture verified PASS 1/1 against `tooling/main` HEAD (25 matched, 0 missing, 0 unexpected).

This is the first r4.3-line regression branch dedicated to the new rule family; the rules are gated `commonalities_release >= r4.3` at the rule-metadata layer and could not be exercised on the r4.2 line.

#### Which issue(s) this PR fixes:

Part of https://github.com/camaraproject/ReleaseManagement/issues/484

#### Special notes for reviewers:

None — inventory-only edit; no engine or schema changes.

#### Changelog input

 release-note
 NONE

#### Additional documentation

 docs
 NONE
