### PR TITLE
feat(release-automation): redesign Release Review PR body and label passing-with-warnings runs

### DIFF
--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -691,16 +691,6 @@ class SnapshotCreator:
         commonalities_release = dependencies.get("commonalities_release", "")
         icm_release = dependencies.get("identity_consent_management_release", "")
 
-        # Determine initial vs stable from calculated API versions
-        # initial: all API versions have major version 0.x
-        # stable: at least one API version has major version >= 1
-        has_stable_api = any(
-            int(m.group(1)) >= 1
-            for v in api_versions.values()
-            if (m := re.match(r"(\d+)\.", v))
-        )
-        is_public = short_type in ("public", "maintenance")
-
         # Construct URLs for template links
         snapshot_branch_url = (
             f"https://github.com/{self.gh.repo}/tree/"
@@ -719,10 +709,6 @@ class SnapshotCreator:
             "release_issue_url": release_issue_url,
             "apis": apis,
             "short_type": short_type,
-            "is_alpha": short_type == "alpha",
-            "is_rc": short_type == "rc",
-            "is_initial_public": is_public and not has_stable_api,
-            "is_stable_public": is_public and has_stable_api,
             "commonalities_release": commonalities_release,
             "identity_consent_management_release": icm_release,
         })

--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -18,10 +18,10 @@ Edit and review this PR before merging it into the release snapshot. After Codeo
 
 _Tick each box once done. Release Management review starts when all three boxes are ticked._
 
-- [ ] **Update the release notes**
+- [ ] **Update the CHANGELOG**
 
       What to do:
-      - Copy all API-consumer-relevant changes into the appropriate Added / Changed / Fixed / Removed sections for each API.
+      - Copy all API-consumer-relevant changes from the provided list into the appropriate Added / Changed / Fixed / Removed sections for each API.
       - Do not copy administrative, tooling-only, or internal maintenance changes unless they affect API consumers.
       - Check which kinds of changes must be listed for *this* release type — the rules are stated at the top of the CHANGELOG file and are easily overlooked.
 
@@ -38,7 +38,7 @@ _Tick each box once done. Release Management review starts when all three boxes 
 - [ ] **The release is ready for Release Management review**
 
       Check that:
-      - All mandatory release assets for the declared status(es) are present (see the release asset table below);
+      - All mandatory release assets for the declared status(es) are present (see the table below "Required release assets per API status" by expanding the arrow);
       - API documentation and test cases are adequate for the target status.
 
       Tick this box to confirm readiness and to start the Release Management review.

--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -16,42 +16,39 @@ Edit and review this PR before merging it into the release snapshot. After Codeo
 
 ### Codeowner Actions
 
-#### 1. Update release notes
+_Tick each box once done. Release Management review starts when all three boxes are ticked._
 
-- [ ] CHANGELOG updated: copy all API-consumer-relevant changes into the appropriate Added / Changed / Fixed / Removed sections for each API as needed.
-      Do not copy administrative, tooling-only, or internal maintenance changes unless they affect API consumers.
+- [ ] **Update the release notes**
 
-#### 2. Confirm API release readiness
+      What to do:
+      - Copy all API-consumer-relevant changes into the appropriate Added / Changed / Fixed / Removed sections for each API.
+      - Do not copy administrative, tooling-only, or internal maintenance changes unless they affect API consumers.
+      - Check which kinds of changes must be listed for *this* release type — the rules are stated at the top of the CHANGELOG file and are easily overlooked.
 
