### PR TITLE
fix(release-automation): close stale release issues after tag changes

### DIFF
--- a/release_automation/scripts/github_client.py
+++ b/release_automation/scripts/github_client.py
@@ -796,6 +796,24 @@ class GitHubClient:
                 # Label might not exist, continue
                 pass
 
+    def add_issue_comment(self, issue_number: int, body: str) -> None:
+        """
+        Add a comment to an issue.
+
+        Args:
+            issue_number: The issue number
+            body: Comment body
+
+        Raises:
+            GitHubClientError: If operation fails
+        """
+        self._run_gh([
+            "api",
+            f"repos/{self.repo}/issues/{issue_number}/comments",
+            "-X", "POST",
+            "-f", f"body={body}",
+        ])
+
     def set_labels(self, issue_number: int, labels: List[str]) -> None:
         """
         Replace all labels on an issue with the specified labels.

--- a/release_automation/scripts/issue_sync.py
+++ b/release_automation/scripts/issue_sync.py
@@ -7,6 +7,7 @@ artifacts.
 """
 
 from dataclasses import dataclass
+import re
 from typing import Any, Dict, List, Optional
 
 from .github_client import GitHubClient
@@ -17,6 +18,9 @@ from .bot_responder import BotResponder
 
 # Marker to identify workflow-owned issues
 WORKFLOW_MARKER = "<!-- release-automation:workflow-owned -->"
+RELEASE_TAG_MARKER_RE = re.compile(
+    r"<!--\s*release-automation:release-tag:(?P<tag>.*?)\s*-->"
+)
 
 # Required labels for release automation
 # Format: (name, color_hex_without_hash, description)
@@ -198,6 +202,7 @@ class IssueSyncManager:
                     )
                     return self.gh.get_issue(new_issue["number"])
                 updated_issue = self.gh.retry_on_not_found(_post_create)
+                self.cleanup_stale_workflow_owned_issues(release_tag, updated_issue)
                 return SyncResult(action="created", issue=updated_issue)
             else:
                 return SyncResult(action="none", reason="no_planned_release")
@@ -217,8 +222,10 @@ class IssueSyncManager:
             )
             # Refetch issue after update
             updated_issue = self.gh.get_issue(issue["number"])
+            self.cleanup_stale_workflow_owned_issues(release_tag, updated_issue)
             return SyncResult(action="updated", issue=updated_issue)
 
+        self.cleanup_stale_workflow_owned_issues(release_tag, issue)
         return SyncResult(action="none", reason="up_to_date")
 
     def find_workflow_owned_issue(self, release_tag: str) -> Optional[Dict[str, Any]]:
@@ -254,6 +261,77 @@ class IssueSyncManager:
                 return issue
 
         return None
