### PR TITLE
fix(validation): reject unsafe integer schema values

### DIFF
--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -14,6 +14,7 @@
 # - 07.04.2026: Added Phase 2a gap rules (S-018..S-035): license, contact, tags,
 #   apiRoot, 403, error codes, subscription, format descriptions, required props,
 #   array items description, notification content-type
+# - 14.06.2026: Added camara-integer-safe-range rule (S-038)
 
 
 # Note: @stoplight/spectral-owasp-ruleset is installed via validation/package.json.
@@ -34,6 +35,7 @@ functions:
   - camara-array-items-description
   - camara-notification-content-type
   - camara-no-numeric-resource-ids
+  - camara-integer-safe-range
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -538,6 +540,15 @@ rules:
     given: '$.paths..parameters[*][?(@property === "name" && (@ === "id" || @.match(/(_id|Id|-id)$/)))]^.schema'
     then:
       function: camara-no-numeric-resource-ids
+    recommended: true
+
+  camara-integer-safe-range:
+    description: "Integer schema values MUST stay within the JavaScript safe-integer range."
+    message: "{{error}}"
+    severity: error
+    given: "$"
+    then:
+      function: camara-integer-safe-range
     recommended: true
 
   # ===== OWASP API Security Top 10 2023 =====

--- a/linting/config/lint_function/camara-integer-safe-range.js
+++ b/linting/config/lint_function/camara-integer-safe-range.js
@@ -1,0 +1,116 @@
+// CAMARA Project - support function for Spectral linter
+// Checks integer schema values for JavaScript safe-integer compatibility.
+//
+// Release snapshot bundling passes OpenAPI YAML through JavaScript tooling.
+// Numeric integer literals outside Number.MAX_SAFE_INTEGER can be silently
+// rounded before the snapshot is published, so r4 validation rejects them.
+
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+const INTEGER_VALUE_KEYS = [
+  "maximum",
+  "minimum",
+  "exclusiveMaximum",
+  "exclusiveMinimum",
+  "default",
+  "example",
+  "multipleOf",
+];
+const SCHEMA_ARRAY_KEYS = ["allOf", "anyOf", "oneOf"];
+const SCHEMA_OBJECT_KEYS = ["items", "additionalProperties", "not"];
+
+export default (document, _options, context) => {
+  const errors = [];
+
+  function addFinding(value, path, label) {
+    errors.push({
+      message:
+        `Integer schema ${label} ${String(value)} exceeds the JavaScript ` +
+        `safe-integer range [-${MAX_SAFE_INTEGER}, ${MAX_SAFE_INTEGER}]. ` +
+        "Values outside this range can be silently rounded by release " +
+        "bundling; use a value within range or model it as a string " +
+        "(CAMARA Design Guide section 2.2).",
+      path,
+    });
+  }
+
+  function isUnsafeIntegerValue(value) {
+    return (
+      typeof value === "number" &&
+      Number.isFinite(value) &&
+      Number.isInteger(value) &&
+      Math.abs(value) > MAX_SAFE_INTEGER
+    );
+  }
+
+  function checkIntegerValue(schema, path, key) {
+    if (Object.prototype.hasOwnProperty.call(schema, key) && isUnsafeIntegerValue(schema[key])) {
+      addFinding(schema[key], [...path, key], `'${key}' value`);
+    }
+  }
+
+  function checkSchema(schema, path) {
+    if (!schema || typeof schema !== "object" || schema.$ref) return;
+
+    if (schema.type === "integer") {
+      for (const key of INTEGER_VALUE_KEYS) {
+        checkIntegerValue(schema, path, key);
+      }
+
+      if (Array.isArray(schema.enum)) {
+        schema.enum.forEach((value, index) => {
+          if (isUnsafeIntegerValue(value)) {
+            addFinding(value, [...path, "enum", index], "enum value");
+          }
+        });
+      }
+    }
+
+    if (schema.properties && typeof schema.properties === "object") {
+      for (const [name, propertySchema] of Object.entries(schema.properties)) {
+        checkSchema(propertySchema, [...path, "properties", name]);
+      }
+    }
+
+    for (const key of SCHEMA_OBJECT_KEYS) {
+      if (schema[key] && typeof schema[key] === "object") {
+        checkSchema(schema[key], [...path, key]);
+      }
+    }
+
+    for (const key of SCHEMA_ARRAY_KEYS) {
+      if (Array.isArray(schema[key])) {
+        schema[key].forEach((subSchema, index) => {
+          checkSchema(subSchema, [...path, key, index]);
+        });
+      }
+    }
+  }
+
+  function isPathSuffix(path, suffix) {
+    if (path.length < suffix.length) return false;
+    return suffix.every((part, index) => path[path.length - suffix.length + index] === part);
+  }
+
+  function walkOpenApi(node, path) {
+    if (!node || typeof node !== "object") return;
+
+    if (isPathSuffix(path, ["components", "schemas"])) {
+      for (const [name, schema] of Object.entries(node)) {
+        checkSchema(schema, [...path, name]);
+      }
+      return;
+    }
+
+    if (node.schema && typeof node.schema === "object") {
+      checkSchema(node.schema, [...path, "schema"]);
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "schema") continue;
+      walkOpenApi(value, [...path, key]);
+    }
+  }
+
+  walkOpenApi(document, context.path);
+  return errors;
+};

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -214,6 +214,11 @@
   short_title: "Use non-numeric resource IDs"
   suggestion: "Use non-numeric (e.g. string) resource identifiers to prevent enumeration attacks."
 
