### PR TITLE
feat(validation): link findings to FAQ via documentation_url

### DIFF
--- a/documentation/validation/faq.md
+++ b/documentation/validation/faq.md
@@ -2,11 +2,13 @@
 
 This page explains common validation problems that need extra context. It is not a full rule catalog — for the complete list of validation results, open the workflow summary linked from the CAMARA Validation check on a pull request.
 
-Each entry has a question heading. The rule code in square brackets is searchable on this page; quoting it when you ask for support also helps others identify the same problem quickly.
+Each entry is a collapsible block under its category. Expand it to read the explanation. The rule code in square brackets is shown on the entry summary, so it stays searchable on this page; quoting it when you ask for support also helps others identify the same problem quickly. The validation workflow summary links directly to the relevant entry's anchor.
 
 ## API definition problems
 
-### Why is a GET or DELETE request body rejected?
+<a name="s-002-get-delete-request-body"></a>
+<details>
+<summary>[S-002] Why is a GET or DELETE request body rejected?</summary>
 
 Applies to: `[S-002] GET / DELETE must not have a request body`
 
@@ -17,7 +19,11 @@ GET and DELETE operations must not declare a request body. The information that 
 
 **What you do:** open the API definition file shown in the message and remove the `requestBody` from the GET or DELETE operation, or change the operation to a method that accepts a body.
 
-### Why does my operation tag need to be listed globally?
+</details>
+
+<a name="s-222-operation-tag"></a>
+<details>
+<summary>[S-222] Why does my operation tag need to be listed globally?</summary>
 
 Applies to: `[S-222] Operation tag not defined in tags list`
 
@@ -25,7 +31,11 @@ A tag used on an operation must also be declared in the OpenAPI document's top-l
 
 **What you do:** either add the missing tag to the document's top-level `tags` section with a description, or correct the tag on the operation to one that is already declared globally.
 
-### Why is an unused component only a hint?
+</details>
+
+<a name="s-211-unused-component"></a>
+<details>
+<summary>[S-211] Why is an unused component only a hint?</summary>
 
 Applies to: `[S-211] Component may be unused`
 
@@ -33,9 +43,13 @@ The check may not follow every discriminator mapping. A component that looks unu
 
 **What you do:** confirm the component is genuinely unused — for example, by checking discriminator mappings and any oneOf/anyOf indirection — before removing it. If it is in use indirectly, no change is needed.
 
+</details>
+
 ## Test definition problems
 
-### Why are missing test files sometimes a hint, warning, or error?
+<a name="p-006-missing-test-files"></a>
+<details>
+<summary>[P-006] Why are missing test files sometimes a hint, warning, or error?</summary>
 
 Applies to: `[P-006] Missing test definition file for API`
 
@@ -47,9 +61,13 @@ The severity of this rule depends on the API's release type and maturity:
 
 **What you do:** add the expected test definition file under `code/Test_definitions/`. The CAMARA Testing Guidelines describe the expected file layout. Address this before the next release type, even when the rule is currently a hint or warning.
 
+</details>
+
 ## Release-plan problems
 
-### Why can a draft API be listed before the API file exists?
+<a name="p-002-api-file-exists"></a>
+<details>
+<summary>[P-002] Why can a draft API be listed before the API file exists?</summary>
 
 Applies to: `[P-002] API definition file must match release-plan api_name`
 
