### PR TITLE
Warn when info.description canonical file is missing

### DIFF
--- a/validation/engines/python_checks/info_description_checks.py
+++ b/validation/engines/python_checks/info_description_checks.py
@@ -1,4 +1,4 @@
-"""Mandatory ``info.description`` content validation (P-026..P-030).
+"""Mandatory ``info.description`` content validation (P-026..P-031).
 
 Enforces the BEGIN/END marker mechanism described in
 ``validation/docs/CAMARA-Validation-Framework-Info-Description-Design.md``.
@@ -10,13 +10,14 @@ the mandatory text that an API spec MUST embed verbatim between
 ``<!-- CAMARA:MANDATORY:<template-name>:END -->`` markers inside its
 ``info.description``.
 
-A single function emits findings under five distinct ``engine_rule`` values:
+A single function emits findings under six distinct ``engine_rule`` values:
 
 * ``check-info-description-mandatory-missing`` (P-026, universal templates only)
 * ``check-info-description-mandatory-drift`` (P-027)
 * ``check-info-description-mandatory-duplicate`` (P-028)
 * ``check-info-description-mandatory-unknown-template-name`` (P-029)
 * ``check-info-description-folded-scalar`` (P-030)
+* ``check-info-description-canonical-missing`` (P-031)
 
 Only the first is registered as a :class:`CheckDescriptor` — the others are
 satellite ``engine_rule`` values that the post-filter maps to their own
@@ -65,6 +66,7 @@ _RULE_DRIFT = "check-info-description-mandatory-drift"
 _RULE_DUPLICATE = "check-info-description-mandatory-duplicate"
 _RULE_UNKNOWN = "check-info-description-mandatory-unknown-template-name"
 _RULE_FOLDED = "check-info-description-folded-scalar"
+_RULE_CANONICAL_MISSING = "check-info-description-canonical-missing"
 
 
 # ---------------------------------------------------------------------------