+- id: S-038
+  engine: spectral
+  engine_rule: camara-integer-safe-range
+  short_title: "Integer value exceeds safe range"
+
 # ===== Built-in OAS rules (S-200+) =====
 
 - id: S-200

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -88,7 +88,7 @@ class TestStructuralIntegrity:
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
         assert counts["python"] == 31
-        assert counts["spectral"] == 85
+        assert counts["spectral"] == 86
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
 

--- a/validation/tests/test_spectral_gap_rules.py
+++ b/validation/tests/test_spectral_gap_rules.py
@@ -770,6 +770,97 @@ class TestS037NoNumericResourceIds:
 
 
 # ---------------------------------------------------------------------------
+# S-038: camara-integer-safe-range
+# ---------------------------------------------------------------------------
+
+_SAFE_RANGE_RULE = "camara-integer-safe-range"
+
+
+class TestS038IntegerSafeRange:
+    """S-038: integer schema values must stay within JS safe-integer range."""
+
+    def test_unsafe_int64_maximum_fires(self):
+        spec = _VALID_SPEC + (
+            "    LargeCounter:\n"
+            "      type: integer\n"
+            "      format: int64\n"
+            "      minimum: 0\n"
+            "      maximum: 9223372036854775807\n"
+            "      description: Large traffic counter\n"
+        )
+        findings = _run_spectral(spec)
+        s038 = _findings_for(findings, _SAFE_RANGE_RULE)
+        assert s038, f"Expected {_SAFE_RANGE_RULE}; got {_codes(findings)}"
+        assert any(f.get("path", [])[-1:] == ["maximum"] for f in s038)
+
+    def test_safe_integer_boundaries_pass(self):
+        spec = _VALID_SPEC + (
+            "    SafeCounter:\n"
+            "      type: integer\n"
+            "      format: int64\n"
+            "      minimum: -9007199254740991\n"
+            "      maximum: 9007199254740991\n"
+            "      description: Safe traffic counter\n"
+        )
+        findings = _run_spectral(spec)
+        assert _SAFE_RANGE_RULE not in _codes(findings)
+
+    def test_numeric_enum_and_default_outside_safe_range_fire(self):
+        spec = _VALID_SPEC + (
+            "    CounterState:\n"
+            "      type: integer\n"
+            "      format: int64\n"
+            "      default: 9007199254740993\n"
+            "      enum:\n"
+            "        - 1\n"
+            "        - 9007199254740992\n"
+            "      description: Counter state\n"
+        )
+        findings = _run_spectral(spec)
+        s038 = _findings_for(findings, _SAFE_RANGE_RULE)
+        assert len(s038) >= 2, f"Expected default and enum findings; got {s038}"
+        paths = {tuple(f.get("path", [])) for f in s038}
+        assert any(path[-1:] == ("default",) for path in paths)
+        assert any("enum" in path for path in paths)
+
+    def test_missing_format_integer_with_unsafe_minimum_fires(self):
+        spec = _VALID_SPEC + (
+            "    UnformattedInteger:\n"
+            "      type: integer\n"
+            "      minimum: -9223372036854775808\n"
+            "      description: Unformatted integer value\n"
+        )
+        findings = _run_spectral(spec)
+        s038 = _findings_for(findings, _SAFE_RANGE_RULE)
+        assert s038, f"Expected {_SAFE_RANGE_RULE}; got {_codes(findings)}"
+        assert any(f.get("path", [])[-1:] == ["minimum"] for f in s038)
+
+    def test_inline_parameter_schema_with_unsafe_maximum_fires(self):
+        schema = (
+            "        schema:\n"
+            "          type: integer\n"
+            "          format: int64\n"
+            "          maximum: 9223372036854775807\n"
+        )
+        findings = _run_spectral(_spec_with_id_param(schema, name="category"))
+        s038 = _findings_for(findings, _SAFE_RANGE_RULE)
+        assert s038, f"Expected {_SAFE_RANGE_RULE}; got {_codes(findings)}"
+        assert any("parameters" in f.get("path", []) for f in s038)
+
+    def test_large_double_value_passes(self):
+        spec = _VALID_SPEC + (
+            "    LargeDouble:\n"
+            "      type: number\n"
+            "      format: double\n"
+            "      maximum: 1000000000000000000000000000000\n"
+            "      example: 1000000000000000000000000000000\n"
+            "      description: Large floating-point value\n"
+        )
+        findings = _run_spectral(spec)
+        assert _SAFE_RANGE_RULE not in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
 # Regression: camara-security-no-secrets must not crash Spectral on null values
 #
 # The rule's `given` includes a recursive-descent filter


