### PR TITLE
fix(validation): adjust S-016 prerelease severity

### DIFF
--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -86,6 +86,12 @@
   engine: spectral
   engine_rule: camara-schema-type-check
   short_title: "Schema must declare a type or combiner"
+  conditional_level:
+    default: error
+    overrides:
+      - condition:
+          target_api_status: [alpha, rc]
+        level: warn
 
 - id: S-017
   engine: spectral


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

S-016 currently reports `camara-schema-type-check` findings as errors for every target API status.

This PR keeps S-016 as an error by default, while downgrading it to a warning for APIs with `target_api_status: alpha` or `target_api_status: rc`. Pre-release validation still reports the schema type issue, but it no longer blocks alpha/rc validation runs.

#### Which issue(s) this PR fixes:

None

#### Special notes for reviewers:

The ReleaseTest regression branch `regression/r4.3-broken-spec-yaml-fundamentals` may need its expected fixture recaptured because it uses alpha API targets and currently records S-016 as an error.

#### Changelog input

```
S-016 schema type findings are warnings for alpha and rc API targets, while remaining errors for public targets.
```

#### Additional documentation

This section can be blank.



```
docs
```
