### PR TITLE
ci(tooling): add PR-time validation and release checks

### DIFF
--- a/.github/workflows/tooling-ci.yml
+++ b/.github/workflows/tooling-ci.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   changes:
-    name: Detect changed trust-chain paths
+    name: Detect changed validation and release paths
     runs-on: ubuntu-latest
     outputs:
       npm: ${{ steps.plan.outputs.npm }}

--- a/.github/workflows/tooling-ci.yml
+++ b/.github/workflows/tooling-ci.yml
@@ -1,0 +1,462 @@
+name: Tooling CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: tooling-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ACTIONLINT_VERSION: "1.7.12"
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  changes:
+    name: Detect changed trust-chain paths
+    runs-on: ubuntu-latest
+    outputs:
+      npm: ${{ steps.plan.outputs.npm }}
+      javascript: ${{ steps.plan.outputs.javascript }}
+      validation: ${{ steps.plan.outputs.validation }}
+      release_automation: ${{ steps.plan.outputs.release_automation }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Plan gated checks
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            printf '%s\n' "__all__" > changed-files.txt
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD > changed-files.txt
+          else
+            printf '%s\n' "__all__" > changed-files.txt
+          fi
+
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          from tooling_lib.ci_plan import plan_for_changed_files
+
+          changed_files = [
+              line.strip()
+              for line in Path("changed-files.txt").read_text(encoding="utf-8").splitlines()
+              if line.strip()
+          ]
+          plan = plan_for_changed_files(changed_files)
+
+          outputs = {
+              "npm": plan.npm,
+              "javascript": plan.javascript,
+              "validation": plan.validation,
+              "release_automation": plan.release_automation,
+          }
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              for key, value in outputs.items():
+                  out.write(f"{key}={str(value).lower()}\n")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("### Planned Tooling CI checks\n\n")
+              summary.write("| Check | Planned | Trigger |\n")
+              summary.write("| --- | --- | --- |\n")
+              summary.write("| Actionlint | yes | every run |\n")
+              summary.write(f"| Validation npm install | {str(plan.npm).lower()} | validation package manifest or lockfile |\n")
+              summary.write(f"| JavaScript syntax | {str(plan.javascript).lower()} | Spectral custom functions |\n")
+              summary.write(f"| Validation pytest | {str(plan.validation).lower()} | validation, linting, validation shared actions, tooling_lib, or validation workflow paths |\n")
+              summary.write(f"| Release automation pytest | {str(plan.release_automation).lower()} | release_automation, RA shared actions, tooling_lib, or RA workflow paths |\n\n")
+              summary.write("<details><summary>Changed files</summary>\n\n")
+              for path in changed_files:
+                  summary.write(f"- `{path}`\n")
+              summary.write("\n</details>\n")
+          PY
+
+      - name: Upload changed file list
+        uses: actions/upload-artifact@v7
+        with:
+          name: tooling-ci-changed-files
+          path: changed-files.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  actionlint:
+    name: Workflow semantics
+    runs-on: ubuntu-latest
+    needs: changes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          install_dir="$RUNNER_TEMP/actionlint"
+          mkdir -p "$install_dir"
+          curl -fsSL \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            -o "$RUNNER_TEMP/actionlint.tar.gz"
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$install_dir" actionlint
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Run actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p artifacts/actionlint
+          mapfile -t workflow_files < <(
+            find \
+              .github/workflows \
+              validation/workflows \
+              release_automation/workflows \
+              linting/workflows \
+              -maxdepth 1 \
+              -type f \
+              -name '*.yml' \
+              -print | sort
+          )
+
+          actionlint_args=(
+            -shellcheck=
+            -pyflakes=
+            -ignore 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+            -ignore 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'
+            -format '{{json .}}'
+          )
+
+          set +e
+          actionlint "${actionlint_args[@]}" "${workflow_files[@]}" > artifacts/actionlint/actionlint.json
+          status=$?
+          set -e
+
+          if [[ ! -s artifacts/actionlint/actionlint.json ]]; then
+            printf '[]\n' > artifacts/actionlint/actionlint.json
+          fi
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          def escape(value: str) -> str:
+              return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+          issues = json.loads(Path("artifacts/actionlint/actionlint.json").read_text(encoding="utf-8"))
+          for issue in issues:
+              message = escape(issue.get("message", "actionlint issue"))
+              filepath = issue.get("filepath", "")
+              line = issue.get("line", 1)
+              column = issue.get("column", 1)
+              print(f"::error file={filepath},line={line},col={column}::{message}")
+          PY
+
+          {
+            echo "### Actionlint"
+            echo
+            echo "| Check | Result | Artifact |"
+            echo "| --- | --- | --- |"
+            if [[ "$status" -eq 0 ]]; then
+              echo "| Core workflow semantics | pass | tooling-ci-actionlint-json: artifacts/actionlint/actionlint.json |"
+            else
+              echo "| Core workflow semantics | fail | tooling-ci-actionlint-json: artifacts/actionlint/actionlint.json |"
+            fi
+            echo
+            echo "ShellCheck and pyflakes integrations are disabled for the first rollout; the current blocking check is core actionlint semantics."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$status"
+
+      - name: Upload actionlint JSON
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tooling-ci-actionlint-json
+          path: artifacts/actionlint/actionlint.json
+          if-no-files-found: error
+          retention-days: 14
+
+  validation-npm:
+    name: Validation npm install
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.npm == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: validation/package-lock.json
+
+      - name: Run npm ci
+        shell: bash
+        working-directory: validation
+        run: |
+          set -euo pipefail
+
+          mkdir -p ../artifacts/npm
+          npm ci --ignore-scripts 2>&1 | tee ../artifacts/npm/npm-ci.log
+
+      - name: Summarize npm install
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Validation npm install"
+            echo
+            echo "| Check | Result | Artifact |"
+            echo "| --- | --- | --- |"
+            echo "| npm ci --ignore-scripts | ${{ job.status }} | tooling-ci-validation-npm-ci-log: artifacts/npm/npm-ci.log |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload npm install log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tooling-ci-validation-npm-ci-log
+          path: artifacts/npm/npm-ci.log
+          if-no-files-found: warn
+          retention-days: 14
+
+  javascript-syntax:
+    name: JavaScript syntax
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.javascript == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Check custom Spectral functions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p artifacts/javascript
+          : > artifacts/javascript/node-check.log
+
+          find linting/config/lint_function -maxdepth 1 -type f -name '*.js' -print | sort | while read -r file; do
+            echo "node --check ${file}" | tee -a artifacts/javascript/node-check.log
+            node --check "$file" 2>&1 | tee -a artifacts/javascript/node-check.log
+          done
+
+      - name: Summarize JavaScript syntax
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### JavaScript syntax"
+            echo
+            echo "| Check | Result | Artifact |"
+            echo "| --- | --- | --- |"
+            echo "| node --check linting/config/lint_function/*.js | ${{ job.status }} | tooling-ci-javascript-syntax-log: artifacts/javascript/node-check.log |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload JavaScript syntax log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tooling-ci-javascript-syntax-log
+          path: artifacts/javascript/node-check.log
+          if-no-files-found: warn
+          retention-days: 14
+
+  validation-tests:
+    name: Validation pytest
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.validation == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: validation/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --quiet -r requirements.txt pytest
+
+      - name: Install validation Node dependencies
+        working-directory: validation
+        run: npm ci --ignore-scripts
+
+      - name: Run validation tests
+        run: |
+          mkdir -p artifacts/pytest
+          python3 -m pytest validation/tests tooling_lib/tests \
+            --junitxml=artifacts/pytest/validation-junit.xml
+
+      - name: Summarize validation tests
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Validation pytest"
+            echo
+            echo "| Check | Result | Artifact |"
+            echo "| --- | --- | --- |"
+            echo "| validation/tests + tooling_lib/tests | ${{ job.status }} | tooling-ci-validation-pytest-junit: artifacts/pytest/validation-junit.xml |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload validation JUnit XML
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tooling-ci-validation-pytest-junit
+          path: artifacts/pytest/validation-junit.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+  release-automation-tests:
+    name: Release automation pytest
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.release_automation == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --quiet -r requirements.txt pytest
+
+      - name: Run release automation tests
+        run: |
+          mkdir -p artifacts/pytest
+          python3 -m pytest release_automation/tests tooling_lib/tests \
+            --junitxml=artifacts/pytest/release-automation-junit.xml
+
+      - name: Summarize release automation tests
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Release automation pytest"
+            echo
+            echo "| Check | Result | Artifact |"
+            echo "| --- | --- | --- |"
+            echo "| release_automation/tests + tooling_lib/tests | ${{ job.status }} | tooling-ci-release-automation-pytest-junit: artifacts/pytest/release-automation-junit.xml |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release automation JUnit XML
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tooling-ci-release-automation-pytest-junit
+          path: artifacts/pytest/release-automation-junit.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+  summary:
+    name: Tooling CI summary
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - actionlint
+      - validation-npm
+      - javascript-syntax
+      - validation-tests
+      - release-automation-tests
+    if: always()
+    steps:
+      - name: Summarize check results
+        shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
+          NPM_PLANNED: ${{ needs.changes.outputs.npm }}
+          NPM_RESULT: ${{ needs.validation-npm.result }}
+          JAVASCRIPT_PLANNED: ${{ needs.changes.outputs.javascript }}
+          JAVASCRIPT_RESULT: ${{ needs.javascript-syntax.result }}
+          VALIDATION_PLANNED: ${{ needs.changes.outputs.validation }}
+          VALIDATION_RESULT: ${{ needs.validation-tests.result }}
+          RELEASE_PLANNED: ${{ needs.changes.outputs.release_automation }}
+          RELEASE_RESULT: ${{ needs.release-automation-tests.result }}
+        run: |
+          set -euo pipefail
+
+          planned_label() {
+            if [[ "$1" == "true" ]]; then
+              printf 'yes'
+            else
+              printf 'no'
+            fi
+          }
+
+          {
+            echo "### Tooling CI summary"
+            echo
+            echo "| Check | Planned | Result | Artifact |"
+            echo "| --- | --- | --- | --- |"
+            echo "| Changed-path detection | yes | ${CHANGES_RESULT} | tooling-ci-changed-files: changed-files.txt |"
+            echo "| Actionlint | yes | ${ACTIONLINT_RESULT} | tooling-ci-actionlint-json: artifacts/actionlint/actionlint.json |"
+            echo "| Validation npm install | $(planned_label "$NPM_PLANNED") | ${NPM_RESULT} | tooling-ci-validation-npm-ci-log: artifacts/npm/npm-ci.log |"
+            echo "| JavaScript syntax | $(planned_label "$JAVASCRIPT_PLANNED") | ${JAVASCRIPT_RESULT} | tooling-ci-javascript-syntax-log: artifacts/javascript/node-check.log |"
+            echo "| Validation pytest | $(planned_label "$VALIDATION_PLANNED") | ${VALIDATION_RESULT} | tooling-ci-validation-pytest-junit: artifacts/pytest/validation-junit.xml |"
+            echo "| Release automation pytest | $(planned_label "$RELEASE_PLANNED") | ${RELEASE_RESULT} | tooling-ci-release-automation-pytest-junit: artifacts/pytest/release-automation-junit.xml |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for result in \
+            "$CHANGES_RESULT" \
+            "$ACTIONLINT_RESULT" \
+            "$NPM_RESULT" \
+            "$JAVASCRIPT_RESULT" \
+            "$VALIDATION_RESULT" \
+            "$RELEASE_RESULT"
+          do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              failed=1
+            fi
+          done
+
+          exit "$failed"

--- a/tooling_lib/ci_plan.py
+++ b/tooling_lib/ci_plan.py
@@ -1,0 +1,68 @@
+"""Path-gating plan for the tooling repository CI workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ToolingCiPlan:
+    """Boolean plan for path-gated Tooling CI jobs."""
+
+    npm: bool
+    javascript: bool
+    validation: bool
+    release_automation: bool
+
+
+def plan_for_changed_files(changed_files: Iterable[str]) -> ToolingCiPlan:
+    """Return the Tooling CI checks needed for *changed_files*."""
+
+    paths = [path.strip() for path in changed_files if path.strip()]
+    run_all = "__all__" in paths
+
+    def matches(*patterns: str) -> bool:
+        return run_all or any(
+            fnmatch(path, pattern) for path in paths for pattern in patterns
+        )
+
+    workflow_changed = matches(".github/workflows/tooling-ci.yml")
+    broad = workflow_changed or matches("requirements.txt", "tooling_lib/**")
+    npm = workflow_changed or matches(
+        "validation/package.json",
+        "validation/package-lock.json",
+    )
+    javascript = workflow_changed or matches("linting/config/lint_function/*.js")
+    validation = broad or npm or matches(
+        "validation/**",
+        "linting/**",
+        "shared-actions/run-validation/**",
+        "shared-actions/validate-release-plan/**",
+        "validation/workflows/**",
+        "linting/workflows/**",
+        ".github/workflows/validation.yml",
+        ".github/workflows/validation-regression.yml",
+        ".github/workflows/validation-settings-ci.yml",
+        "config/validation-settings.yaml",
+    )
+    release_automation = broad or matches(
+        "release_automation/**",
+        "release_automation/workflows/**",
+        "shared-actions/create-snapshot/**",
+        "shared-actions/derive-release-state/**",
+        "shared-actions/post-bot-comment/**",
+        "shared-actions/run-validation/**",
+        "shared-actions/sync-release-issue/**",
+        "shared-actions/update-issue-section/**",
+        ".github/workflows/release-automation-reusable.yml",
+        ".github/workflows/release-automation-regression.yml",
+    )
+
+    return ToolingCiPlan(
+        npm=npm,
+        javascript=javascript,
+        validation=validation,
+        release_automation=release_automation,
+    )

--- a/tooling_lib/tests/test_ci_plan.py
+++ b/tooling_lib/tests/test_ci_plan.py
@@ -1,0 +1,90 @@
+"""Tests for Tooling CI path gating."""
+
+from __future__ import annotations
+
+from tooling_lib.ci_plan import ToolingCiPlan, plan_for_changed_files
+
+
+def test_docs_only_change_skips_heavy_checks():
+    assert plan_for_changed_files(["documentation/README.md"]) == ToolingCiPlan(
+        npm=False,
+        javascript=False,
+        validation=False,
+        release_automation=False,
+    )
+
+
+def test_workflow_change_runs_all_gated_checks():
+    assert plan_for_changed_files([".github/workflows/tooling-ci.yml"]) == ToolingCiPlan(
+        npm=True,
+        javascript=True,
+        validation=True,
+        release_automation=True,
+    )
+
+
+def test_validation_lockfile_change_runs_npm_and_validation_tests():
+    assert plan_for_changed_files(["validation/package-lock.json"]) == ToolingCiPlan(
+        npm=True,
+        javascript=False,
+        validation=True,
+        release_automation=False,
+    )
+
+
+def test_validation_shared_action_runs_validation_and_release_automation_tests():
+    assert plan_for_changed_files(["shared-actions/run-validation/action.yml"]) == ToolingCiPlan(
+        npm=False,
+        javascript=False,
+        validation=True,
+        release_automation=True,
+    )
+
+
+def test_release_plan_shared_action_runs_validation_tests():
+    assert plan_for_changed_files(
+        ["shared-actions/validate-release-plan/action.yml"]
+    ) == ToolingCiPlan(
+        npm=False,
+        javascript=False,
+        validation=True,
+        release_automation=False,
+    )
+
+
+def test_release_automation_shared_action_runs_release_automation_tests():
+    assert plan_for_changed_files(["shared-actions/create-snapshot/action.yml"]) == ToolingCiPlan(
+        npm=False,
+        javascript=False,
+        validation=False,
+        release_automation=True,
+    )
+
+
+def test_tooling_lib_change_runs_both_python_suites():
+    assert plan_for_changed_files(["tooling_lib/cache_sync.py"]) == ToolingCiPlan(
+        npm=False,
+        javascript=False,
+        validation=True,
+        release_automation=True,
+    )
+
+
+def test_workflow_dispatch_sentinel_runs_all_gated_checks():
+    assert plan_for_changed_files(["__all__"]) == ToolingCiPlan(
+        npm=True,
+        javascript=True,
+        validation=True,
+        release_automation=True,
+    )
+
+
+def test_lint_function_change_runs_javascript_and_validation_tests():
+    assert plan_for_changed_files(
+        ["linting/config/lint_function/camara-reserved-words.js"]
+    ) == ToolingCiPlan(
+        npm=False,
+        javascript=True,
+        validation=True,
+        release_automation=False,
+    )


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Adds a Tooling CI workflow that runs on every pull request and keeps the heavier checks path-gated. The workflow runs core actionlint semantics on tooling workflow files, verifies validation npm installs when package metadata changes, checks custom Spectral JavaScript functions with `node --check`, and runs the validation or release automation pytest suites for the touched area.

The path-gating logic is factored into a small tested helper so docs-only changes still get a stable CI summary while validation, release automation, shared-action, and tooling library changes run the relevant suites. The workflow uploads native or structured artifacts for changed files, actionlint JSON, npm install logs, JavaScript syntax logs, and pytest JUnit XML.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

ShellCheck and pyflakes integrations are disabled for this first rollout because the repository has existing baseline findings outside this PR. The actionlint job also carries narrow ignores for the current `actions/create-github-app-token@v3` `client-id` metadata mismatch. The existing validation settings CI and post-merge regression canaries remain separate.

Local validation run before opening the PR:

- `actionlint` with the same first-rollout options returned `[]`.
- `npm ci --ignore-scripts` passed in `validation/`.
- `node --check linting/config/lint_function/*.js` passed.
- `pytest tooling_lib/tests/test_ci_plan.py` passed.
- Validation mapped pytest suite passed: `1112 passed`.
- Release automation mapped pytest suite passed: `701 passed`.

#### Changelog input

```
 release-note
Add PR-time Tooling CI checks for workflow semantics, validation dependency installs, JavaScript syntax, and validation/release automation pytest suites.
```

#### Additional documentation 

This section can be blank.

```
docs
```