### PR DESCRIPTION
#### What type of PR is this?

bug


#### What this PR does / why we need it:

Adds the r4 Spectral rule `camara-integer-safe-range` to reject integer schema values outside the JavaScript safe-integer range.

Release snapshot bundling runs OpenAPI YAML through JavaScript tooling. Integer literals above `Number.MAX_SAFE_INTEGER` can be silently rounded, which can make a published snapshot differ from the source contract. This rule catches those values before bundling.

The rule checks integer schema values in `maximum`, `minimum`, `exclusiveMaximum`, `exclusiveMinimum`, `default`, `example`, `multipleOf`, and numeric `enum` entries. It walks component schemas and inline `schema:` objects, and it intentionally skips `type: number` / `format: double` schemas because floating-point precision is a separate concern.

This also adds S-038 rule metadata and regression coverage for unsafe int64 bounds, unsafe default/enum values, safe boundary values, inline parameter schemas, and a large double false-positive guard.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #331

#### Special notes for reviewers:

Test PR against the CI baseline passed: https://github.com/hdamker/tooling/pull/4

Local validation:

- `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pytest validation/tests/test_spectral_gap_rules.py::TestS038IntegerSafeRange -x`
- `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pytest validation/tests/test_rule_metadata_integrity.py -x`
- `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pytest validation/tests/test_spectral_gap_rules.py validation/tests/test_rule_metadata_integrity.py`

#### Changelog input

```
release-note
Add r4 validation for integer schema values outside the JavaScript safe-integer range.
```

#### Additional documentation 

This section can be blank.



```
docs
```