@@ -59,7 +77,11 @@ If the same entry is listed at any other status (`alpha`, `rc`, `public`, `stabl
 
 **What you do:** if you are starting a new API, keep the entry at `target_api_status: draft` until the API definition file is committed. Promote the status to `alpha` (or higher) only when the file is present in `code/API_definitions/` with a matching filename.
 
-### Why must `release-plan.yaml` change in its own pull request?
+</details>
+
+<a name="p-022-release-plan-exclusivity"></a>
+<details>
+<summary>[P-022] Why must <code>release-plan.yaml</code> change in its own pull request?</summary>
 
 Applies to: `[P-022] release-plan.yaml must change in its own PR`
 
@@ -67,9 +89,13 @@ Applies to: `[P-022] release-plan.yaml must change in its own PR`
 
 **What you do:** split the pull request. Keep `release-plan.yaml` changes in a dedicated pull request, and move the other listed files to a separate pull request.
 
+</details>
+
 ## Commonalities and shared files
 
-### Why should CloudEvent use `$ref` instead of an inline schema?
+<a name="p-020-cloudevent-ref"></a>
+<details>
+<summary>[P-020] Why should CloudEvent use <code>$ref</code> instead of an inline schema?</summary>
 
 Applies to: `[P-020] CloudEvent should be $ref, not inline`
 
@@ -77,7 +103,11 @@ Subscription APIs should reuse the shared CloudEvent schema from `CAMARA_event_c
 
 **What you do:** replace the local CloudEvent schema with `$ref: './CAMARA_event_common.yaml#/components/schemas/CloudEvent'`. Where you also need an API-specific event type, use `allOf` combining the `$ref` with an API-specific `ApiEventType` schema. The implicit-events API template in the Commonalities artifacts directory shows the recommended pattern.
 
-### Why is `code/common/` missing or out of sync?
+</details>
+
+<a name="p-021-common-cache-sync"></a>
+<details>
+<summary>[P-021] Why is <code>code/common/</code> missing or out of sync?</summary>
 
 Applies to: `[P-021] code/common/ is missing or out of sync`
 
@@ -92,6 +122,8 @@ Applies to: `[P-021] code/common/ is missing or out of sync`
 A real issue with the *content* of a cached common file is fixed upstream in [Commonalities](https://github.com/camaraproject/Commonalities), not in the API repository.
 
 This rule is a warning by default, and an error during release automation runs.
+
+</details>
 
 ## Related
 

--- a/validation/output/diagnostics.py
+++ b/validation/output/diagnostics.py
@@ -22,7 +22,15 @@ from validation.postfilter.engine import PostFilterResult
 from .formatting import count_findings, format_rule_label
 
 # TSV columns (header row + per-finding rows).
-_TSV_COLUMNS = ("rule", "file", "line", "level", "message", "suggestion")
+_TSV_COLUMNS = (
+    "rule",
+    "file",
+    "line",
+    "level",
+    "message",
+    "suggestion",
+    "documentation_url",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +146,7 @@ def _write_findings_tsv(findings: List[dict], path: Path) -> None:
             f.get("level", "") or "",
             f.get("message", "") or "",
             f.get("suggestion", "") or "",
+            f.get("documentation_url", "") or "",
         )
         lines.append("\t".join(_sanitize_tsv_field(v) for v in row))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -193,8 +193,9 @@ def _render_rule_block(rule_id: str, findings: List[dict]) -> str:
 
     # Documentation link rendered once per rule block (all findings in the
     # block share the rule, so the URL is identical).  Deliberately kept
-    # out of annotations, where Markdown/HTML links do not render as short
-    # clickable text — see issue 015.
+    # out of annotations: a GitHub Actions annotation-rendering probe
+    # showed Markdown/HTML links there do not render as short clickable
+    # text (see ReleaseManagement#555).
     documentation_url = (findings[0].get("documentation_url") or "").strip()
     if documentation_url:
         out.append(f"> Details: [Validation FAQ]({documentation_url})")

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -167,7 +167,8 @@ def _group_by_rule(findings: List[dict]) -> "Dict[str, List[dict]]":
 
 
 def _render_rule_block(rule_id: str, findings: List[dict]) -> str:
-    """Render one rule's block: bold subject line, bullets, suggestion.
+    """Render one rule's block: bold subject line, bullets, suggestion,
+    and an optional documentation link.
 
     Spacing is intentional: no blank lines inside the block, so the
     bullet list stays tight in the GitHub-flavoured Markdown renderer.
@@ -189,6 +190,14 @@ def _render_rule_block(rule_id: str, findings: List[dict]) -> str:
         out.append(f"> Suggestion: {suggestion_lines[0]}")
         for cont in suggestion_lines[1:]:
             out.append(f"> {cont}")
+
+    # Documentation link rendered once per rule block (all findings in the
+    # block share the rule, so the URL is identical).  Deliberately kept
+    # out of annotations, where Markdown/HTML links do not render as short
+    # clickable text — see issue 015.
+    documentation_url = (findings[0].get("documentation_url") or "").strip()
+    if documentation_url:
+        out.append(f"> Details: [Validation FAQ]({documentation_url})")
 
     return "\n".join(out)
 

--- a/validation/postfilter/engine.py
+++ b/validation/postfilter/engine.py
@@ -111,7 +111,8 @@ def _enrich_finding(
     When *message_override* is set, the finding's message is replaced.
     When *suggestion* is set, it is added to the finding as additional
     guidance.  When neither is set, the engine's original message is
-    preserved and no suggestion is added.
+    preserved and no suggestion is added.  When *documentation_url* is
+    set, it is added so downstream surfaces can link to deeper guidance.
     """
     enriched = dict(finding)
     enriched["rule_id"] = rule.id
@@ -123,6 +124,8 @@ def _enrich_finding(
         enriched["suggestion"] = rule.suggestion
     if rule.short_title is not None:
         enriched["short_title"] = rule.short_title
+    if rule.documentation_url is not None:
+        enriched["documentation_url"] = rule.documentation_url
     return enriched
 
 

--- a/validation/postfilter/metadata_loader.py
+++ b/validation/postfilter/metadata_loader.py
@@ -77,6 +77,11 @@ class RuleMetadata:
         suggestion: Additional fix guidance shown alongside the message
             (rendered under a ``Suggestion:`` label).  ``None`` means
             no extra guidance.
+        documentation_url: Canonical public documentation URL with a deeper
+            explanation and fix guidance (usually a ``faq.md`` anchor).
+            Rendered as a details link in the workflow summary and carried
+            into diagnostics; deliberately omitted from annotations.
+            ``None`` means no documentation link (selective by design).
         applicability: Condition dict — omitted fields are unconstrained.
         conditional_level: Severity specification, or ``None`` to preserve
             engine-reported severity (identity mapping).
@@ -96,6 +101,7 @@ class RuleMetadata:
     conditional_level: Optional[ConditionalLevel]
     short_title: Optional[str] = None
     suppress_schema_paths: Tuple[str, ...] = ()
+    documentation_url: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +176,7 @@ def parse_rule_metadata(raw: dict) -> RuleMetadata:
         conditional_level=conditional_level,
         short_title=raw.get("short_title"),
         suppress_schema_paths=suppress_schema_paths,
+        documentation_url=raw.get("documentation_url"),
     )
 
 

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -22,6 +22,7 @@
   engine: python
   engine_rule: check-filename-matches-api-name
   short_title: "API definition file must match release-plan api_name"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-002-api-file-exists"
   conditional_level:
     default: error
     overrides:
@@ -66,6 +67,7 @@
   engine: python
   engine_rule: check-test-files-exist
   short_title: "Missing test definition file for API"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-006-missing-test-files"
   conditional_level:
     default: hint
     overrides:
@@ -259,6 +261,7 @@
   engine: python
   engine_rule: check-cloudevent-via-ref
   short_title: "CloudEvent should be $ref, not inline"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-020-cloudevent-ref"
   applicability:
     api_pattern: [explicit-subscription, implicit-subscription]
     commonalities_release: ">=r4.2"
@@ -281,6 +284,7 @@
   engine: python
   engine_rule: check-common-cache-sync
   short_title: "code/common/ is missing or out of sync"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-021-common-cache-sync"
   applicability:
     release_plan_changed: false
     commonalities_release: ">=r4.2"
@@ -307,6 +311,7 @@
   engine: python
   engine_rule: check-release-plan-exclusivity
   short_title: "release-plan.yaml must change in its own PR"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-022-release-plan-exclusivity"
   applicability:
     release_plan_changed: true
   conditional_level:

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -15,6 +15,7 @@
   engine: spectral
   engine_rule: camara-get-no-request-body
   short_title: "GET / DELETE must not have a request body"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#s-002-get-delete-request-body"
 
 - id: S-003
   engine: spectral
@@ -269,6 +270,7 @@
   engine_rule: oas3-unused-component
   short_title: "Component may be unused"
   suggestion: "Spectral does not follow discriminator mappings — verify the schema is truly unused."
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#s-211-unused-component"
   conditional_level:
     default: hint
 
@@ -326,6 +328,7 @@
   engine: spectral
   engine_rule: operation-tag-defined
   short_title: "Operation tag not defined in tags list"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#s-222-operation-tag"
 
 - id: S-223
   engine: spectral

--- a/validation/schemas/findings-schema.yaml
+++ b/validation/schemas/findings-schema.yaml
@@ -88,3 +88,11 @@ properties:
     description: >
       Actionable fix guidance from rule metadata.  Only present when
       the rule metadata explicitly provides a hint.
+
+  documentation_url:
+    type: string
+    description: >
+      Canonical public documentation URL for this rule, copied from rule
+      metadata by the post-filter when present.  Surfaced in the workflow
+      summary and the findings.tsv / findings.json diagnostics.  Optional
+      and selective — absent for rules without a documentation link.

--- a/validation/schemas/rule-metadata-schema.yaml
+++ b/validation/schemas/rule-metadata-schema.yaml
@@ -69,6 +69,21 @@ properties:
       summary).  Optional — only set when there is "how to fix"
       guidance beyond what the message already says.
 
+  documentation_url:
+    type: string
+    pattern: "^https://github\\.com/camaraproject/tooling/blob/main/documentation/validation/[^#]+#.+$"
+    description: >
+      Canonical public documentation URL pointing to a deeper explanation
+      and fix guidance for this rule — usually a `faq.md` entry anchor.
+      Rendered as a details link in the workflow summary and carried into
+      the `findings.json` / `findings.tsv` diagnostics; deliberately left
+      out of GitHub Actions annotation bodies because Markdown/HTML links
+      do not render as short clickable text there.  Optional and
+      selective — set only for rules that benefit from extra explanation;
+      self-explanatory rules leave it unset.  Must be a full absolute URL
+      under `documentation/validation/` with an anchor fragment so the
+      target FAQ section resolves.
+
   applicability:
     type: object
     description: >

--- a/validation/tests/test_output_diagnostics.py
+++ b/validation/tests/test_output_diagnostics.py
@@ -156,7 +156,9 @@ class TestFindingsTsv:
         write_diagnostics(_make_result(), _make_context(), out)
         text = (out / "findings.tsv").read_text(encoding="utf-8")
         first_line = text.splitlines()[0]
-        assert first_line == "rule\tfile\tline\tlevel\tmessage\tsuggestion"
+        assert first_line == (
+            "rule\tfile\tline\tlevel\tmessage\tsuggestion\tdocumentation_url"
+        )
 
     def test_row_per_finding(self, tmp_path: Path):
         findings = [
@@ -210,9 +212,9 @@ class TestFindingsTsv:
         write_diagnostics(_make_result(findings), _make_context(), out)
         text = (out / "findings.tsv").read_text(encoding="utf-8")
         # Tab inside the message must be flattened to a single space —
-        # the row must still split into exactly 6 columns on `\t`.
+        # the row must still split into exactly 7 columns on `\t`.
         data_row = text.splitlines()[1]
-        assert data_row.count("\t") == 5
+        assert data_row.count("\t") == 6
         assert "left right" in data_row
 
     def test_newline_in_field_sanitized(self, tmp_path: Path):
@@ -244,7 +246,9 @@ class TestFindingsTsv:
         # Header only.
         rows = [line for line in text.splitlines() if line.strip()]
         assert len(rows) == 1
-        assert rows[0] == "rule\tfile\tline\tlevel\tmessage\tsuggestion"
+        assert rows[0] == (
+            "rule\tfile\tline\tlevel\tmessage\tsuggestion\tdocumentation_url"
+        )
 
     def test_missing_optional_fields(self, tmp_path: Path):
         # Finding without `suggestion` field — TSV row writes empty string.
@@ -264,6 +268,33 @@ class TestFindingsTsv:
         write_diagnostics(_make_result(findings), _make_context(), out)
         text = (out / "findings.tsv").read_text(encoding="utf-8")
         data_row = text.splitlines()[1]
-        # 5 tabs → 6 columns, last column (suggestion) is empty.
-        assert data_row.count("\t") == 5
-        assert data_row.endswith("msg\t")
+        # 6 tabs → 7 columns; suggestion and documentation_url both empty.
+        assert data_row.count("\t") == 6
+        assert data_row.endswith("msg\t\t")
+
+    def test_documentation_url_column(self, tmp_path: Path):
+        url = (
+            "https://github.com/camaraproject/tooling/blob/main/"
+            "documentation/validation/faq.md#s-042-example"
+        )
+        findings = [
+            {
+                "engine": "spectral",
+                "engine_rule": "camara-x",
+                "rule_id": "S-042",
+                "level": "error",
+                "message": "Bad path",
+                "path": "spec.yaml",
+                "line": 47,
+                "api_name": None,
+                "blocks": True,
+                "suggestion": "Use kebab-case",
+                "documentation_url": url,
+            }
+        ]
+        out = tmp_path / "output"
+        write_diagnostics(_make_result(findings), _make_context(), out)
+        text = (out / "findings.tsv").read_text(encoding="utf-8")
+        data_row = text.splitlines()[1]
+        assert data_row.endswith(f"\t{url}")
+        assert data_row.count("\t") == 6

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -53,6 +53,7 @@ def _make_finding(
     rule_id: str | None = None,
     engine_rule: str = "some-rule",
     suggestion: str | None = None,
+    documentation_url: str | None = None,
 ) -> dict:
     f: dict = {
         "engine": "spectral",
@@ -68,6 +69,8 @@ def _make_finding(
         f["rule_id"] = rule_id
     if suggestion is not None:
         f["suggestion"] = suggestion
+    if documentation_url is not None:
+        f["documentation_url"] = documentation_url
     return f
 
 
@@ -400,6 +403,41 @@ class TestFindingsSection:
         assert "> Suggestion: first line" in sr.markdown
         assert "> second line" in sr.markdown
         assert "> third line" in sr.markdown
+
+    def test_documentation_url_renders_details_link(self):
+        url = (
+            "https://github.com/camaraproject/tooling/blob/main/"
+            "documentation/validation/faq.md#s-001-example"
+        )
+        findings = [
+            _make_finding(level="error", rule_id="S-001", documentation_url=url)
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert f"]({url})" in sr.markdown
+
+    def test_documentation_url_rendered_once_per_rule_block(self):
+        url = (
+            "https://github.com/camaraproject/tooling/blob/main/"
+            "documentation/validation/faq.md#s-001-example"
+        )
+        findings = [
+            _make_finding(
+                level="error", rule_id="S-001", line=10, documentation_url=url
+            ),
+            _make_finding(
+                level="error", rule_id="S-001", line=20, documentation_url=url
+            ),
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        # One rule block (same rule) → exactly one details link.
+        assert sr.markdown.count(f"]({url})") == 1
+
+    def test_no_documentation_link_when_url_absent(self):
+        findings = [
+            _make_finding(level="error", rule_id="S-001", documentation_url=None)
+        ]
+        sr = generate_workflow_summary(_make_result(findings), _make_context())
+        assert "documentation/validation/faq.md" not in sr.markdown
 
     def test_newline_in_message_flattened(self):
         findings = [

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -116,6 +116,7 @@ def _minimal_rule(
     applicability: dict | None = None,
     overrides: list[dict] | None = None,
     short_title: str | None = None,
+    documentation_url: str | None = None,
 ) -> dict:
     """Build a rule with conditional_level (full behavior)."""
     rule: dict = {
@@ -134,6 +135,8 @@ def _minimal_rule(
         rule["conditional_level"]["overrides"] = overrides
     if short_title is not None:
         rule["short_title"] = short_title
+    if documentation_url is not None:
+        rule["documentation_url"] = documentation_url
     return rule
 
 
@@ -294,6 +297,37 @@ class TestRunPostFilter:
         assert f["short_title"] == "Path must be kebab-case"
         # Message is untouched — short_title supplements, never replaces.
         assert f["message"] == "Original msg"
+
+    def test_documentation_url_propagated_to_finding(self, tmp_path: Path):
+        """documentation_url in metadata is copied onto the enriched finding."""
+        url = (
+            "https://github.com/camaraproject/tooling/blob/main/"
+            "documentation/validation/faq.md#s-001-example"
+        )
+        _write_rules(tmp_path, [
+            _minimal_rule(
+                id="S-001",
+                engine_rule="some-rule",
+                documentation_url=url,
+            )
+        ])
+        ctx = _make_context(profile="standard")
+        findings = [_make_finding(message="Original msg")]
+        result = run_post_filter(findings, ctx, tmp_path)
+
+        f = result.findings[0]
+        assert f["documentation_url"] == url
+
+    def test_no_documentation_url_when_unset(self, tmp_path: Path):
+        """A rule without documentation_url leaves the field off the finding."""
+        _write_rules(tmp_path, [
+            _minimal_rule(id="S-001", engine_rule="some-rule")
+        ])
+        ctx = _make_context(profile="standard")
+        findings = [_make_finding(message="Original msg")]
+        result = run_post_filter(findings, ctx, tmp_path)
+
+        assert "documentation_url" not in result.findings[0]
 
     def test_applicability_filters_finding(self, tmp_path: Path):
         """Non-applicable findings are silently removed."""

--- a/validation/tests/test_postfilter_metadata.py
+++ b/validation/tests/test_postfilter_metadata.py
@@ -69,6 +69,7 @@ class TestParseRuleMetadata:
         assert rule.engine_rule == "camara-test-rule"
         assert rule.message_override is None
         assert rule.suggestion is None
+        assert rule.documentation_url is None
         assert rule.applicability == {}
         assert rule.conditional_level is None
 
@@ -98,6 +99,7 @@ class TestParseRuleMetadata:
         rule = parse_rule_metadata(raw)
         assert rule.message_override is None
         assert rule.suggestion is None
+        assert rule.documentation_url is None
         assert rule.suppress_schema_paths == ()
 
     def test_suppress_schema_paths_parsed(self):
@@ -149,6 +151,19 @@ class TestParseRuleMetadata:
         raw = _minimal_rule_dict(suggestion="Do this instead.")
         rule = parse_rule_metadata(raw)
         assert rule.suggestion == "Do this instead."
+
+    def test_explicit_documentation_url(self):
+        raw = _minimal_rule_dict(
+            documentation_url=(
+                "https://github.com/camaraproject/tooling/blob/main/"
+                "documentation/validation/faq.md#s-001-example"
+            )
+        )
+        rule = parse_rule_metadata(raw)
+        assert rule.documentation_url == (
+            "https://github.com/camaraproject/tooling/blob/main/"
+            "documentation/validation/faq.md#s-001-example"
+        )
 
     def test_both_message_override_and_suggestion(self):
         raw = _minimal_rule_dict(

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -27,6 +27,16 @@ from validation.postfilter.metadata_loader import (
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _RULES_DIR = _REPO_ROOT / "validation" / "rules"
 _LINTING_DIR = _REPO_ROOT / "linting" / "config"
+_DOC_VALIDATION_DIR = _REPO_ROOT / "documentation" / "validation"
+
+# Canonical public documentation URL: a file under
+# documentation/validation/ on the tooling repo's main branch, with an
+# anchor fragment so the target section resolves.
+_DOCUMENTATION_URL_PATTERN = re.compile(
+    r"^https://github\.com/camaraproject/tooling/blob/main/"
+    r"documentation/validation/(?P<file>[A-Za-z0-9._-]+\.md)"
+    r"#(?P<fragment>[a-z0-9-]+)$"
+)
 
 _SPECTRAL_CONFIG = _LINTING_DIR / ".spectral.yaml"
 _SPECTRAL_R34_CONFIG = _LINTING_DIR / ".spectral-r3.4.yaml"
@@ -392,3 +402,77 @@ class TestShortTitleConvention:
     def test_short_titles_are_non_empty(self, all_rules):
         empty = [r.id for r in all_rules if r.short_title == ""]
         assert not empty, f"Rules with empty short_title: {empty}"
+
+
+# ---------------------------------------------------------------------------
+# documentation_url convention
+# ---------------------------------------------------------------------------
+
+
+def _extract_faq_anchors(text: str) -> set[str]:
+    """Return the set of explicit ``<a name="...">`` anchors in a doc page."""
+    return set(re.findall(r'<a\s+name="([^"]+)"\s*>', text))
+
+
+class TestDocumentationUrl:
+    """Verify documentation links are selective, canonical, and resolvable.
+
+    ``documentation_url`` is optional by design (links are selective), so
+    absence is never an error.  When present, the URL must be a canonical
+    public documentation URL and its anchor fragment must resolve to an
+    explicit anchor in the referenced ``documentation/validation/`` page.
+    """
+
+    def test_missing_documentation_url_is_valid(self, all_rules):
+        """Most rules carry no documentation_url — that is expected."""
+        without = [r.id for r in all_rules if r.documentation_url is None]
+        # The field is selective; the overwhelming majority opt out.
+        assert without, "Expected most rules to omit documentation_url"
+
+    def test_present_urls_are_canonical(self, all_rules):
+        """Every present documentation_url is a canonical public doc URL."""
+        bad = [
+            (r.id, r.documentation_url)
+            for r in all_rules
+            if r.documentation_url is not None
+            and not _DOCUMENTATION_URL_PATTERN.match(r.documentation_url)
+        ]
+        assert not bad, (
+            f"Non-canonical documentation_url values "
+            f"(expected {_DOCUMENTATION_URL_PATTERN.pattern}): {bad}"
+        )
+
+    def test_fragments_resolve_to_explicit_anchors(self, all_rules):
+        """Each documentation_url fragment resolves to an explicit anchor.
+
+        The referenced page must exist under documentation/validation/ and
+        contain a matching ``<a name="...">`` anchor.
+        """
+        linked = [r for r in all_rules if r.documentation_url is not None]
+        if not linked:
+            pytest.skip("No rules define documentation_url yet")
+
+        anchors_by_file: dict[str, set[str]] = {}
+        unresolved = []
+        for r in linked:
+            m = _DOCUMENTATION_URL_PATTERN.match(r.documentation_url)
+            assert m, f"{r.id}: non-canonical URL {r.documentation_url}"
+            filename = m.group("file")
+            fragment = m.group("fragment")
+            if filename not in anchors_by_file:
+                doc_path = _DOC_VALIDATION_DIR / filename
+                if not doc_path.is_file():
+                    unresolved.append(
+                        f"{r.id}: doc page missing ({filename})"
+                    )
+                    continue
+                anchors_by_file[filename] = _extract_faq_anchors(
+                    doc_path.read_text(encoding="utf-8")
+                )
+            if fragment not in anchors_by_file.get(filename, set()):
+                unresolved.append(
+                    f"{r.id}: anchor #{fragment} not found in {filename}"
+                )
+        assert not unresolved, (
+            f"documentation_url fragments without anchors: {unresolved}"
+        )


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Lets a validation rule link to a deeper FAQ explanation, instead of trying to fit everything into the short suggestion text on each finding. A new optional `documentation_url` on the rule shows up as a single "Validation FAQ" link in the workflow summary for that rule, and is also included in the `findings.json` / `findings.tsv` artifacts. The annotations shown on the diff are left as-is: a quick test on GitHub confirmed that links there just show as raw text, so adding them would only add noise.

- Optional and selective: rules with a clear message need no link, and a missing link is never an error.
- The FAQ entries are now collapsible blocks with stable anchors, so each link lands on the right section. Tests check that every link points at a real FAQ anchor.
- Eight existing FAQ-backed rules are linked (S-002, S-211, S-222, P-002, P-006, P-020, P-021, P-022).

#### Which issue(s) this PR fixes:

Relates to camaraproject/ReleaseManagement#555

#### Special notes for reviewers:

The best place to see this is the workflow summary; the ReleaseTest validation run will show the live links once this is on `main`. The FAQ category headings stay as normal headings — only the individual entries became collapsible. Links for the info.description rules (P-026/P-027) are left for when their FAQ entry lands.

#### Changelog input

```
 release-note
Validation findings can now link to a FAQ explanation via an optional rule documentation_url, shown in the workflow summary and findings artifacts.
```

#### Additional documentation

```
docs
documentation/validation/faq.md — FAQ entries are now collapsible blocks with stable anchors that rule documentation_url values link to.
```
