### PR TITLE
feat(validation): flag leftover API readiness checklists

### DIFF
--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -10,7 +10,10 @@ from .error_code_checks import check_conflict_deprecated, check_contextcode_form
 from .filename_checks import check_filename_kebab_case, check_filename_matches_api_name
 from .info_description_checks import check_info_description_templates
 from .metadata_checks import check_commonalities_version
-from .readme_checks import check_readme_placeholder_removal
+from .readme_checks import (
+    check_api_readiness_checklist_removal,
+    check_readme_placeholder_removal,
+)
 from .common_cache_checks import check_common_cache_sync
 from .release_plan_checks import (
     check_declared_dependency_tags_exist,
@@ -65,6 +68,7 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-test-directory-exists", CheckScope.REPO, check_test_directory_exists),
     CheckDescriptor("check-release-plan-semantics", CheckScope.REPO, check_release_plan_semantics),
     CheckDescriptor("check-readme-placeholder-removal", CheckScope.REPO, check_readme_placeholder_removal),
+    CheckDescriptor("check-api-readiness-checklist-removal", CheckScope.REPO, check_api_readiness_checklist_removal),
     CheckDescriptor("check-release-review-file-restriction", CheckScope.REPO, check_release_review_file_restriction),
     CheckDescriptor("check-orphan-api-definitions", CheckScope.REPO, check_orphan_api_definitions),
     CheckDescriptor("check-common-cache-sync", CheckScope.REPO, check_common_cache_sync),

--- a/validation/engines/python_checks/readme_checks.py
+++ b/validation/engines/python_checks/readme_checks.py
@@ -1,11 +1,13 @@
-"""README placeholder checks.
+"""README and readiness checklist removal checks.
 
 Detects template placeholder README files that should be removed once
-real API specification files have been added.
+real API specification files have been added, and legacy API readiness
+checklist files that should no longer remain in API repositories.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import List
 
@@ -19,6 +21,14 @@ _API_DEFS_DIR = "code/API_definitions"
 #   "Here you can add your definition file(s). Delete this README.MD ..."
 #   "Here you can add your definitions and delete this README.MD file"
 _PLACEHOLDER_PHRASE = "delete this readme"
+_SKIP_DIRS = {
+    ".git",
+    ".github",
+    ".pytest_cache",
+    ".ruff_cache",
+    "node_modules",
+    "__pycache__",
+}
 
 
 def check_readme_placeholder_removal(
@@ -73,3 +83,49 @@ def check_readme_placeholder_removal(
             line=1,
         )
     ]
+
+
+def _is_readiness_checklist_filename(filename: str) -> bool:
+    name = filename.lower()
+    return (
+        name.endswith((".md", ".markdown"))
+        and "readiness" in name
+        and "checklist" in name
+    )
+
+
+def check_api_readiness_checklist_removal(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Check that legacy API readiness checklist files are removed.
+
+    Repo-level check.  CAMARA API repositories historically used several
+    filename variants, for example ``*-API-Readiness-Checklist.md``,
+    ``API-Readiness-Checklist.md``, and underscore-separated variants.
+    The stable signal is a Markdown filename containing both
+    ``readiness`` and ``checklist``.
+    """
+    findings: list[dict] = []
+
+    for root, dirnames, filenames in os.walk(repo_path):
+        dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
+        root_path = Path(root)
+        for filename in sorted(filenames):
+            if not _is_readiness_checklist_filename(filename):
+                continue
+            rel_path = (root_path / filename).relative_to(repo_path).as_posix()
+            findings.append(
+                make_finding(
+                    engine_rule="check-api-readiness-checklist-removal",
+                    level="warn",
+                    message=(
+                        f"API readiness checklist file '{rel_path}' should be "
+                        "removed from the API repository; use the canonical "
+                        "ReleaseManagement readiness documentation instead"
+                    ),
+                    path=rel_path,
+                    line=1,
+                )
+            )
+
+    return findings

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -172,8 +172,8 @@
           target_release_type: [none, pre-release-alpha, pre-release-rc]
         level: warn
   suggestion: >-
-    Delete the repo-local API readiness checklist file and use the canonical
-    ReleaseManagement readiness documentation instead.
+    Delete the obsolete API readiness checklist file(s). It is replaced by the
+    new Release process and API Readiness documentation.
 
 # P-014: check-subscription-filename (DG-088)
 # Explicit subscription API names must end with '-subscriptions'.

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -156,6 +156,25 @@
   conditional_level:
     default: warn
 
+# P-032: check-api-readiness-checklist-removal
+# API readiness checklist files moved to canonical ReleaseManagement
+# documentation; repo-local checklist files should be deleted from API repos.
+- id: P-032
+  engine: python
+  engine_rule: check-api-readiness-checklist-removal
+  short_title: "Remove API readiness checklist file from API repo"
+  applicability:
+    commonalities_release: ">=r4.3"
+  conditional_level:
+    default: error
+    overrides:
+      - condition:
+          target_release_type: [none, pre-release-alpha, pre-release-rc]
+        level: warn
+  suggestion: >-
+    Delete the repo-local API readiness checklist file and use the canonical
+    ReleaseManagement readiness documentation instead.
+
 # P-014: check-subscription-filename (DG-088)
 # Explicit subscription API names must end with '-subscriptions'.
 - id: P-014

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -14,7 +14,7 @@ version: 1
 generated: 2026-04-07
 
 summary:
-  total_implemented: 144
+  total_implemented: 145
   total_gap: 0
   total_manual: 25
   total_pending: 0
@@ -22,7 +22,7 @@ summary:
   by_engine:
     spectral: 85
     gherkin: 25
-    python: 21
+    python: 22
     yamllint: 13
 
 # ---------------------------------------------------------------------------
@@ -210,6 +210,12 @@ gap_rules:
     target_engine: python
     status: implemented
     rule_id: P-021
+
+  - audit_id: NEW-005
+    description: "API readiness checklist files must be removed from API repositories"
+    target_engine: python
+    status: implemented
+    rule_id: P-032
 
 # ---------------------------------------------------------------------------
 # Fixes needed — implemented rules with incorrect behavior

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 91
+  total_tested: 92
   by_engine:
     spectral: 85
     gherkin: 25
@@ -329,6 +329,7 @@ tested_rules:
   P-029: [regression/r4.3-broken-spec-info-description-mandatory]
   P-030: [regression/r4.3-broken-spec-info-description-mandatory]
   P-031: [regression/r4.3-broken-spec-info-description-missing-canonical]
+  P-032: [regression/r4.3-broken-spec-test-files]
   S-002: [regression/r4.3-broken-spec-routing]
   S-003: [regression/r4.3-broken-spec-routing]
   S-005: [regression/r4.3-broken-spec-yaml-fundamentals]

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -450,6 +450,63 @@ class TestRunPostFilter:
         assert result_release.findings[0]["level"] == "error"
         assert result_release.findings[0]["blocks"] is True
 
+    def test_repo_level_release_type_override_and_commonalities_gate(
+        self, tmp_path: Path
+    ):
+        """Repo-level findings use target_release_type, not per-API status."""
+        _write_rules(tmp_path, [
+            _minimal_rule(
+                id="P-032",
+                engine="python",
+                engine_rule="check-api-readiness-checklist-removal",
+                default_level="error",
+                applicability={"commonalities_release": ">=r4.3"},
+                overrides=[
+                    {
+                        "condition": {
+                            "target_release_type": [
+                                "none",
+                                "pre-release-alpha",
+                                "pre-release-rc",
+                            ],
+                        },
+                        "level": "warn",
+                    }
+                ],
+            )
+        ], filename="python-rules.yaml")
+        finding = _make_finding(
+            engine="python",
+            engine_rule="check-api-readiness-checklist-removal",
+            api_name=None,
+        )
+
+        draft_ctx = _make_context(
+            commonalities_release="r4.3",
+            target_release_type="none",
+            profile="standard",
+        )
+        draft_result = run_post_filter([finding], draft_ctx, tmp_path)
+        assert draft_result.findings[0]["level"] == "warn"
+        assert draft_result.findings[0]["blocks"] is False
+
+        public_ctx = _make_context(
+            commonalities_release="r4.3",
+            target_release_type="public-release",
+            profile="standard",
+        )
+        public_result = run_post_filter([finding], public_ctx, tmp_path)
+        assert public_result.findings[0]["level"] == "error"
+        assert public_result.findings[0]["blocks"] is True
+
+        old_commonalities_ctx = _make_context(
+            commonalities_release="r4.2",
+            target_release_type="public-release",
+            profile="standard",
+        )
+        old_result = run_post_filter([finding], old_commonalities_ctx, tmp_path)
+        assert old_result.findings == []
+
     def test_engine_error_finding(self, tmp_path: Path):
         """Engine execution errors pass through and set result to 'error'."""
         ctx = _make_context()

--- a/validation/tests/test_python_checks_readme.py
+++ b/validation/tests/test_python_checks_readme.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from validation.context import ValidationContext
 from validation.engines.python_checks.readme_checks import (
+    check_api_readiness_checklist_removal,
     check_readme_placeholder_removal,
 )
 
@@ -116,3 +117,74 @@ class TestCheckReadmePlaceholderRemoval:
     def test_no_api_defs_directory(self, tmp_path: Path):
         """No API_definitions directory → no finding."""
         assert check_readme_placeholder_removal(tmp_path, _make_context()) == []
+
+
+class TestCheckApiReadinessChecklistRemoval:
+    def test_detects_hyphenated_api_readiness_checklist(self, tmp_path: Path):
+        """Legacy per-API readiness checklist filenames are detected."""
+        doc_dir = tmp_path / "documentation" / "API_documentation"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "quality-on-demand-API-Readiness-Checklist.md").touch()
+
+        findings = check_api_readiness_checklist_removal(tmp_path, _make_context())
+
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert findings[0]["engine_rule"] == "check-api-readiness-checklist-removal"
+        assert findings[0]["path"] == (
+            "documentation/API_documentation/"
+            "quality-on-demand-API-Readiness-Checklist.md"
+        )
+        assert findings[0]["api_name"] is None
+
+    def test_detects_root_supporting_document_variant(self, tmp_path: Path):
+        """Generic API-Readiness-Checklist.md variants are detected."""
+        doc_dir = tmp_path / "documentation" / "SupportingDocuments"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "API-Readiness-Checklist.md").touch()
+
+        findings = check_api_readiness_checklist_removal(tmp_path, _make_context())
+
+        assert len(findings) == 1
+        assert findings[0]["path"] == (
+            "documentation/SupportingDocuments/API-Readiness-Checklist.md"
+        )
+
+    def test_detects_underscore_variant_case_insensitively(self, tmp_path: Path):
+        """Underscore-separated and mixed-case filenames are detected."""
+        doc_dir = tmp_path / "documentation" / "API_documentation"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "simple-edge-discovery_API_Readiness_Checklist.md").touch()
+
+        findings = check_api_readiness_checklist_removal(tmp_path, _make_context())
+
+        assert len(findings) == 1
+        assert findings[0]["path"].endswith(
+            "simple-edge-discovery_API_Readiness_Checklist.md"
+        )
+
+    def test_ignores_readiness_mentions_without_checklist_filename(
+        self, tmp_path: Path
+    ):
+        """Only filenames containing both readiness and checklist are flagged."""
+        doc_dir = tmp_path / "documentation" / "API_documentation"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "readiness-notes.md").touch()
+        (doc_dir / "release-checklist.md").touch()
+        (doc_dir / "api-readiness-checklist.txt").touch()
+
+        assert check_api_readiness_checklist_removal(tmp_path, _make_context()) == []
+
+    def test_multiple_files_produce_multiple_findings(self, tmp_path: Path):
+        """Multi-API repos get one finding per leftover checklist file."""
+        doc_dir = tmp_path / "documentation" / "API_documentation"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "one-API-Readiness-Checklist.md").touch()
+        (doc_dir / "two-API-Readiness-Checklist.md").touch()
+
+        findings = check_api_readiness_checklist_removal(tmp_path, _make_context())
+
+        assert [finding["path"] for finding in findings] == [
+            "documentation/API_documentation/one-API-Readiness-Checklist.md",
+            "documentation/API_documentation/two-API-Readiness-Checklist.md",
+        ]

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -87,7 +87,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 30
+        assert counts["python"] == 31
         assert counts["spectral"] == 85
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -317,8 +317,8 @@ class TestMetadataQuality:
         """
         with_suggestions = [r.id for r in all_rules if r.suggestion is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_suggestions) == 21, (
-            f"Expected 21 explicit suggestions (update test if adding "
+        assert len(with_suggestions) == 22, (
+            f"Expected 22 explicit suggestions (update test if adding "
             f"suggestions): {with_suggestions}"
         )
         assert len(with_overrides) == 0, (
@@ -362,6 +362,26 @@ class TestMetadataQuality:
         assert overrides[0].level == "warn"
         assert rule.suggestion is not None
         assert "Commonalities#608" in rule.suggestion
+
+    def test_p032_readiness_checklist_removal_levels(self, rule_index):
+        """P-032 warns for non-public release types and errors by default."""
+        rule = rule_index[("python", "check-api-readiness-checklist-removal")]
+        assert rule.id == "P-032"
+        assert rule.applicability == {"commonalities_release": ">=r4.3"}
+        assert rule.conditional_level is not None
+        assert rule.conditional_level.default == "error"
+        overrides = rule.conditional_level.overrides
+        assert len(overrides) == 1
+        assert overrides[0].condition == {
+            "target_release_type": [
+                "none",
+                "pre-release-alpha",
+                "pre-release-rc",
+            ],
+        }
+        assert overrides[0].level == "warn"
+        assert rule.suggestion is not None
+        assert "ReleaseManagement" in rule.suggestion
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -381,7 +381,7 @@ class TestMetadataQuality:
         }
         assert overrides[0].level == "warn"
         assert rule.suggestion is not None
-        assert "ReleaseManagement" in rule.suggestion
+        assert "Release process and API Readiness documentation" in rule.suggestion
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature


#### What this PR does / why we need it:

Adds Python validation rule P-032 to report repo-local API readiness checklist files that should be removed from API repositories.

The rule detects Markdown filenames containing both `readiness` and `checklist`, which covers the known legacy checklist filename variants in API repositories. It applies from Commonalities `r4.3`, warns for draft/alpha/rc release types, and errors by default/public release type.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes https://github.com/camaraproject/ReleaseManagement/issues/572

#### Special notes for reviewers:

The severity uses repository-level `target_release_type` because the finding is repo-level; per-API status conditions are intentionally not used for this rule.

Validation:

`/Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pytest validation/tests`


#### Changelog input

```
 release-note
Add validation signal for legacy API readiness checklist files that should be removed from API repositories.
```

#### Additional documentation 

This section can be blank.



```
docs
```
