### PR TITLE
fix(release-automation): retry regression bot comment reads

### DIFF
--- a/release_automation/scripts/regression_runner.py
+++ b/release_automation/scripts/regression_runner.py
@@ -411,6 +411,8 @@ _RA_BOT_LOGINS = frozenset({
     "github-actions[bot]",
     "camara-release-automation[bot]",
 })
+_COMMENT_READ_ATTEMPTS = 3
+_COMMENT_READ_RETRY_SECONDS = 5
 
 
 def _expected_comments_path() -> Path:
@@ -474,6 +476,39 @@ def _match_comment_title(body: str, expected_prefix: str) -> bool:
     return _first_visible_line(body).startswith(expected_prefix)
 
 
+def _read_issue_comments(repo: str, issue_number: int) -> list[dict[str, Any]]:
+    """Read issue comments, retrying transient `gh api` transport failures."""
+    last_error: InfrastructureError | None = None
+    for attempt in range(1, _COMMENT_READ_ATTEMPTS + 1):
+        try:
+            return gh(
+                [
+                    "api", f"repos/{repo}/issues/{issue_number}/comments",
+                    "--paginate",
+                    "--jq",
+                    "[.[] | {body, created_at, user: {login: .user.login}, html_url}]",
+                ],
+                parse_json=True,
+            )
+        except InfrastructureError as exc:
+            last_error = exc
+            if attempt == _COMMENT_READ_ATTEMPTS:
+                break
+            logger.warning(
+                "comment read failed for %s#%s (attempt %s/%s); retrying: %s",
+                repo,
+                issue_number,
+                attempt,
+                _COMMENT_READ_ATTEMPTS,
+                exc,
+            )
+            time.sleep(_COMMENT_READ_RETRY_SECONDS)
+    raise InfrastructureError(
+        f"could not fetch issue comments after {_COMMENT_READ_ATTEMPTS} attempts: "
+        f"{last_error}"
+    ) from last_error
+
+
 def fetch_last_bot_comment(
     repo: str, issue_number: int, since: datetime,
 ) -> dict[str, Any] | None:
@@ -484,14 +519,7 @@ def fetch_last_bot_comment(
     Returns the comment dict (with `body`, `created_at`, `user.login`, `html_url`)
     or None if no matching comment is found.
     """
-    data = gh(
-        [
-            "api", f"repos/{repo}/issues/{issue_number}/comments",
-            "--paginate",
-            "--jq", "[.[] | {body, created_at, user: {login: .user.login}, html_url}]",
-        ],
-        parse_json=True,
-    )
+    data = _read_issue_comments(repo, issue_number)
     candidates: list[dict[str, Any]] = []
     for item in data:
         user = (item.get("user") or {}).get("login")

--- a/release_automation/tests/test_regression_runner.py
+++ b/release_automation/tests/test_regression_runner.py
@@ -964,6 +964,35 @@ class TestFetchLastBotComment:
         assert result is not None
         assert result["body"] == "good"
 
+    def test_retries_transient_comment_read_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "release_automation.scripts.regression_runner.time.sleep",
+            lambda *_a, **_k: None,
+        )
+        since = datetime(2026, 4, 23, 10, 0, 0, tzinfo=timezone.utc)
+        comments = [
+            _comment(
+                "2026-04-23T10:00:30Z",
+                "github-actions[bot]",
+                "<!-- release-bot:r1.2 -->\n**✅ Snapshot created — State: `snapshot-active`**",
+            ),
+        ]
+        gh_mock = patch(
+            "release_automation.scripts.regression_runner.gh",
+            side_effect=[
+                InfrastructureError(
+                    "gh api repos/o/r/issues/90/comments: exit 1\n"
+                    "stderr: invalid character 'u' looking for beginning of value"
+                ),
+                comments,
+            ],
+        )
+        with gh_mock as mocked:
+            result = fetch_last_bot_comment("o/r", 90, since)
+
+        assert result == comments[0]
+        assert mocked.call_count == 2
+
 
 # ---------------------------------------------------------------------------
 # _build_command_body + _canary_run_url


### PR DESCRIPTION
#### What type of PR is this?

bug
tests


#### What this PR does / why we need it:

The release automation regression runner currently treats a failed comments API read as a final failure after the caller workflow has already succeeded. One canary run hit a transient/non-JSON `gh api` response while fetching Release Issue comments, even though the expected snapshot-created bot reply was present.

This PR retries issue-comment reads before reporting an infrastructure failure. It keeps the existing bot reply title checks unchanged.


#### Which issue(s) this PR fixes:

N/A - follow-up to #336.

#### Special notes for reviewers:

Validation:

- `python3 -m pytest release_automation/tests/test_regression_runner.py -q`
- `python3 -m pytest release_automation/tests -q`
- Full ReleaseTest round trip from this branch: PASS, 5 of 5 phases. The runner created snapshot [PR #209](https://github.com/camaraproject/ReleaseTest/pull/209), read the expected bot replies, discarded the snapshot, and restored the Release Issue to `planned`.

#### Changelog input

```
release-note
None
```

#### Additional documentation 

This section can be blank.



```
docs
N/A
```
