### PR TITLE
ci(validation): align tooling CI with Node 24

### DIFF
--- a/.github/workflows/tooling-ci.yml
+++ b/.github/workflows/tooling-ci.yml
@@ -14,6 +14,8 @@ permissions:
 env:
   ACTIONLINT_VERSION: "1.7.12"
   PYTHON_VERSION: "3.11"
+  # Must match .github/workflows/validation.yml; Tooling CI validates the same Node-backed engines.
+  VALIDATION_NODE_VERSION: "24"
 
 jobs:
   changes:
@@ -205,7 +207,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: ${{ env.VALIDATION_NODE_VERSION }}
           cache: npm
           cache-dependency-path: validation/package-lock.json
 
@@ -253,7 +255,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: ${{ env.VALIDATION_NODE_VERSION }}
 
       - name: Check custom Spectral functions
         shell: bash
@@ -308,7 +310,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: ${{ env.VALIDATION_NODE_VERSION }}
           cache: npm
           cache-dependency-path: validation/package-lock.json
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,6 +39,7 @@ env:
   # Allowlist for tooling_ref_override beyond a 40-char SHA. Comma-separated.
   # Each consuming caller's override input must match a SHA or one of these.
   ALLOWED_TOOLING_REFS: "main,v1-rc,hotfix"
+  VALIDATION_NODE_VERSION: "24"
 
 permissions:
   checks: write
@@ -208,7 +209,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ env.VALIDATION_NODE_VERSION }}
 
       # ── Step 6: Detect release-plan changes (PR only) ──────────────
       - name: Detect release-plan changes


### PR DESCRIPTION
#### What type of PR is this?

repository management


#### What this PR does / why we need it:

Aligns the validation-facing Tooling CI jobs with the Node runtime used by the reusable validation workflow.

The reusable validation workflow already runs Node 24. Tooling CI was still running the validation npm install, custom Spectral JavaScript syntax check, and validation pytest jobs on Node 20, which means PR-time checks were not exercising the same Node/npm runtime as consuming repositories.

This PR introduces a `VALIDATION_NODE_VERSION` workflow variable and uses Node 24 for those validation-facing checks.


#### Which issue(s) this PR fixes:

None.


#### Special notes for reviewers:

This is intentionally separate from the GPLint migration PR so that dependency replacement and CI runtime alignment can be reviewed independently.

Local checks run:

- `actionlint -shellcheck= -pyflakes= -ignore 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"' -ignore 'input "client-id" is not defined in action "actions/create-github-app-token@v3"' .github/workflows/tooling-ci.yml .github/workflows/validation.yml`
- `python3 -m pytest tooling_lib/tests -q`
- `npm ci --ignore-scripts --dry-run` in `validation/`


#### Changelog input

```
release-note
NONE
```

#### Additional documentation 

This section can be blank.



```
docs
```
