### PR TITLE
Align validation Python runtime policy

### DIFF
--- a/.github/workflows/release-automation-regression.yml
+++ b/.github/workflows/release-automation-regression.yml
@@ -37,6 +37,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Keep release automation runtime pins explicit and aligned with validation.
+  PYTHON_VERSION: "3.14"
+
 jobs:
   regression:
     name: RA regression canary
@@ -50,7 +54,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install runner dependencies
         run: |

--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -37,6 +37,9 @@ env:
   # Allowlist for tooling_ref_override beyond a 40-char SHA. Comma-separated.
   # Each consuming caller's override input must match a SHA or one of these.
   ALLOWED_TOOLING_REFS: "main,v1-rc,hotfix"
+  # Keep release automation runtime pins explicit and aligned with validation.
+  PYTHON_VERSION: "3.14"
+  NODE_VERSION: "24"
 
 permissions:
   contents: write
@@ -1004,12 +1007,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ env.NODE_VERSION }}
 
       # ── Central validation settings (main) ─────────────────────────
       #
@@ -1473,7 +1476,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: pip install --quiet -r _tooling/requirements.txt

--- a/.github/workflows/tooling-ci.yml
+++ b/.github/workflows/tooling-ci.yml
@@ -13,9 +13,9 @@ permissions:
 
 env:
   ACTIONLINT_VERSION: "1.7.12"
-  PYTHON_VERSION: "3.11"
-  # Must match .github/workflows/validation.yml; Tooling CI validates the same Node-backed engines.
-  VALIDATION_NODE_VERSION: "24"
+  # Must match the reusable workflows; Tooling CI validates the same engines.
+  PYTHON_VERSION: "3.14"
+  NODE_VERSION: "24"
 
 jobs:
   changes:
@@ -207,7 +207,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.VALIDATION_NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: validation/package-lock.json
 
@@ -255,7 +255,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.VALIDATION_NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Check custom Spectral functions
         shell: bash
@@ -310,7 +310,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.VALIDATION_NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: validation/package-lock.json
 

--- a/.github/workflows/validation-regression.yml
+++ b/.github/workflows/validation-regression.yml
@@ -36,6 +36,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Keep validation runtime pins explicit and aligned across CI workflows.
+  PYTHON_VERSION: "3.14"
+
 jobs:
   regression:
     name: Regression canary
@@ -49,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install runner dependencies
         run: |

--- a/.github/workflows/validation-settings-ci.yml
+++ b/.github/workflows/validation-settings-ci.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Keep validation runtime pins explicit and aligned across CI workflows.
+  PYTHON_VERSION: "3.14"
+
 jobs:
   validate:
     name: Schema-validate validation-settings.yaml
@@ -37,7 +41,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: pip install --quiet -r requirements.txt

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,7 +39,9 @@ env:
   # Allowlist for tooling_ref_override beyond a 40-char SHA. Comma-separated.
   # Each consuming caller's override input must match a SHA or one of these.
   ALLOWED_TOOLING_REFS: "main,v1-rc,hotfix"
-  VALIDATION_NODE_VERSION: "24"
+  # Keep validation runtime pins explicit and aligned across reusable workflows.
+  PYTHON_VERSION: "3.14"
+  NODE_VERSION: "24"
 
 permissions:
   checks: write
@@ -204,13 +206,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       # ── Step 5: Setup Node ─────────────────────────────────────────
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.VALIDATION_NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
 
       # ── Step 6: Detect release-plan changes (PR only) ──────────────
       - name: Detect release-plan changes

--- a/shared-actions/create-snapshot/action.yml
+++ b/shared-actions/create-snapshot/action.yml
@@ -74,7 +74,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.14'
 
     - name: Install Python dependencies
       shell: bash

--- a/shared-actions/derive-release-state/action.yml
+++ b/shared-actions/derive-release-state/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.14"
 
     - name: Install dependencies
       shell: bash

--- a/shared-actions/post-bot-comment/action.yml
+++ b/shared-actions/post-bot-comment/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.14"
 
     - name: Install dependencies
       shell: bash

--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -6,7 +6,7 @@ description: |
   (all engines, post-filter, output generation), writes workflow summary,
   and outputs the overall result.
 
-  Prerequisites: Python 3.11 and Node 24 must be available (caller sets
+  Prerequisites: Python 3.14 and Node 24 must be available (caller sets
   up runtimes via setup-python and setup-node before invoking this action).
 
 inputs:

--- a/shared-actions/sync-release-issue/action.yml
+++ b/shared-actions/sync-release-issue/action.yml
@@ -79,7 +79,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.14'
 
     - name: Install dependencies
       shell: bash

--- a/shared-actions/update-issue-section/action.yml
+++ b/shared-actions/update-issue-section/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.14'
 
     - name: Fetch Issue and Update Section
       id: update

--- a/shared-actions/validate-release-plan/action.yml
+++ b/shared-actions/validate-release-plan/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.14'
 
     - name: Install dependencies
       shell: bash

--- a/validation/scripts/README.md
+++ b/validation/scripts/README.md
@@ -27,7 +27,7 @@ This file is the CLI reference only.
 
 ### Prerequisites
 
-- Python 3.11+ with `pyyaml` and `jsonschema`
+- Python 3.14 with `pyyaml` and `jsonschema`
 - `gh` CLI installed and authenticated (`gh auth status` must be green)
 - The test repo must have the validation framework caller workflow installed
   at `.github/workflows/camara-validation.yml`


### PR DESCRIPTION
#### What type of PR is this?

cleanup
repository management


#### What this PR does / why we need it:

Aligns validation and release automation workflow runtimes on Python 3.14.

This PR:
- adds explicit `PYTHON_VERSION: "3.14"` workflow env pins where Python setup is owned by the workflow
- updates release automation shared actions to set up Python 3.14 directly
- renames validation Node runtime env usage from `VALIDATION_NODE_VERSION` to `NODE_VERSION`
- wires the release automation pre-snapshot validation Node setup through the same `NODE_VERSION` env
- updates runtime references in the reusable validation action docs and regression runner README


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #342

#### Special notes for reviewers:

The reusable validation and release automation workflows are consumed by API repositories, so this intentionally changes the downstream Python runtime from 3.11 to 3.14.

Local validation:
- `python3 -m pytest tooling_lib/tests`
- touched workflow/action YAML parsed successfully
- `actionlint` passed with the existing create-github-app-token metadata and shellcheck baseline categories ignored

#### Changelog input

```
release-note
Align validation and release automation workflow runtime pins to Python 3.14.
```

#### Additional documentation 

This section can be blank.



```
docs
No additional documentation.
```
