### PR TITLE
fix(deps): pin @stoplight/spectral-rulesets to 1.22.2

### DIFF
--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -789,6 +789,49 @@
         "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
+    "node_modules/@stoplight/spectral-cli/node_modules/@stoplight/spectral-rulesets": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.2.tgz",
+      "integrity": "sha512-JsaNqtxBRfjKTCgQJK+LoOyDhzm9Hhw9kV9U3NalsQMH5ERBJw6IVhYyCZtgHBc5FhjXao2iJnnDfGta07M4wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asyncapi/specs": "^6.8.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^8.18.0",
+        "ajv-formats": "~2.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "leven": "3.1.0",
+        "lodash": "^4.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@stoplight/spectral-cli/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1051,6 +1094,49 @@
         "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
+    "node_modules/@stoplight/spectral-ruleset-bundler/node_modules/@stoplight/spectral-rulesets": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.2.tgz",
+      "integrity": "sha512-JsaNqtxBRfjKTCgQJK+LoOyDhzm9Hhw9kV9U3NalsQMH5ERBJw6IVhYyCZtgHBc5FhjXao2iJnnDfGta07M4wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asyncapi/specs": "^6.8.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^8.18.0",
+        "ajv-formats": "~2.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "leven": "3.1.0",
+        "lodash": "^4.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-bundler/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@stoplight/spectral-ruleset-migrator": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.1.tgz",
@@ -1096,49 +1182,6 @@
       "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
       "integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.3.tgz",
-      "integrity": "sha512-CDkXEsrA1OOQPmF0VE92zira+eSI411s7hyIdfVeS/91BrNz3Y5HJgnwWFbh2abKVJ2rNciOzBPyGar+xfiFKA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asyncapi/specs": "^6.8.0",
-        "@stoplight/better-ajv-errors": "1.0.3",
-        "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.19.4",
-        "@stoplight/spectral-formats": "^1.8.1",
-        "@stoplight/spectral-functions": "^1.9.1",
-        "@stoplight/spectral-runtime": "^1.1.2",
-        "@stoplight/types": "^13.6.0",
-        "@types/json-schema": "^7.0.7",
-        "ajv": "^8.18.0",
-        "ajv-formats": "~2.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "leven": "3.1.0",
-        "lodash": "^4.18.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": "^16.20 || ^18.18 || >= 20.17"
-      }
-    },
-    "node_modules/@stoplight/spectral-rulesets/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@stoplight/spectral-runtime": {
       "version": "1.1.5",

--- a/validation/package.json
+++ b/validation/package.json
@@ -9,6 +9,7 @@
     "gherkin-lint": "^4.2.4"
   },
   "overrides": {
+    "@stoplight/spectral-rulesets": "1.22.2",
     "lodash": "^4.18.0",
     "postcss": "^8.5.10",
     "protobufjs": "^7.5.8",


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Pins `@stoplight/spectral-rulesets` to `1.22.2` via `overrides`. A recent lockfile regeneration pulled `1.22.3`, which crashes Spectral (exit 2, `Cannot read properties of null (reading 'enum')`) on any r4 spec containing a literal `null` value — an upstream regression (stoplightio/spectral#2934 dropped a null guard in `duplicated-entry-in-enum`). `1.22.2` is the last pre-regression release.

#### Which issue(s) this PR fixes:

Fixes #328

#### Special notes for reviewers:

Dependency-only (`validation/package.json` + lockfile). Verified: the previously-crashing spec lints clean (17 findings), and the spectral golden suites pass (128). 1.22.4 (latest) still crashes; upstream fix PRs are unmerged — drop the pin once a fixed release ships (track stoplightio/spectral#2959).

#### Changelog input

```
 release-note
Pin spectral-rulesets to 1.22.2 to avoid an upstream null-value crash in r4 validation
```

#### Additional documentation

This section can be blank.

```
docs

```