@@ -337,15 +339,15 @@ def check_info_description_templates(
     API-scoped (one invocation per API in ``context.apis``; the adapter
     narrows ``context.apis`` to a single API before calling).
 
-    Returns findings tagged with five distinct ``engine_rule`` values
+    Returns findings tagged with six distinct ``engine_rule`` values
     (see module docstring).  Returns ``[]`` when:
 
-    * the canonical file is absent (resolver safety; the
-      ``commonalities_release >= r4.3`` applicability gate in rule metadata
-      is the primary scope filter)
     * the spec file is absent
     * the spec lacks ``info.description`` entirely (covered by built-in
       OAS rule S-201 ``info-description``)
+
+    When the canonical file is absent or unreadable, emits a warning so
+    r4.3+ branches do not silently skip the template validation family.
     """
     if not context.apis:
         return []
@@ -356,7 +358,22 @@ def check_info_description_templates(
 
     canonical = _load_canonical(repo_path)
     if canonical is None:
-        return []
+        return [
+            make_finding(
+                engine_rule=_RULE_CANONICAL_MISSING,
+                level="warn",
+                message=(
+                    f"Cannot validate mandatory info.description templates "
+                    f"because {_CANONICAL_REL_PATH!r} is missing or "
+                    f"unreadable. The common-file sync must provide this "
+                    f"file before P-026..P-030 can check mandatory "
+                    f"info.description blocks."
+                ),
+                path=api.spec_file,
+                line=1,
+                api_name=api.api_name,
+            )
+        ]
 
     try:
         spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -363,11 +363,11 @@
   conditional_level:
     default: error
 
-# P-026..P-030: mandatory info.description content validation.
+# P-026..P-031: mandatory info.description content validation.
 #
-# Five rules emitted by a single check function (check_info_description_templates)
+# Six rules emitted by a single check function (check_info_description_templates)
 # in info_description_checks.py.  Only P-026's engine_rule is registered as a
-# CheckDescriptor — P-027..P-030 are satellite engine_rule values discovered
+# CheckDescriptor — P-027..P-031 are satellite engine_rule values discovered
 # via emitted findings, same pattern as P-024 alongside P-007.
 #
 # Activation gated commonalities_release >= r4.3 at the rule-metadata layer.
@@ -459,3 +459,22 @@
   suggestion: >-
     Change 'description: >' to 'description: |' so line-anchored
     mandatory-template markers survive YAML parsing.
+
+# P-031: the canonical template file is unavailable, so P-026..P-030
+# cannot validate mandatory info.description blocks.  Warning — this is
+# normally paired with the common-cache sync finding and explains the
+# otherwise silent coverage gap.
+- id: P-031
+  engine: python
+  engine_rule: check-info-description-canonical-missing
+  short_title: "info.description canonical template file missing"
+  applicability:
+    commonalities_release: ">=r4.3"
+  conditional_level:
+    default: warn
+  suggestion: >-
+    `code/common/` is managed by the sync mechanism. If your branch is
+    missing code/common/info-description-templates.yaml, merge `main` into
+    your branch when `main` already carries the latest synced files; if
+    `main` is also behind, merge the auto-created sync PR or dispatch the
+    release automation workflow to create the sync PR again.

--- a/validation/tests/test_python_checks_info_description.py
+++ b/validation/tests/test_python_checks_info_description.py
@@ -1,4 +1,4 @@
-"""Unit tests for mandatory info.description content checks (P-026..P-030)."""
+"""Unit tests for mandatory info.description content checks (P-026..P-031)."""
 
 from __future__ import annotations
 
@@ -198,7 +198,7 @@ def _codes(findings: list[dict]) -> list[str]:
 
 
 class TestNS27InfoDescriptionMandatory:
-    """Behavioural tests for the five P-026..P-030 rules."""
+    """Behavioural tests for the P-026..P-031 rules."""
 
     def test_valid_spec_no_findings(self, tmp_path: Path) -> None:
         _write_canonical(tmp_path)
@@ -345,13 +345,14 @@ class TestNS27InfoDescriptionMandatory:
         findings = check_info_description_templates(tmp_path, _make_context())
         assert "check-info-description-folded-scalar" not in _codes(findings)
 
-    def test_canonical_absent_no_findings(self, tmp_path: Path) -> None:
-        """No canonical file present — all five rules are quiet."""
+    def test_canonical_absent_fires_p031(self, tmp_path: Path) -> None:
+        """No canonical file present — warn that template validation is skipped."""
         # Note: do NOT call _write_canonical.
         body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
         _write_spec(tmp_path, "sample-service", body)
         findings = check_info_description_templates(tmp_path, _make_context())
-        assert findings == [], _codes(findings)
+        assert _codes(findings) == ["check-info-description-canonical-missing"]
+        assert "info-description-templates.yaml" in findings[0]["message"]
 
     def test_appendix_a_drift_fires_when_present(self, tmp_path: Path) -> None:
         """Opt-in template absent = no finding; opt-in template drifted = drift fires."""

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -77,7 +77,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 29
+        assert counts["python"] == 30
         assert counts["spectral"] == 85
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -307,8 +307,8 @@ class TestMetadataQuality:
         """
         with_suggestions = [r.id for r in all_rules if r.suggestion is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_suggestions) == 20, (
-            f"Expected 20 explicit suggestions (update test if adding "
+        assert len(with_suggestions) == 21, (
+            f"Expected 21 explicit suggestions (update test if adding "
             f"suggestions): {with_suggestions}"
         )
         assert len(with_overrides) == 0, (


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Adds a warning when mandatory `info.description` template validation cannot run because `code/common/info-description-templates.yaml` is missing or unreadable.

This avoids a silent coverage gap on r4.3+ branches: P-026..P-030 need the canonical template file before they can check missing, drifted, duplicate, unknown, or folded mandatory template blocks.

Follow-up to https://github.com/camaraproject/tooling/pull/295.

#### Which issue(s) this PR fixes:

Related to https://github.com/camaraproject/ReleaseManagement/issues/535

#### Special notes for reviewers:

The new P-031 suggestion points code owners to the managed common-file sync flow: merge `main` if it already carries the synced files, otherwise merge the auto-created sync PR or dispatch release automation to create the sync PR again.

#### Changelog input

```
 release-note
Validation now warns when mandatory info.description template checks cannot run because the canonical template file is missing from code/common.
```

#### Additional documentation 

This section can be blank.

```
docs

```
