### PR TITLE
fix(validation): source canonical fallback on release-review PRs

### DIFF
--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -139,6 +139,55 @@ runs:
           fi
         fi
 
+    - name: Fetch canonical info.description templates (release-review only)
+      id: fetch-canonical-fallback
+      if: startsWith(github.base_ref, 'release-snapshot/')
+      shell: bash
+      env:
+        REPO_PATH: ${{ inputs.repo_path }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # On the Release Review PR (snapshot branch) code/common/ has been
+        # stripped after bundling, so the info.description family cannot read
+        # the canonical templates locally and P-031 would false-fire. Fetch the
+        # matching version from Commonalities source at the pinned
+        # commonalities_release and inject its path; the engine uses it as the
+        # canonical fallback so P-026..P-030 evaluate and the codeowner sees
+        # real warnings. release-plan.yaml is gone on the snapshot, so read the
+        # tag from release-metadata.yaml. Fetch failure is tolerated: no inject
+        # means the engine degrades to a single P-031 warn (not a block).
+        META_FILE="${REPO_PATH}/release-metadata.yaml"
+        if [ ! -f "$META_FILE" ]; then
+          echo "No release-metadata.yaml; skipping canonical fallback fetch."
+          exit 0
+        fi
+        # release-metadata.yaml carries the enriched string form
+        # "r4.2 (1.2.0-rc.1)"; take the leading rX.Y tag (mirrors
+        # release_metadata_parser._extract_release_tag).
+        RELEASE_TAG=$(python3 -c "
+        import re, yaml
+        try:
+            meta = yaml.safe_load(open('${META_FILE}'))
+            dep = meta.get('dependencies', {}).get('commonalities_release', '')
+            m = re.match(r'^(r\d+\.\d+)', str(dep).strip())
+            print(m.group(1) if m else '')
+        except Exception:
+            print('')
+        ")
+        if [ -z "$RELEASE_TAG" ]; then
+          echo "No commonalities_release in release-metadata.yaml; skipping."
+          exit 0
+        fi
+        DEST="${RUNNER_TEMP}/info-description-templates.fallback.yaml"
+        if gh api "repos/camaraproject/Commonalities/contents/artifacts/common/info-description-templates.yaml?ref=${RELEASE_TAG}" \
+             --jq '.content' 2>/dev/null | base64 -d > "$DEST" 2>/dev/null && [ -s "$DEST" ]; then
+          echo "VALIDATION_FALLBACK_CANONICAL_PATH=${DEST}" >> "$GITHUB_ENV"
+          echo "Fetched canonical templates from Commonalities ${RELEASE_TAG} -> ${DEST}"
+        else
+          rm -f "$DEST"
+          echo "Could not fetch canonical templates at ${RELEASE_TAG}; P-031 will warn."
+        fi
+
     - name: Run validation orchestrator
       id: run
       shell: bash

--- a/validation/context/context_builder.py
+++ b/validation/context/context_builder.py
@@ -141,6 +141,15 @@ class ValidationContext:
     icm_tag_exists: Optional[bool] = None
     non_release_plan_files_changed: Tuple[str, ...] = ()
 
+    # fallback_canonical_path: absolute path to an info-description-templates.yaml
+    # fetched by the workflow from Commonalities source at commonalities_release.
+    # Injected ONLY in the release-review / snapshot context, where code/common/
+    # has been stripped after bundling; empty everywhere else (working-branch PRs,
+    # main, local runs stay offline).  The info.description family uses it as the
+    # second canonical-resolution tier so the codeowner sees real P-026..P-030
+    # warnings on the Release Review PR instead of a P-031 false positive.
+    fallback_canonical_path: Optional[str] = None
+
     def to_dict(self) -> dict:
         """Serialize to dict with all keys present.
 
@@ -288,6 +297,7 @@ def build_validation_context(
     commonalities_tag_exists: Optional[bool] = None,
     icm_tag_exists: Optional[bool] = None,
     non_release_plan_files_changed: Tuple[str, ...] = (),
+    fallback_canonical_path: Optional[str] = None,
 ) -> ValidationContext:
     """Assemble the unified validation context.
 
@@ -378,4 +388,5 @@ def build_validation_context(
         commonalities_tag_exists=commonalities_tag_exists,
         icm_tag_exists=icm_tag_exists,
         non_release_plan_files_changed=non_release_plan_files_changed,
+        fallback_canonical_path=fallback_canonical_path,
     )

--- a/validation/engines/python_checks/info_description_checks.py
+++ b/validation/engines/python_checks/info_description_checks.py
@@ -78,17 +78,44 @@ _RULE_CANONICAL_MISSING = "check-info-description-canonical-missing"
 _canonical_cache: Dict[Path, Tuple[int, Dict[str, List[str]]]] = {}
 
 
-def _load_canonical(repo_path: Path) -> Optional[Dict[str, List[str]]]:
+def _load_canonical(
+    repo_path: Path, fallback_path: Optional[str] = None
+) -> Optional[Dict[str, List[str]]]:
     """Load and paragraph-normalise the canonical templates.
 
-    Returns ``{template_name: [normalised_paragraph, ...]}`` or ``None`` if
-    the canonical file does not exist (e.g. r4.2 repo, or a release-review
-    branch after the snapshot bundling step has cleared ``code/common/``).
+    Resolution is two-tier:
 
-    Cached by (path, mtime_ns) so the file is read at most once per
+    1. **Local** — repo-local ``code/common/info-description-templates.yaml``.
+       Always wins when present, even if stale: the spec's blocks were copied
+       from it and P-021 already warns when it is out of sync.
+    2. **Fallback** — only when the local file is absent and *fallback_path* is
+       set.  The workflow injects this path (a copy of the templates file
+       fetched from Commonalities source at ``commonalities_release``) **only in
+       the release-review / snapshot context**, where bundling has cleared
+       ``code/common/``.  On main / working-branch / local runs no fallback is
+       injected, so resolution falls through to ``None`` and P-031 fires.
+
+    Returns ``{template_name: [normalised_paragraph, ...]}`` or ``None`` when
+    neither source resolves.
+
+    Cached by (path, mtime_ns) so each file is read at most once per
     validation run regardless of how many specs the repo contains.
     """
-    canonical_path = (repo_path / _CANONICAL_REL_PATH).resolve()
+    result = _load_canonical_from((repo_path / _CANONICAL_REL_PATH).resolve())
+    if result is not None:
+        return result
+    if fallback_path:
+        return _load_canonical_from(Path(fallback_path).resolve())
+    return None
+
+
+def _load_canonical_from(
+    canonical_path: Path,
+) -> Optional[Dict[str, List[str]]]:
+    """Read and normalise one canonical templates file.
+
+    Returns ``None`` if the file does not exist or is not valid YAML mapping.
+    """
     try:
         mtime = canonical_path.stat().st_mtime_ns
     except FileNotFoundError:
@@ -356,18 +383,25 @@ def check_info_description_templates(
     if not spec_path.is_file():
         return []
 
-    canonical = _load_canonical(repo_path)
+    canonical = _load_canonical(repo_path, context.fallback_canonical_path)
     if canonical is None:
+        # P-031 fires only when the canonical is unresolvable from BOTH the
+        # repo-local copy AND the injected fallback (Commonalities source,
+        # release-review context only).  On the Release Review PR the workflow
+        # always injects the fallback, so this no longer false-fires there; on
+        # main / working branches no fallback is injected and a genuinely
+        # missing local copy still produces this warning.
         return [
             make_finding(
                 engine_rule=_RULE_CANONICAL_MISSING,
                 level="warn",
                 message=(
-                    f"Cannot validate mandatory info.description templates "
-                    f"because {_CANONICAL_REL_PATH!r} is missing or "
-                    f"unreadable. The common-file sync must provide this "
-                    f"file before P-026..P-030 can check mandatory "
-                    f"info.description blocks."
+                    f"Cannot validate mandatory info.description templates: "
+                    f"the canonical templates file is unresolvable from both "
+                    f"the repo-local {_CANONICAL_REL_PATH!r} and the "
+                    f"Commonalities source fallback. The common-file sync must "
+                    f"provide this file before P-026..P-030 can check "
+                    f"mandatory info.description blocks."
                 ),
                 path=api.spec_file,
                 line=1,

--- a/validation/orchestrator.py
+++ b/validation/orchestrator.py
@@ -78,6 +78,12 @@ class OrchestratorArgs:
     # When empty, falls back to the in-tree copy at the pinned ref.
     config_path: str
 
+    # Optional path to an info-description-templates.yaml fetched by the
+    # workflow from Commonalities source at commonalities_release.  Injected
+    # only in the release-review / snapshot context (code/common/ stripped);
+    # empty everywhere else, keeping local/main/working-branch runs offline.
+    fallback_canonical_path: str
+
     repo_name: str  # e.g. "camaraproject/QualityOnDemand"
     repo_owner: str  # e.g. "camaraproject"
     event_name: str  # e.g. "pull_request", "workflow_dispatch"
@@ -162,6 +168,7 @@ def parse_args() -> OrchestratorArgs:
         tooling_path=Path(_env("TOOLING_PATH", ".tooling")),
         output_dir=Path(_env("OUTPUT_DIR", "validation-output")),
         config_path=_env("CONFIG_PATH"),
+        fallback_canonical_path=_env("FALLBACK_CANONICAL_PATH"),
         repo_name=_env("REPO_NAME"),
         repo_owner=_env("REPO_OWNER"),
         event_name=_env("EVENT_NAME"),
@@ -531,6 +538,7 @@ def main() -> int:
         commonalities_tag_exists=args.commonalities_tag_exists,
         icm_tag_exists=args.icm_tag_exists,
         non_release_plan_files_changed=args.non_release_plan_files_changed,
+        fallback_canonical_path=args.fallback_canonical_path or None,
     )
     logger.info(
         "Context: branch=%s trigger=%s profile=%s release_review=%s apis=%d",

--- a/validation/tests/test_context_builder.py
+++ b/validation/tests/test_context_builder.py
@@ -244,6 +244,7 @@ class TestValidationContextToDict:
             "release_plan_check_only",
             "commonalities_tag_exists", "icm_tag_exists",
             "non_release_plan_files_changed",
+            "fallback_canonical_path",
         }
         assert set(d.keys()) == expected_keys
 

--- a/validation/tests/test_python_checks_info_description.py
+++ b/validation/tests/test_python_checks_info_description.py
@@ -118,6 +118,7 @@ def _make_context(
     api_name: str = "sample-service",
     target_api_status: str = "rc",
     commonalities_release: str = "r4.3",
+    fallback_canonical_path: str | None = None,
 ) -> ValidationContext:
     api = ApiContext(
         api_name=api_name,
@@ -144,6 +145,7 @@ def _make_context(
         apis=(api,),
         workflow_run_url="",
         tooling_ref="",
+        fallback_canonical_path=fallback_canonical_path,
     )
 
 
@@ -353,6 +355,63 @@ class TestNS27InfoDescriptionMandatory:
         findings = check_info_description_templates(tmp_path, _make_context())
         assert _codes(findings) == ["check-info-description-canonical-missing"]
         assert "info-description-templates.yaml" in findings[0]["message"]
+
+    def test_local_absent_fallback_present_evaluates_no_p031(
+        self, tmp_path: Path
+    ) -> None:
+        """Release-review context: code/common/ stripped but the workflow has
+        injected the source-fetched canonical. P-026..P-030 must evaluate
+        against it and P-031 must NOT fire."""
+        # No _write_canonical: the repo-local copy is absent (snapshot strip).
+        fallback = tmp_path / "fallback" / "info-description-templates.yaml"
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        fallback.write_text(_CANONICAL_YAML, encoding="utf-8")
+        # A valid spec carrying all universal blocks → no findings at all.
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        ctx = _make_context(fallback_canonical_path=str(fallback))
+        findings = check_info_description_templates(tmp_path, ctx)
+        assert "check-info-description-canonical-missing" not in _codes(findings)
+        assert findings == []
+
+    def test_local_absent_fallback_present_surfaces_real_finding(
+        self, tmp_path: Path
+    ) -> None:
+        """The injected fallback drives a genuine P-026, not a P-031, when a
+        mandatory block is missing on the snapshot."""
+        fallback = tmp_path / "fallback" / "info-description-templates.yaml"
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        fallback.write_text(_CANONICAL_YAML, encoding="utf-8")
+        # Omit the authorization block → P-026 should fire via the fallback.
+        body = "\n\n".join([_BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        ctx = _make_context(fallback_canonical_path=str(fallback))
+        codes = _codes(check_info_description_templates(tmp_path, ctx))
+        assert "check-info-description-mandatory-missing" in codes
+        assert "check-info-description-canonical-missing" not in codes
+
+    def test_local_present_wins_over_fallback(self, tmp_path: Path) -> None:
+        """Local copy always wins, even when a fallback path is also set —
+        local validation stays offline and unchanged on working branches."""
+        _write_canonical(tmp_path)
+        # Point the fallback at a deliberately broken file; it must be ignored.
+        bad_fallback = tmp_path / "fallback" / "info-description-templates.yaml"
+        bad_fallback.parent.mkdir(parents=True, exist_ok=True)
+        bad_fallback.write_text("not: [a, valid, catalog", encoding="utf-8")
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        ctx = _make_context(fallback_canonical_path=str(bad_fallback))
+        findings = check_info_description_templates(tmp_path, ctx)
+        assert findings == []
+
+    def test_local_absent_no_fallback_fires_p031(self, tmp_path: Path) -> None:
+        """Main / working-branch contract: no local copy and no injected
+        fallback → exactly one P-031 (offline, fires truthfully)."""
+        body = "\n\n".join([_BLOCK_AUTH, _BLOCK_ERRORS, _BLOCK_STRICTNESS])
+        _write_spec(tmp_path, "sample-service", body)
+        ctx = _make_context(fallback_canonical_path=None)
+        findings = check_info_description_templates(tmp_path, ctx)
+        assert _codes(findings) == ["check-info-description-canonical-missing"]
 
     def test_appendix_a_drift_fires_when_present(self, tmp_path: Path) -> None:
         """Opt-in template absent = no finding; opt-in template drifted = drift fires."""


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

On the Release Review PR (snapshot branch) `code/common/` is stripped after bundling, so the info.description family (P-026..P-031) has no canonical `info-description-templates.yaml` to validate against. P-031 therefore false-fired once per API, and a release-warning-gating policy can only bite on a trustworthy warning set.

This adds a second canonical-resolution tier instead of skipping the family on stripped branches:

- The engine resolves the canonical local-first; when the local copy is absent it uses an injected fallback path.
- The validation workflow fetches `info-description-templates.yaml` from Commonalities at the pinned `commonalities_release` and injects its path — **only in the release-review context** (`base_ref` starts with `release-snapshot/`). Everywhere else (main, working-branch PRs, local runs) no fallback is injected, so validation stays offline and P-031 fires truthfully when the local file is genuinely missing.
- P-031 is repurposed to fire only when the canonical is unresolvable from **both** the local copy and the source fallback.

Result: P-026..P-030 evaluate on the snapshot against the source-fetched canonical, so the codeowner sees real warnings on the artifact under review, and the P-031 false positive is gone.

#### Which issue(s) this PR fixes:

Fixes #316

#### Special notes for reviewers:

The fetch reads the tag from `release-metadata.yaml` (release-plan.yaml is stripped on the snapshot), mirroring `release_metadata_parser._extract_release_tag`. Fetch failure is tolerated: no path is injected and the engine degrades to a single P-031 `warn`, never a block. The source path is `artifacts/common/...`, not the repo-local `code/common/...`. No new regression fixture is needed — the existing missing-canonical pin keeps `release-plan.yaml`, so it represents the no-fallback path and stays green.

#### Changelog input

```
 release-note
P-031 (info.description canonical missing) no longer false-fires on Release Review PRs; the canonical templates file is fetched from Commonalities source when the bundled copy is absent.
```

#### Additional documentation

This section can be blank.

```
docs

```