-- [ ] API version(s) used in all files match `release-plan.yaml`
-{{#is_alpha}}
-- [ ] API documentation (`info.description`) is up to date with the API definition
-{{/is_alpha}}
-{{#is_rc}}
-- [ ] API definitions comply with declared Commonalities version
-- [ ] API documentation is complete
-- [ ] Basic test cases are present (sunny day + main error cases)
-{{/is_rc}}
-{{#is_initial_public}}
-- [ ] API definitions comply with declared Commonalities version
-- [ ] API documentation is complete
-- [ ] Basic test cases are present (sunny day + main error cases)
-- [ ] API Description is set for external visibility
-{{/is_initial_public}}
-{{#is_stable_public}}
-- [ ] API definitions comply with declared Commonalities version
-- [ ] API documentation is complete
-- [ ] Basic test cases are present (sunny day + main error cases)
-- [ ] Enhanced test cases cover rainy day scenarios
-- [ ] User stories are current for each API
-- [ ] API Description is up to date for the API(s)
-{{/is_stable_public}}
+- [ ] **Document deferred validation warnings (and hints)**
+
+      What to do:
+      - Check the CAMARA Validation comment on this PR for warnings and hints.
+      - For each warning you do not fix, document it in an issue: include a copy of the validation summary line(s) and the reason the fix is deferred.
+      - Document in the same way any validation hint that is applicable to the API and needs to be fixed later.
+      - You may group several findings into one issue or split them across issues — either is fine.
+      - List the documenting issue(s) in a comment on this PR.
+      - Note: documenting deferred warnings is optional but recommended for alpha pre-releases, and mandatory for rc pre-releases and public releases.
+
+- [ ] **The release is ready for Release Management review**
+
+      Check that:
+      - All mandatory release assets for the declared status(es) are present (see the release asset table below);
+      - API documentation and test cases are adequate for the target status.
+
+      Tick this box to confirm readiness and to start the Release Management review.
 
 ### Release Management Actions
 
 - [ ] CHANGELOG follows the release documentation rules
 - [ ] Breaking changes are documented and version updates follow SemVer rules
 - [ ] Mandatory release assets are present for each API according to its status
+- [ ] All remaining validation warnings are documented in issues and the reasons for deferral are defensible
 
 <details>
 <summary><b>Required release assets per API status</b></summary>
@@ -70,8 +67,6 @@ Edit and review this PR before merging it into the release snapshot. After Codeo
 M = Mandatory, O = Optional — [Full documentation](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/readiness/api-readiness-checklist.md)
 
 </details>
-
-_During the automation introduction phase, please also verify the snapshot content: that `release-metadata.yaml` is correct, that the generated API version numbers and server URLs (and other version fields and references) are right, and that the README update reflects the release tag and version handling._
 
 ### Valid next actions for codeowners
 

--- a/release_automation/tests/test_template_loader.py
+++ b/release_automation/tests/test_template_loader.py
@@ -9,14 +9,13 @@ from release_automation.scripts.template_loader import render_template, Template
 class TestRenderTemplate:
     """Tests for render_template function."""
 
-    def test_render_release_review_pr_rc_template(self):
-        """Test rendering the release review PR template for RC release."""
+    def test_render_release_review_pr_template(self):
+        """Test rendering the (status-independent) release review PR template."""
         context = {
             "release_tag": "r4.1",
             "snapshot_id": "r4.1-abc1234",
             "snapshot_branch_url": "https://github.com/org/repo/tree/release-snapshot/r4.1-abc1234",
             "short_type": "rc",
-            "is_rc": True,
             "apis": [
                 {"api_name": "QualityOnDemand", "api_version": "v1.0.0", "status_label": "rc"},
                 {"api_name": "DeviceLocation", "api_version": "v2.0.0", "status_label": "rc"},
@@ -33,85 +32,50 @@ class TestRenderTemplate:
         assert "| DeviceLocation | `v2.0.0` | rc |" in result
         assert "### Codeowner Actions" in result
         assert "### Release Management Actions" in result
-        assert "During the automation introduction phase" in result
-        assert "#### 1. Update release notes" in result
-        assert "#### 2. Confirm API release readiness" in result
-        assert "CHANGELOG updated: copy all API-consumer-relevant changes" in result
-        assert "declared Commonalities version" in result
+        # Three status-independent codeowner actions
+        assert "**Update the release notes**" in result
+        assert "**Document deferred validation warnings (and hints)**" in result
+        assert "**The release is ready for Release Management review**" in result
+        # API Readiness Checklist link lives once, in the asset-table footer
+        assert "documentation/readiness/api-readiness-checklist.md" in result
         assert "Commonalities r3.4" in result
         assert "Mandatory release assets are present for each API according to its status" in result
-        assert "README update reflects the release tag" in result
+        assert "All remaining validation warnings are documented in issues and the reasons for deferral are defensible" in result
         assert "### Valid next actions for codeowners" in result
         assert "Snapshot: [`r4.1-abc1234`]" in result
         assert "<details>" in result
         assert "Required release assets per API status" in result
+        # Removed in RM#554: status-conditional checklist, version-match box,
+        # and the automation-introduction-phase snapshot-content note
+        assert "Confirm API release readiness" not in result
+        assert "API version(s) used in all files match" not in result
+        assert "During the automation introduction phase" not in result
 
-    def test_render_release_review_pr_alpha_template(self):
-        """Test rendering the release review PR template for alpha release."""
-        context = {
-            "release_tag": "r3.2",
-            "snapshot_id": "r3.2-def5678",
-            "short_type": "alpha",
-            "is_alpha": True,
-            "apis": [
-                {"api_name": "NumberVerification", "api_version": "v0.3.0-alpha.1", "status_label": "alpha"},
-            ],
-        }
+    def test_render_release_review_pr_body_is_status_independent(self):
+        """The Codeowner/RM action blocks are identical regardless of release status."""
+        bodies = []
+        for short_type, status_label, version in [
+            ("alpha", "alpha", "v0.3.0-alpha.1"),
+            ("rc", "rc", "v1.0.0-rc.1"),
+            ("public", "initial public", "v0.5.0"),
+            ("maintenance", "stable public", "v1.0.0"),
+        ]:
+            result = render_template(
+                "release_review_pr",
+                {
+                    "release_tag": "r4.1",
+                    "snapshot_id": "r4.1-abc1234",
+                    "short_type": short_type,
+                    "apis": [
+                        {"api_name": "TestAPI", "api_version": version, "status_label": status_label},
+                    ],
+                },
+            )
+            # The slice between the actions heading and the asset table must not vary by status
+            actions = result[result.index("### Codeowner Actions"):result.index("<details>")]
+            bodies.append(actions)
 
-        result = render_template("release_review_pr", context)
-
-        assert "## Release Review: r3.2 alpha" in result
-        assert "| NumberVerification | `v0.3.0-alpha.1` | alpha |" in result
-        assert "API version(s) used in all files match" in result
-        assert "API documentation (`info.description`) is up to date with the API definition" in result
-        assert "CHANGELOG updated: copy all API-consumer-relevant changes" in result
-        # Alpha should NOT have rc/public-specific items
-        assert "Enhanced test cases" not in result
-
-    def test_render_release_review_pr_initial_public_template(self):
-        """Test rendering the release review PR template for initial public release."""
-        context = {
-            "release_tag": "r5.0",
-            "snapshot_id": "r5.0-xyz9999",
-            "short_type": "public",
-            "is_initial_public": True,
-            "apis": [
-                {"api_name": "TestAPI", "api_version": "v0.5.0", "status_label": "initial public"},
-            ],
-            "commonalities_release": "r4.0",
-        }
-
-        result = render_template("release_review_pr", context)
-
-        assert "## Release Review: r5.0 public" in result
-        assert "| TestAPI | `v0.5.0` | initial public |" in result
-        assert "API Description is set" in result
-        assert "Mandatory release assets are present for each API according to its status" in result
-        # Initial public should NOT have stable-public-only items
-        assert "Enhanced test cases" not in result
-        assert "User stories" not in result
-
-    def test_render_release_review_pr_stable_public_template(self):
-        """Test rendering the release review PR template for stable public release."""
-        context = {
-            "release_tag": "r6.1",
-            "snapshot_id": "r6.1-aaa1111",
-            "short_type": "maintenance",
-            "is_stable_public": True,
-            "apis": [
-                {"api_name": "TestAPI", "api_version": "v1.0.0", "status_label": "stable public"},
-            ],
-            "commonalities_release": "r5.0",
-        }
-
-        result = render_template("release_review_pr", context)
-
-        assert "## Release Review: r6.1 maintenance" in result
-        assert "| TestAPI | `v1.0.0` | stable public |" in result
-        assert "Enhanced test cases cover rainy day scenarios" in result
-        assert "User stories are current" in result
-        assert "API Description is up to date" in result
-        assert "Mandatory release assets are present for each API according to its status" in result
+        assert len(set(bodies)) == 1, "Codeowner/RM action blocks differ across release statuses"
 
     def test_render_release_review_pr_no_apis(self):
         """Test rendering with no APIs (edge case)."""

--- a/validation/output/formatting.py
+++ b/validation/output/formatting.py
@@ -72,6 +72,36 @@ def count_findings(findings: List[dict]) -> FindingCounts:
     )
 
 
+# ---------------------------------------------------------------------------
+# Result label
+# ---------------------------------------------------------------------------
+
+_RESULT_LABEL = {
+    "pass": "PASS",
+    "fail": "FAIL",
+    "error": "ERROR",
+    "advisory": "ADVISORY",
+}
+
+
+def resolve_result_label(result: str, profile: str, counts: FindingCounts) -> str:
+    """Map a post-filter result string to its display label.
+
+    Two refinements on a passing run:
+      * Advisory profile never blocks, so the post-filter always returns
+        ``"pass"``; show **ADVISORY** when any findings exist, since **PASS**
+        would hide them.
+      * Under a blocking profile, a pass with warnings present is genuine but
+        incomplete; show **PASS (with warnings)** so the warnings stay visible.
+        Hints alone never change the label.
+    """
+    if result == "pass" and profile == "advisory" and counts.total:
+        return _RESULT_LABEL["advisory"]
+    if result == "pass" and counts.warnings > 0:
+        return f"{_RESULT_LABEL['pass']} (with warnings)"
+    return _RESULT_LABEL.get(result, result.upper())
+
+
 def count_findings_by_api(
     findings: List[dict],
 ) -> Dict[str, FindingCounts]:

--- a/validation/output/pr_comment.py
+++ b/validation/output/pr_comment.py
@@ -15,7 +15,7 @@ import logging
 from validation.context import ValidationContext
 from validation.postfilter.engine import PostFilterResult
 
-from .formatting import count_findings
+from .formatting import count_findings, resolve_result_label
 
 logger = logging.getLogger(__name__)
 
@@ -24,13 +24,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 MARKER = "<!-- camara-validation -->"
-
-_RESULT_LABEL = {
-    "pass": "PASS",
-    "fail": "FAIL",
-    "error": "ERROR",
-    "advisory": "ADVISORY",
-}
 
 
 # ---------------------------------------------------------------------------
@@ -56,12 +49,8 @@ def generate_pr_comment(
     """
     result = post_filter_result.result
     findings = post_filter_result.findings
-    # Advisory profile: show ADVISORY instead of PASS when findings exist
-    if result == "pass" and context.profile == "advisory" and findings:
-        result_label = _RESULT_LABEL["advisory"]
-    else:
-        result_label = _RESULT_LABEL.get(result, result.upper())
     counts = count_findings(findings)
+    result_label = resolve_result_label(result, context.profile, counts)
 
     lines = [
         MARKER,
@@ -77,5 +66,21 @@ def generate_pr_comment(
         lines.append(f"[View full results]({context.workflow_run_url})")
     else:
         lines.append("See workflow summary for full results.")
+
+    # On the release-review PR, point the codeowner to the deferral workflow
+    # when warnings remain (MUST from rc onward, SHOULD at alpha).
+    if context.is_release_review_pr and counts.warnings > 0:
+        modal = (
+            "SHOULD"
+            if context.target_release_type == "pre-release-alpha"
+            else "MUST"
+        )
+        lines.extend([
+            "",
+            (
+                f"> Warnings {modal} be documented in one or more issues before "
+                "this release — see the Codeowner Actions in the PR description."
+            ),
+        ])
 
     return "\n".join(lines)

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -46,8 +46,9 @@ _DIAGNOSTICS_ARTIFACT = "validation-diagnostics"
 _WARNINGS_NOTE = (
     "> Warnings that will not be fixed immediately should be documented in one or "
     "more issues (with the validation summary line(s) and a reason for deferral). "
-    "Documenting warnings is required for rc pre-releases, and lets PR authors check "
-    "whether a warning is already known rather than newly introduced by their change."
+    "Documenting warnings is required for releases. "
+    "The documentation is also helpful for PR authors: they can check whether a "
+    "warning is already known or potentially introduced by their own change."
 )
 
 # ---------------------------------------------------------------------------

--- a/validation/output/workflow_summary.py
+++ b/validation/output/workflow_summary.py
@@ -28,6 +28,7 @@ from .formatting import (
     format_finding_location,
     format_rule_label,
     resolve_annotation_title,
+    resolve_result_label,
     sort_findings_by_priority,
 )
 
@@ -39,14 +40,15 @@ logger = logging.getLogger(__name__)
 
 SUMMARY_SIZE_LIMIT = 900 * 1024  # 900 KB (GitHub limit is 1 MB)
 
-_RESULT_LABEL = {
-    "pass": "PASS",
-    "fail": "FAIL",
-    "error": "ERROR",
-    "advisory": "ADVISORY",
-}
-
 _DIAGNOSTICS_ARTIFACT = "validation-diagnostics"
+
+# Recommendation shown after the header whenever warnings are present.
+_WARNINGS_NOTE = (
+    "> Warnings that will not be fixed immediately should be documented in one or "
+    "more issues (with the validation summary line(s) and a reason for deferral). "
+    "Documenting warnings is required for rc pre-releases, and lets PR authors check "
+    "whether a warning is already known rather than newly introduced by their change."
+)
 
 # ---------------------------------------------------------------------------
 # Result type
@@ -74,39 +76,23 @@ class SummaryResult:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_result_label(
-    result: str,
-    context: ValidationContext,
-    findings: List[dict],
-) -> str:
-    """Map result string to display label, with advisory override.
-
-    Advisory profile never blocks, so the post-filter always returns
-    ``"pass"``.  Showing **PASS** when there are errors is misleading;
-    **ADVISORY** signals that findings exist but nothing was blocked.
-    """
-    if (
-        result == "pass"
-        and context.profile == "advisory"
-        and findings
-    ):
-        return _RESULT_LABEL["advisory"]
-    return _RESULT_LABEL.get(result, result.upper())
-
-
 def _render_header(
     result: str,
     context: ValidationContext,
     findings: List[dict],
 ) -> str:
     """Render the summary header with result and metadata."""
-    label = _resolve_result_label(result, context, findings)
-    return (
+    counts = count_findings(findings)
+    label = resolve_result_label(result, context.profile, counts)
+    header = (
         f"## CAMARA Validation — {label}\n\n"
         f"**Profile**: {context.profile} | "
         f"**Branch**: {context.branch_type} | "
         f"**Trigger**: {context.trigger_type}\n"
     )
+    if counts.warnings > 0:
+        header += f"\n{_WARNINGS_NOTE}\n"
+    return header
 
 
 def _render_engine_summary_table(

--- a/validation/tests/test_output_pr_comment.py
+++ b/validation/tests/test_output_pr_comment.py
@@ -15,6 +15,8 @@ from validation.postfilter.engine import PostFilterResult
 def _make_context(
     profile: str = "standard",
     workflow_run_url: str = "https://github.com/test/run/1",
+    is_release_review_pr: bool = False,
+    target_release_type: str | None = None,
 ) -> ValidationContext:
     return ValidationContext(
         repository="TestRepo",
@@ -22,12 +24,12 @@ def _make_context(
         trigger_type="pr",
         profile=profile,
         stage="enabled",
-        target_release_type=None,
+        target_release_type=target_release_type,
         commonalities_release=None,
         commonalities_version=None,
         icm_release=None,
         base_ref=None,
-        is_release_review_pr=False,
+        is_release_review_pr=is_release_review_pr,
         release_plan_changed=None,
         pr_number=None,
         apis=(),
@@ -121,3 +123,43 @@ class TestGeneratePrComment:
     def test_empty_findings(self):
         comment = generate_pr_comment(_make_result([]), _make_context())
         assert "0 errors, 0 warnings, 0 hints" in comment
+
+    def test_pass_with_warnings_label(self):
+        comment = generate_pr_comment(
+            _make_result([_make_finding(level="warn")]), _make_context()
+        )
+        assert "CAMARA Validation — PASS (with warnings)" in comment
+
+    def test_hints_only_keeps_plain_pass(self):
+        comment = generate_pr_comment(
+            _make_result([_make_finding(level="hint")]), _make_context()
+        )
+        assert "CAMARA Validation — PASS" in comment
+        assert "(with warnings)" not in comment
+
+    def test_review_pr_warning_note_must_for_rc(self):
+        ctx = _make_context(
+            is_release_review_pr=True, target_release_type="pre-release-rc"
+        )
+        comment = generate_pr_comment(_make_result([_make_finding(level="warn")]), ctx)
+        assert "Warnings MUST be documented in one or more issues" in comment
+
+    def test_review_pr_warning_note_should_for_alpha(self):
+        ctx = _make_context(
+            is_release_review_pr=True, target_release_type="pre-release-alpha"
+        )
+        comment = generate_pr_comment(_make_result([_make_finding(level="warn")]), ctx)
+        assert "Warnings SHOULD be documented in one or more issues" in comment
+
+    def test_no_review_note_on_normal_pr(self):
+        comment = generate_pr_comment(
+            _make_result([_make_finding(level="warn")]), _make_context()
+        )
+        assert "be documented in one or more issues before" not in comment
+
+    def test_no_review_note_when_no_warnings(self):
+        ctx = _make_context(
+            is_release_review_pr=True, target_release_type="pre-release-rc"
+        )
+        comment = generate_pr_comment(_make_result([_make_finding(level="hint")]), ctx)
+        assert "be documented in one or more issues before" not in comment

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -119,6 +119,27 @@ class TestHeader:
         assert "release" in sr.markdown
         assert "dispatch" in sr.markdown
 
+    def test_pass_with_warnings_label(self):
+        findings = [_make_finding(level="warn")]
+        sr = generate_workflow_summary(_make_result(findings, result="pass"), _make_context())
+        assert "## CAMARA Validation — PASS (with warnings)" in sr.markdown
+
+    def test_hints_only_keeps_plain_pass(self):
+        findings = [_make_finding(level="hint")]
+        sr = generate_workflow_summary(_make_result(findings, result="pass"), _make_context())
+        assert "## CAMARA Validation — PASS\n" in sr.markdown
+        assert "(with warnings)" not in sr.markdown
+
+    def test_warnings_note_present_when_warnings(self):
+        findings = [_make_finding(level="warn")]
+        sr = generate_workflow_summary(_make_result(findings, result="pass"), _make_context())
+        assert "should be documented in one or more issues" in sr.markdown
+        assert "required for rc pre-releases" in sr.markdown
+
+    def test_warnings_note_absent_when_no_warnings(self):
+        sr = generate_workflow_summary(_make_result(), _make_context())
+        assert "should be documented in one or more issues" not in sr.markdown
+
 
 # ---------------------------------------------------------------------------
 # Engine summary table

--- a/validation/tests/test_output_workflow_summary.py
+++ b/validation/tests/test_output_workflow_summary.py
@@ -134,7 +134,7 @@ class TestHeader:
         findings = [_make_finding(level="warn")]
         sr = generate_workflow_summary(_make_result(findings, result="pass"), _make_context())
         assert "should be documented in one or more issues" in sr.markdown
-        assert "required for rc pre-releases" in sr.markdown
+        assert "required for releases" in sr.markdown
 
     def test_warnings_note_absent_when_no_warnings(self):
         sr = generate_workflow_summary(_make_result(), _make_context())


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Implements the Release Review changes discussed in camaraproject/ReleaseManagement#554, in two parts:

- **Release Review PR body** (`release_review_pr.mustache`): replaces the four per-status conditional checklists with one status-independent set of three Codeowner Actions (update release notes; document deferred validation warnings and hints; declare ready for Release Management review). Adds a Release Management Action for accepting documented warning deferrals, and drops the retired automation-introduction-phase note and the version-match box.
- **Validation result communication**: a passing run that still has warnings is now labelled `PASS (with warnings)` in both the workflow summary and the PR comment (hints alone do not change the label). The workflow summary gains a note recommending that deferred warnings be documented in issues; the release-review PR comment gains a short MUST/SHOULD reminder. The label logic is factored into one shared helper in `output/formatting.py`.

Out of scope (tracked separately): guidance on how to document breaking changes within the release notes.

#### Which issue(s) this PR fixes:

Implements camaraproject/ReleaseManagement#554 (cross-repo — close manually after merge).

#### Special notes for reviewers:

The Codeowner Actions block is now fully status-independent — a regression test asserts the rendered block is byte-identical across alpha/rc/initial-public/stable-public. The `PASS (with warnings)` relabel applies to every PR (not only release-review PRs); the deferral reminder note in the PR comment is gated on `is_release_review_pr`.

#### Changelog input

```
 release-note
Redesigned the Release Review PR body (status-independent Codeowner Actions, validation findings handling) and labelled passing-with-warnings validation runs as "PASS (with warnings)".
```

#### Additional documentation

This section can be blank.

```
docs

```
