### PR TITLE
fix(release-review): render codeowner action details as lists, not code blocks

### DIFF
--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -20,28 +20,28 @@ _Tick each box once done. Release Management review starts when all three boxes 
 
 - [ ] **Update the CHANGELOG**
 
-      What to do:
-      - Copy all API-consumer-relevant changes from the provided list into the appropriate Added / Changed / Fixed / Removed sections for each API.
-      - Do not copy administrative, tooling-only, or internal maintenance changes unless they affect API consumers.
-      - Check which kinds of changes must be listed for *this* release type — the rules are stated at the top of the CHANGELOG file and are easily overlooked.
+  What to do:
+  - Copy all API-consumer-relevant changes from the provided list into the appropriate Added / Changed / Fixed / Removed sections for each API.
+  - Do not copy administrative, tooling-only, or internal maintenance changes unless they affect API consumers.
+  - Check which kinds of changes must be listed for *this* release type — the rules are stated at the top of the CHANGELOG file and are easily overlooked.
 
 - [ ] **Document deferred validation warnings (and hints)**
 
-      What to do:
-      - Check the CAMARA Validation comment on this PR for warnings and hints.
-      - For each warning you do not fix, document it in an issue: include a copy of the validation summary line(s) and the reason the fix is deferred.
-      - Document in the same way any validation hint that is applicable to the API and needs to be fixed later.
-      - You may group several findings into one issue or split them across issues — either is fine.
-      - List the documenting issue(s) in a comment on this PR.
-      - Note: documenting deferred warnings is optional but recommended for alpha pre-releases, and mandatory for rc pre-releases and public releases.
+  What to do:
+  - Check the CAMARA Validation comment on this PR for warnings and hints.
+  - For each warning you do not fix, document it in an issue: include a copy of the validation summary line(s) and the reason the fix is deferred.
+  - Document in the same way any validation hint that is applicable to the API and needs to be fixed later.
+  - You may group several findings into one issue or split them across issues — either is fine.
+  - List the documenting issue(s) in a comment on this PR.
+  - Note: documenting deferred warnings is optional but recommended for alpha pre-releases, and mandatory for rc pre-releases and public releases.
 
 - [ ] **The release is ready for Release Management review**
 
-      Check that:
-      - All mandatory release assets for the declared status(es) are present (see the table below "Required release assets per API status" by expanding the arrow);
-      - API documentation and test cases are adequate for the target status.
+  Check that:
+  - All mandatory release assets for the declared status(es) are present (see the table below "Required release assets per API status" by expanding the arrow);
+  - API documentation and test cases are adequate for the target status.
 
-      Tick this box to confirm readiness and to start the Release Management review.
+  Tick this box to confirm readiness and to start the Release Management review.
 
 ### Release Management Actions
 

--- a/release_automation/tests/test_template_loader.py
+++ b/release_automation/tests/test_template_loader.py
@@ -33,7 +33,7 @@ class TestRenderTemplate:
         assert "### Codeowner Actions" in result
         assert "### Release Management Actions" in result
         # Three status-independent codeowner actions
-        assert "**Update the release notes**" in result
+        assert "**Update the CHANGELOG**" in result
         assert "**Document deferred validation warnings (and hints)**" in result
         assert "**The release is ready for Release Management review**" in result
         # API Readiness Checklist link lives once, in the asset-table footer


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Part of camaraproject/ReleaseManagement#554 (follow-up to #318, which
implemented it). In the generated Release Review PR body, the "What to do"
detail under each Codeowner Action checkbox rendered as a grey monospace box
with a horizontal scrollbar instead of readable text.

The detail lines were indented 6 spaces under a `- ` list item. Since a list
item's content starts at column 2, a further 4+ spaces crosses Markdown's
indented-code-block threshold, so each block was rendered as a code block.

This reduces the indentation to 2 spaces, so each block renders as a normal
paragraph followed by a nested bullet list — readable and wrapping, with no
horizontal scroll.

#### Which issue(s) this PR fixes:

Part of camaraproject/ReleaseManagement#554

#### Special notes for reviewers:

- Content is unchanged; only the leading indentation of the three action detail
  blocks changed (6 → 2 spaces).
- Also aligns one `test_template_loader` assertion with the merged
  "Update the CHANGELOG" heading (the assertion still referenced the earlier
  "Update the release notes" wording from before the in-review rename).
- Full test suite green (1766 passed).

#### Changelog input

```
 release-note
Fix Release Review PR body so the Codeowner Action details render as lists instead of code blocks.
```

#### Additional documentation

This section can be blank.

```
docs

```
