### PR TITLE
docs(validation): pin P-021 and P-031 to missing-canonical regression branch

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 89
+  total_tested: 91
   by_engine:
     spectral: 85
     gherkin: 25
@@ -316,11 +316,13 @@ tested_rules:
   P-015: [regression/r4.3-broken-spec-subscriptions]
   P-016: [regression/r4.3-broken-spec-subscriptions]
   P-020: [regression/r4.3-broken-spec-subscriptions]
+  P-021: [regression/r4.3-broken-spec-info-description-missing-canonical]
   P-026: [regression/r4.3-broken-spec-info-description-mandatory]
   P-027: [regression/r4.3-broken-spec-info-description-mandatory]
   P-028: [regression/r4.3-broken-spec-info-description-mandatory]
   P-029: [regression/r4.3-broken-spec-info-description-mandatory]
   P-030: [regression/r4.3-broken-spec-info-description-mandatory]
+  P-031: [regression/r4.3-broken-spec-info-description-missing-canonical]
   S-002: [regression/r4.3-broken-spec-routing]
   S-003: [regression/r4.3-broken-spec-routing]
   S-005: [regression/r4.3-broken-spec-yaml-fundamentals]


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Pins `P-021` (common-cache sync — managed common file missing) and `P-031`
(info.description canonical source unavailable) in the regression
`tested_rules` inventory, and bumps `total_tested` 89 → 91.

Both rules are now exercised by a new ReleaseTest regression branch,
`regression/r4.3-broken-spec-info-description-missing-canonical`, which deletes
`code/common/info-description-templates.yaml` (retaining its `.sync-manifest.yaml`
entry) to reproduce the canonical-source-unavailable state. `P-031` was added
in #308 and previously had no regression coverage; the companion
`info-description-mandatory` branch pins `P-026..P-030` with the canonical file
present, so this branch covers the missing-file path it cannot.

The fixture was captured and verified against `tooling@main`: the runner reports
`1/1 branches PASS` (20 findings matched, 0 missing, 0 unexpected) — 4 warnings
(`P-021` ×1, `P-031` ×3, one per API spec) over the inherited baseline.

#### Which issue(s) this PR fixes:

Part of camaraproject/ReleaseManagement#483

#### Special notes for reviewers:

Inventory-only change; the regression branch and its `.regression/` fixture are
already pushed to `camaraproject/ReleaseTest`. No framework code changes.

#### Changelog input

```
 release-note

NONE
```

#### Additional documentation

This section can be blank.

```
docs

NONE
```
