### PR TITLE
docs(validation): explain P-026 and P-027 handling

### DIFF
--- a/documentation/validation/faq.md
+++ b/documentation/validation/faq.md
@@ -93,6 +93,24 @@ A real issue with the *content* of a cached common file is fixed upstream in [Co
 
 This rule is a warning by default, and an error during release automation runs.
 
+### What should I do about missing or drifted mandatory `info.description` blocks?
+
+Applies to: `[P-026] Mandatory info.description template missing`, `[P-027] info.description mandatory template content drift`
+
+CAMARA API specifications must include mandatory `info.description` text blocks from the API Design Guide and the Identity and Consent Management profile. Starting with Commonalities r4.3, the canonical text is synchronized into each API repository as `code/common/info-description-templates.yaml`. The API definition marks each mandatory block with `<!-- BEGIN: ... -->` and `<!-- END: ... -->` delimiters, and validation compares the delimited content with the canonical file.
+
+The severity depends on the API status in `release-plan.yaml`:
+
+- `target_api_status: alpha`: P-026/P-027 are hints. The blocks should be added or corrected before the API progresses to rc.
+- `target_api_status: rc`: P-026/P-027 are warnings. The API can still use the r4.3 sync PR to receive the canonical file, but codeowners should fix the warnings before the rc pre-release.
+- `target_api_status: public`: P-026/P-027 are errors. The API is expected to contain the mandatory blocks verbatim; validation fails and would block the release until they are fixed.
+
+**What you do:** copy the reported template from `code/common/info-description-templates.yaml` into the affected API file's `info.description`, keeping the BEGIN/END delimiters and the canonical text unchanged. For P-027, replace the whole drifted delimited block with the matching block from the canonical file.
+
+If the finding appears on the automated Commonalities r4.3 sync pull request itself, first check the API status. For alpha or rc APIs, merge the sync PR so the repository receives `code/common/info-description-templates.yaml`, then open a follow-up API PR to copy the canonical blocks into `info.description`. For APIs already marked `public`, change the release plan only if the API is actually still preparing an rc release; otherwise fix the missing or drifted blocks before release.
+
+Do not edit `code/common/info-description-templates.yaml` in the API repository. That file is owned by Commonalities and updated by the common-file synchronization.
+
 ## Related
 
 - [Validation problem messages](problem-messages.md) — the shape of each message

--- a/documentation/validation/faq.md
+++ b/documentation/validation/faq.md
@@ -131,17 +131,17 @@ This rule is a warning by default, and an error during release automation runs.
 
 Applies to: `[P-026] Mandatory info.description template missing`, `[P-027] info.description mandatory template content drift`
 
-CAMARA API specifications must include mandatory `info.description` text blocks from the API Design Guide and the Identity and Consent Management profile. Starting with Commonalities r4.3, the canonical text is synchronized into each API repository as `code/common/info-description-templates.yaml`. The API definition marks each mandatory block with `<!-- BEGIN: ... -->` and `<!-- END: ... -->` delimiters, and validation compares the delimited content with the canonical file.
+CAMARA API specifications must include mandatory `info.description` text blocks from the API Design Guide and the Identity and Consent Management profile. Starting with Commonalities r4.3, the mandatory text blocks are synchronized into each API repository as `code/common/info-description-templates.yaml`. The API definition marks each mandatory text block with `<!-- BEGIN: ... -->` and `<!-- END: ... -->` delimiters, and validation compares the delimited content with that synced `code/common/info-description-templates.yaml` file.
 
 The severity depends on the API status in `release-plan.yaml`:
 
 - `target_api_status: alpha`: P-026/P-027 are hints. The blocks should be added or corrected before the API progresses to rc.
-- `target_api_status: rc`: P-026/P-027 are warnings. The API can still use the r4.3 sync PR to receive the canonical file, but codeowners should fix the warnings before the rc pre-release.
-- `target_api_status: public`: P-026/P-027 are errors. The API is expected to contain the mandatory blocks verbatim; validation fails and would block the release until they are fixed.
+- `target_api_status: rc`: P-026/P-027 are warnings. The API can still use the r4.3 sync PR to receive the `code/common/info-description-templates.yaml` file, but codeowners should fix the warnings before the rc pre-release.
+- `target_api_status: public`: P-026/P-027 are errors. The API is expected to contain the mandatory blocks verbatim; validation fails and will block the release until they are fixed.
 
-**What you do:** copy the reported template from `code/common/info-description-templates.yaml` into the affected API file's `info.description`, keeping the BEGIN/END delimiters and the canonical text unchanged. For P-027, replace the whole drifted delimited block with the matching block from the canonical file.
+**What you do:** on main, copy the reported template from `code/common/info-description-templates.yaml` into the affected API file's `info.description`, keeping the BEGIN/END delimiters and the copied text unchanged. For P-027, replace the whole drifted delimited block with the matching block from the local `code/common/info-description-templates.yaml` file.
 
-If the finding appears on the automated Commonalities r4.3 sync pull request itself, first check the API status. For alpha or rc APIs, merge the sync PR so the repository receives `code/common/info-description-templates.yaml`, then open a follow-up API PR to copy the canonical blocks into `info.description`. For APIs already marked `public`, change the release plan only if the API is actually still preparing an rc release; otherwise fix the missing or drifted blocks before release.
+If the finding appears when merging the automated Commonalities r4.3 sync PR itself, first check the API status in `release-plan.yaml`. For alpha or rc APIs, merge the sync PR so the repository receives the required `code/common/info-description-templates.yaml`, then open a follow-up API PR to copy the common mandatory blocks into the API's `info.description`. For an API already declared `public`, P-026/P-027 are reported as errors and block the release. Fix the missing or drifted blocks before the release. If the API is in fact not yet ready for a public release, one option is to set `target_api_status` back to `rc` in `release-plan.yaml`, which lowers the findings to warnings.
 
 Do not edit `code/common/info-description-templates.yaml` in the API repository. That file is owned by Commonalities and updated by the common-file synchronization.
 

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -383,6 +383,7 @@
   engine: python
   engine_rule: check-info-description-mandatory-missing
   short_title: "Mandatory info.description template missing"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-026-p-027-info-description-mandatory"
   applicability:
     commonalities_release: ">=r4.3"
   conditional_level:
@@ -405,6 +406,7 @@
   engine: python
   engine_rule: check-info-description-mandatory-drift
   short_title: "info.description mandatory template content drift"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-026-p-027-info-description-mandatory"
   applicability:
     commonalities_release: ">=r4.3"
   conditional_level:

--- a/validation/tests/test_info_description_canonical_self.py
+++ b/validation/tests/test_info_description_canonical_self.py
@@ -28,6 +28,15 @@ _MARKER_END_RE = re.compile(
 )
 
 
+def _template_entries(canonical: dict) -> dict[str, dict]:
+    """Return only canonical entries that carry mandatory template content."""
+    return {
+        name: entry
+        for name, entry in canonical.items()
+        if isinstance(entry, dict) and isinstance(entry.get("content"), str)
+    }
+
+
 def _resolve_canonical_path() -> Path | None:
     """Locate ``artifacts/common/info-description-templates.yaml`` in the workspace.
 
@@ -80,7 +89,9 @@ class TestInfoDescriptionTemplatesCanonical:
         return data
 
     def test_every_entry_has_content_field(self, canonical: dict) -> None:
-        for name, entry in canonical.items():
+        templates = _template_entries(canonical)
+        assert templates, "canonical file must contain template entries"
+        for name, entry in templates.items():
             assert isinstance(entry, dict), (
                 f"template {name!r} is not a mapping"
             )
@@ -89,7 +100,7 @@ class TestInfoDescriptionTemplatesCanonical:
             )
 
     def test_markers_match_key_and_appear_once(self, canonical: dict) -> None:
-        for name, entry in canonical.items():
+        for name, entry in _template_entries(canonical).items():
             content = entry["content"]
             begins = _MARKER_BEGIN_RE.findall(content)
             ends = _MARKER_END_RE.findall(content)
@@ -103,7 +114,7 @@ class TestInfoDescriptionTemplatesCanonical:
             )
 
     def test_begin_precedes_end(self, canonical: dict) -> None:
-        for name, entry in canonical.items():
+        for name, entry in _template_entries(canonical).items():
             content = entry["content"]
             begin_match = _MARKER_BEGIN_RE.search(content)
             end_match = _MARKER_END_RE.search(content)


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Adds a CAMARA Validation FAQ entry for P-026/P-027 mandatory `info.description` findings.

The entry explains how codeowners should react when the findings are reported as hints, warnings, or errors, including the r4.3 common-file sync case where `code/common/info-description-templates.yaml` is introduced by the sync PR.

#### Which issue(s) this PR fixes:

Part of https://github.com/camaraproject/ReleaseManagement/issues/535

#### Special notes for reviewers:

The text keeps the current severity model: hints for alpha APIs, warnings for rc APIs, and errors for public APIs.

#### Changelog input

```
 release-note

```

#### Additional documentation

This section can be blank.


```
docs

```