+
+    def cleanup_stale_workflow_owned_issues(
+        self,
+        release_tag: str,
+        current_issue: Dict[str, Any],
+    ) -> None:
+        """
+        Close older workflow-owned Release Issues for superseded release tags.
+
+        Current automation has one active Release Issue per repository. When
+        the target release tag changes, the old issue keeps its workflow and
+        release-tag markers but no longer matches the current tag lookup.
+        """
+        current_issue_number = current_issue["number"]
+        current_issue_url = current_issue.get("html_url", "")
+        issues = self.gh.search_issues(
+            labels=[self.RELEASE_ISSUE_LABEL],
+            state="open"
+        )
+
+        for issue in issues:
+            issue_number = issue.get("number")
+            if issue_number == current_issue_number:
+                continue
+
+            body = issue.get("body", "") or ""
+            if WORKFLOW_MARKER not in body:
+                continue
+
+            match = RELEASE_TAG_MARKER_RE.search(body)
+            if not match or match.group("tag") == release_tag:
+                continue
+
+            current_labels = [
+                label.get("name", "") if isinstance(label, dict) else label
+                for label in issue.get("labels", [])
+            ]
+            state_labels = [
+                label for label in current_labels
+                if isinstance(label, str) and label.startswith(self.STATE_LABEL_PREFIX)
+            ]
+            if state_labels:
+                self.gh.remove_labels(issue_number, state_labels)
+
+            self.gh.add_issue_comment(
+                issue_number,
+                self._stale_issue_comment(
+                    release_tag,
+                    current_issue_number,
+                    current_issue_url,
+                )
+            )
+            self.gh.close_issue(issue_number, state_reason="not_planned")
+
+    def _stale_issue_comment(
+        self,
+        release_tag: str,
+        current_issue_number: int,
+        current_issue_url: str,
+    ) -> str:
+        """Build the comment posted before closing a superseded Release Issue."""
+        current_issue_ref = (
+            f"#{current_issue_number}"
+            if not current_issue_url
+            else f"#{current_issue_number} ({current_issue_url})"
+        )
+        return (
+            "This workflow-owned Release Issue has been superseded by "
+            f"{current_issue_ref} for release tag `{release_tag}`.\n\n"
+            "Removing the release-state label and closing this stale issue."
+        )
 
     def create_release_issue(
         self,

--- a/release_automation/tests/test_issue_sync.py
+++ b/release_automation/tests/test_issue_sync.py
@@ -260,6 +260,55 @@ class TestSyncReleaseIssue:
         gh.remove_labels.assert_called()
         gh.add_labels.assert_called()
 
+    def test_closes_stale_workflow_owned_issue_after_current_issue_exists(self):
+        """Test stale workflow-owned issues for old tags are de-stated and closed."""
+        manager, gh, state_manager, issue_manager, _ = self._create_manager()
+
+        release_plan = {
+            "repository": {
+                "target_release_tag": "r4.1",
+                "target_release_type": "pre-release-rc"
+            }
+        }
+
+        current_issue = {
+            "number": 2,
+            "title": "Release r4.1 (RC)",
+            "body": f"{WORKFLOW_MARKER}\n<!-- release-automation:release-tag:r4.1 -->",
+            "labels": [{"name": "release-state:planned"}],
+            "html_url": "https://github.com/test/repo/issues/2",
+        }
+        stale_issue = {
+            "number": 1,
+            "title": "Release r4.0 (RC)",
+            "body": f"{WORKFLOW_MARKER}\n<!-- release-automation:release-tag:r4.0 -->",
+            "labels": [
+                {"name": "release-issue"},
+                {"name": "release-state:planned"},
+            ],
+            "html_url": "https://github.com/test/repo/issues/1",
+        }
+
+        state_manager.derive_state.return_value = ReleaseInfoResult(
+            success=True, state=ReleaseState.PLANNED,
+            release_tag="r4.1", source="release-plan.yaml")
+        gh.search_issues.return_value = [stale_issue, current_issue]
+        gh.get_issue.return_value = current_issue
+        issue_manager.should_update_title.return_value = False
+        issue_manager.generate_state_section.return_value = "**State**: planned"
+        issue_manager.update_section.return_value = current_issue["body"]
+
+        result = manager.sync_release_issue(release_plan)
+
+        assert result.action == "updated"
+        gh.remove_labels.assert_any_call(1, ["release-state:planned"])
+        gh.add_issue_comment.assert_called_once()
+        comment_args = gh.add_issue_comment.call_args.args
+        assert comment_args[0] == 1
+        assert "#2" in comment_args[1]
+        assert "`r4.1`" in comment_args[1]
+        gh.close_issue.assert_called_once_with(1, state_reason="not_planned")
+
     def test_no_action_when_not_planned_and_no_issue(self):
         """Test no action when not PLANNED and no existing issue."""
         manager, gh, state_manager, _, _ = self._create_manager()


### PR DESCRIPTION
#### What type of PR is this?

bug


#### What this PR does / why we need it:

Release Automation previously created or updated the Release Issue for a new `repository.target_release_tag` without tidying the workflow-owned Release Issue for the old tag. The stale issue stayed open with `release-issue` and `release-state:*` labels, which made it look like an active release.

This change closes workflow-owned Release Issues with an old release-tag marker after the current canonical Release Issue is ensured. Stale issues now lose their `release-state:*` label, receive a comment pointing to the current Release Issue, and close as not planned.


#### Which issue(s) this PR fixes:

Fixes #307

#### Special notes for reviewers:

The cleanup uses the existing workflow-owned and release-tag markers. A future maintenance-branch model should add a branch marker before multiple release plans can be active in parallel.

Validated with:

`python3 -m pytest release_automation/tests -q`

#### Changelog input

```
Release Automation now closes stale workflow-owned Release Issues after the target release tag changes.
```

#### Additional documentation 

This section can be blank.



```
docs

```
