### PR TITLE
feat(validation): add published-history release-plan checks (P-035, P-036)

### DIFF
--- a/.github/workflows/release-automation-reusable.yml
+++ b/.github/workflows/release-automation-reusable.yml
@@ -1082,6 +1082,17 @@ jobs:
           print(f"Validation settings: {config_path} (main) — schema-valid")
           PY
 
+      - name: Resolve published release history
+        id: release-history
+        if: hashFiles('_repo/release-plan.yaml') != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          python3 _tooling/validation/scripts/resolve-release-history.py \
+            --repo "${{ github.repository }}" \
+            --base-ref "${{ github.event.repository.default_branch || github.ref_name || 'main' }}" \
+            --output "${RUNNER_TEMP}/release-history.json"
+
       - name: Run pre-snapshot validation
         id: validation
         uses: ./_tooling/shared-actions/run-validation
@@ -1091,6 +1102,7 @@ jobs:
           mode: pre-snapshot
           tooling_ref: ${{ needs.check-trigger.outputs.tooling_checkout_ref }}
           config_path: ${{ github.workspace }}/_tooling-config/config/validation-settings.yaml
+          release_history_path: ${{ steps.release-history.outputs.release_history_path || '' }}
 
       - name: Gate on validation result
         id: validation-gate

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -248,10 +248,7 @@ jobs:
       # why the orchestrator suppresses the Spectral + gherkin engines.
       # ICM has no common files to sync, so an ICM advance does not
       # trigger engine suppression.
-      - name: Install Python dependencies for dependency resolver
-        if: >-
-          github.event_name == 'pull_request'
-          && steps.detect-changes.outputs.release_plan_changed == 'true'
+      - name: Install Python dependencies for workflow resolvers
         run: pip install --quiet -r .tooling/requirements.txt
 
       - name: Resolve dependency changes and declared tags
@@ -278,6 +275,22 @@ jobs:
           && steps.detect-changes.outputs.release_plan_changed == 'true'
         uses: ./.tooling/shared-actions/derive-release-state
 
+      # ── Step 6d: Resolve published release history for P-035 ──────
+      #
+      # The Python orchestrator stays offline.  Resolve published releases and
+      # release-metadata.yaml in the workflow layer, write a compact JSON
+      # snapshot, and pass only that file path into validation.
+      - name: Resolve published release history
+        id: release-history
+        if: hashFiles('release-plan.yaml') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .tooling/validation/scripts/resolve-release-history.py \
+            --repo "${{ github.repository }}" \
+            --base-ref "${{ github.base_ref || github.ref_name || 'main' }}" \
+            --output "${RUNNER_TEMP}/release-history.json"
+
       # ── Step 7: Run validation (shared action) ─────────────────────
       #
       # The run-validation action installs dependencies, runs the Python
@@ -300,6 +313,7 @@ jobs:
           active_release_state: ${{ steps.derive-release-state.outputs.state || '' }}
           active_release_snapshot_branch: ${{ steps.derive-release-state.outputs.snapshot_branch || '' }}
           active_release_issue_number: ${{ steps.derive-release-state.outputs.release_issue_number || '' }}
+          release_history_path: ${{ steps.release-history.outputs.release_history_path || '' }}
           tooling_ref: ${{ steps.resolve-ref.outputs.tooling_checkout_ref }}
           config_path: ${{ steps.resolve-config.outputs.config_path }}
 

--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -101,6 +101,12 @@ inputs:
       from tag moves.  When empty, falls back to the pinned-ref copy.
     required: false
     default: ''
+  release_history_path:
+    description: >
+      Optional path to workflow-resolved published release history JSON.
+      Consumed by P-035 and later history-aware release-plan rules.
+    required: false
+    default: ''
 
 outputs:
   result:
@@ -242,6 +248,7 @@ runs:
         VALIDATION_TOOLING_REF: ${{ inputs.tooling_ref }}
         VALIDATION_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         VALIDATION_CONFIG_PATH: ${{ inputs.config_path }}
+        VALIDATION_RELEASE_HISTORY_PATH: ${{ inputs.release_history_path }}
       run: |
         export PATH="${PATH_NODE_MODULES}:${PATH}"
         python -m validation.orchestrator

--- a/validation/context/__init__.py
+++ b/validation/context/__init__.py
@@ -11,3 +11,8 @@ from .context_builder import (  # noqa: F401
     ValidationContext,
     build_validation_context,
 )
+from .release_history import (  # noqa: F401
+    PublishedRelease,
+    PublishedReleaseApi,
+    ReleaseHistorySnapshot,
+)

--- a/validation/context/context_builder.py
+++ b/validation/context/context_builder.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 from .api_pattern_detector import detect_api_pattern_from_file
+from .release_history import ReleaseHistorySnapshot, load_release_history
 from .release_metadata_parser import load_release_metadata
 from .release_plan_parser import load_release_plan
 
@@ -162,6 +163,11 @@ class ValidationContext:
     # active_release_state: compact workflow-resolved state for P-033.
     # Populated from shared-actions/derive-release-state outputs.
     active_release_state: ActiveReleaseState = field(default_factory=ActiveReleaseState)
+
+    # release_history: optional workflow-resolved published-history snapshot for
+    # P-035 and later history/content checks.  None means absent, incomplete,
+    # or unreadable input; history-aware rules fail open in that case.
+    release_history: Optional[ReleaseHistorySnapshot] = None
 
     def to_dict(self) -> dict:
         """Serialize to dict with all keys present.
@@ -314,6 +320,7 @@ def build_validation_context(
     active_release_state: str = "",
     active_release_snapshot_branch: str = "",
     active_release_issue_number: Optional[int] = None,
+    release_history_path: Optional[Path] = None,
 ) -> ValidationContext:
     """Assemble the unified validation context.
 
@@ -381,6 +388,12 @@ def build_validation_context(
                 )
             api_contexts = tuple(api_list)
 
+    release_history = (
+        load_release_history(release_history_path)
+        if release_history_path is not None
+        else None
+    )
+
     return ValidationContext(
         repository=repo_name,
         branch_type=branch_type,
@@ -410,4 +423,5 @@ def build_validation_context(
             snapshot_branch=active_release_snapshot_branch,
             release_issue_number=active_release_issue_number,
         ),
+        release_history=release_history,
     )

--- a/validation/context/release_history.py
+++ b/validation/context/release_history.py
@@ -1,0 +1,221 @@
+"""Published release-history snapshot parser for validation.
+
+The workflow layer resolves GitHub release metadata and writes a compact JSON
+snapshot.  The Python orchestrator consumes that file offline; it never calls
+GitHub while evaluating validation rules.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_RELEASE_TYPES = {"public-release", "maintenance-release"}
+
+
+@dataclass(frozen=True, order=True)
+class ReleaseTag:
+    """Sortable CAMARA repository release tag, e.g. ``r4.3``."""
+
+    major: int
+    minor: int
+
+
+@dataclass(frozen=True)
+class PublishedReleaseApi:
+    """API entry from a published release metadata snapshot."""
+
+    api_name: str
+    api_version: str
+    api_file_name: str = ""
+
+    @property
+    def base_version(self) -> str:
+        return normalize_api_version_base(self.api_version)
+
+    @property
+    def status(self) -> str:
+        if "-alpha." in self.api_version:
+            return "alpha"
+        if "-rc." in self.api_version:
+            return "rc"
+        return "public"
+
+
+@dataclass(frozen=True)
+class PublishedRelease:
+    """Published repository release plus release-metadata summary."""
+
+    tag: str
+    release_type: str
+    prerelease: bool
+    published_at: str
+    src_commit_sha: str
+    metadata_available: bool
+    apis: Tuple[PublishedReleaseApi, ...]
+
+    @property
+    def parsed_tag(self) -> Optional[ReleaseTag]:
+        return parse_release_tag(self.tag)
+
+
+@dataclass(frozen=True)
+class ReleaseHistorySnapshot:
+    """Workflow-resolved release history consumed by history-aware rules."""
+
+    schema_version: int
+    repository: str
+    base_ref: str
+    lookup_status: str
+    published_releases: Tuple[PublishedRelease, ...]
+
+    def release_tags_available(self) -> bool:
+        """Return True when repository release tags are known enough to compare."""
+        return self.lookup_status == "complete" or bool(self.published_releases)
+
+    def latest_release(self) -> Optional[PublishedRelease]:
+        releases = [
+            release
+            for release in self.published_releases
+            if release.parsed_tag is not None
+        ]
+        if not releases:
+            return None
+        return max(releases, key=lambda release: release.parsed_tag)
+
+    def release_by_tag(self, tag: str) -> Optional[PublishedRelease]:
+        for release in self.published_releases:
+            if release.tag == tag:
+                return release
+        return None
+
+    def has_cycle(self, major: int) -> bool:
+        return any(
+            release.parsed_tag is not None and release.parsed_tag.major == major
+            for release in self.published_releases
+        )
+
+    def terminal_api_version_statuses(self, api_name: str) -> set[tuple[str, str]]:
+        versions: set[tuple[str, str]] = set()
+        for release in self.published_releases:
+            if (
+                not release.metadata_available
+                or release.release_type not in TERMINAL_RELEASE_TYPES
+            ):
+                continue
+            for api in release.apis:
+                if api.api_name == api_name:
+                    versions.add((api.base_version, api.status))
+        return versions
+
+    def may_have_missing_terminal_metadata(self) -> bool:
+        """Return True when unavailable metadata could hide terminal API evidence."""
+        return any(
+            not release.metadata_available and not release.prerelease
+            for release in self.published_releases
+        )
+
+
+_RELEASE_TAG_RE = re.compile(r"^r([1-9]\d*)\.([1-9]\d*)$")
+_API_VERSION_BASE_RE = re.compile(r"^(\d+\.\d+\.\d+)(?:-(?:alpha|rc)\.\d+)?$")
+
+
+def parse_release_tag(tag: str) -> Optional[ReleaseTag]:
+    """Parse ``rX.Y`` into a sortable value; return None for invalid tags."""
+    match = _RELEASE_TAG_RE.fullmatch(str(tag))
+    if not match:
+        return None
+    return ReleaseTag(major=int(match.group(1)), minor=int(match.group(2)))
+
+
+def normalize_api_version_base(version: str) -> str:
+    """Return the release-plan base version for a metadata API version."""
+    match = _API_VERSION_BASE_RE.fullmatch(str(version))
+    if not match:
+        return str(version)
+    return match.group(1)
+
+
+def _parse_api(raw: Any) -> Optional[PublishedReleaseApi]:
+    if not isinstance(raw, dict):
+        return None
+    api_name = raw.get("api_name")
+    api_version = raw.get("api_version")
+    if not isinstance(api_name, str) or not isinstance(api_version, str):
+        return None
+    api_file_name = raw.get("api_file_name")
+    return PublishedReleaseApi(
+        api_name=api_name,
+        api_version=api_version,
+        api_file_name=api_file_name if isinstance(api_file_name, str) else "",
+    )
+
+
+def _parse_release(raw: Any) -> Optional[PublishedRelease]:
+    if not isinstance(raw, dict):
+        return None
+    tag = raw.get("tag")
+    if not isinstance(tag, str) or not tag:
+        return None
+    apis = tuple(
+        api
+        for api in (_parse_api(item) for item in raw.get("apis", []))
+        if api is not None
+    )
+    return PublishedRelease(
+        tag=tag,
+        release_type=str(raw.get("release_type") or ""),
+        prerelease=bool(raw.get("prerelease", False)),
+        published_at=str(raw.get("published_at") or ""),
+        src_commit_sha=str(raw.get("src_commit_sha") or ""),
+        metadata_available=bool(raw.get("metadata_available", False)),
+        apis=apis,
+    )
+
+
+def parse_release_history(data: Any) -> Optional[ReleaseHistorySnapshot]:
+    """Parse release-history JSON data into a tolerant immutable snapshot."""
+    if not isinstance(data, dict):
+        return None
+
+    releases = tuple(
+        release
+        for release in (
+            _parse_release(item) for item in data.get("published_releases", [])
+        )
+        if release is not None
+    )
+
+    try:
+        schema_version = int(data.get("schema_version", 1))
+    except (TypeError, ValueError):
+        schema_version = 1
+
+    return ReleaseHistorySnapshot(
+        schema_version=schema_version,
+        repository=str(data.get("repository") or ""),
+        base_ref=str(data.get("base_ref") or ""),
+        lookup_status=str(data.get("lookup_status") or "missing"),
+        published_releases=releases,
+    )
+
+
+def load_release_history(path: Path) -> Optional[ReleaseHistorySnapshot]:
+    """Load and parse a workflow-resolved release-history JSON file."""
+    if not path.is_file():
+        logger.debug("release-history snapshot not found at %s", path)
+        return None
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Failed to load release-history snapshot from %s", path)
+        return None
+
+    return parse_release_history(data)

--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -21,7 +21,9 @@ from .release_plan_checks import (
     check_release_plan_active_release_state,
     check_release_plan_api_names_unique,
     check_release_plan_exclusivity,
+    check_release_plan_published_history,
     check_release_plan_semantics,
+    check_release_plan_terminal_api_status,
 )
 from .release_review_checks import check_release_review_file_restriction
 from .subscription_checks import (
@@ -70,6 +72,8 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-test-directory-exists", CheckScope.REPO, check_test_directory_exists),
     CheckDescriptor("check-release-plan-semantics", CheckScope.REPO, check_release_plan_semantics),
     CheckDescriptor("check-release-plan-api-names-unique", CheckScope.REPO, check_release_plan_api_names_unique),
+    CheckDescriptor("check-release-plan-published-history", CheckScope.REPO, check_release_plan_published_history),
+    CheckDescriptor("check-release-plan-terminal-api-status", CheckScope.REPO, check_release_plan_terminal_api_status),
     CheckDescriptor("check-readme-placeholder-removal", CheckScope.REPO, check_readme_placeholder_removal),
     CheckDescriptor("check-api-readiness-checklist-removal", CheckScope.REPO, check_api_readiness_checklist_removal),
     CheckDescriptor("check-release-review-file-restriction", CheckScope.REPO, check_release_review_file_restriction),

--- a/validation/engines/python_checks/release_plan_checks.py
+++ b/validation/engines/python_checks/release_plan_checks.py
@@ -16,6 +16,11 @@ from typing import List, Optional
 
 from release_automation.scripts import config
 from validation.context import ValidationContext
+from validation.context.release_history import (
+    PublishedRelease,
+    normalize_api_version_base,
+    parse_release_tag,
+)
 from validation.context.release_plan_parser import is_valid_release_tag
 
 from ._types import load_yaml_safe, make_finding
@@ -336,6 +341,302 @@ def check_release_plan_api_names_unique(
         )
 
     return findings
+
+
+# ---------------------------------------------------------------------------
+# P-035: check-release-plan-published-history
+# ---------------------------------------------------------------------------
+
+
+def _planned_api_set(release_plan: dict) -> tuple[tuple[str, str, str], ...]:
+    return tuple(sorted(_planned_api_entries(release_plan)))
+
+
+def _published_api_set(release: PublishedRelease) -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        sorted(
+            (
+                api.api_name,
+                normalize_api_version_base(api.api_version),
+                api.status,
+            )
+            for api in release.apis
+        )
+    )
+
+
+def _plan_matches_published_release(
+    release_plan: dict, release: PublishedRelease
+) -> bool:
+    repo = release_plan.get("repository", {})
+    release_type = repo.get("target_release_type")
+    if release_type != release.release_type:
+        return False
+    return _planned_api_set(release_plan) == _published_api_set(release)
+
+
+def _inactive_plan_matches_published_release(
+    release_plan: dict, release: PublishedRelease
+) -> bool:
+    repo = release_plan.get("repository", {})
+    if repo.get("target_release_type") != "none":
+        return False
+    return _planned_api_set(release_plan) == _published_api_set(release)
+
+
+def _prefix_pre_existing_release_plan_condition(
+    context: ValidationContext, message: str
+) -> str:
+    if context.release_plan_changed is False:
+        return (
+            "Pre-existing release-plan condition: "
+            f"{message} Submit the fix in a dedicated release-plan PR."
+        )
+    return message
+
+
+def _release_history_finding(
+    context: ValidationContext, message: str, suggestion: str
+) -> dict:
+    return make_finding(
+        engine_rule="check-release-plan-published-history",
+        level="error",
+        message=_prefix_pre_existing_release_plan_condition(context, message),
+        path=_RELEASE_PLAN_PATH,
+        line=1,
+        suggestion=suggestion,
+    )
+
+
+def _planned_api_entries(release_plan: dict) -> list[tuple[str, str, str]]:
+    entries: list[tuple[str, str, str]] = []
+    for api in release_plan.get("apis", []):
+        if not isinstance(api, dict):
+            continue
+        api_name = api.get("api_name")
+        api_version = api.get("target_api_version")
+        api_status = api.get("target_api_status")
+        if (
+            isinstance(api_name, str)
+            and isinstance(api_version, str)
+            and isinstance(api_status, str)
+        ):
+            entries.append((api_name, api_version, api_status))
+    return entries
+
+
+def _plan_declares_new_api_content(
+    release_plan: dict, context: ValidationContext
+) -> Optional[bool]:
+    history = context.release_history
+    if history is None:
+        return None
+
+    for api_name, api_version, api_status in _planned_api_entries(release_plan):
+        if (api_version, api_status) not in history.terminal_api_version_statuses(
+            api_name
+        ):
+            if history.may_have_missing_terminal_metadata():
+                return None
+            return True
+    return False
+
+
+def check_release_plan_published_history(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate repository-level release-plan consistency against history."""
+    plan_path = repo_path / _RELEASE_PLAN_PATH
+    release_plan = load_yaml_safe(plan_path)
+    if release_plan is None:
+        return []
+
+    history = context.release_history
+    if history is None:
+        return []
+
+    repo = release_plan.get("repository", {})
+    release_type = repo.get("target_release_type", "none")
+    target_tag = repo.get("target_release_tag")
+
+    # A parked plan (target_release_type: none) only carries forward the last
+    # release.  On a PR that does not touch release-plan.yaml there is no
+    # actionable release-planning finding, so stay silent rather than block
+    # unrelated work.  When the plan IS edited under none, the consistency checks
+    # below still apply: the plan must remain in a shape where flipping the
+    # release type makes it valid.
+    if release_type == "none" and context.release_plan_changed is not True:
+        return []
+
+    if release_type != "none" and not target_tag:
+        return [
+            _release_history_finding(
+                context,
+                f"target_release_tag is required when target_release_type is "
+                f"'{release_type}'.",
+                "Set target_release_tag for the release being prepared, or set "
+                "target_release_type: none when no release is being prepared.",
+            )
+        ]
+
+    if not target_tag:
+        return []
+
+    latest_release = (
+        history.latest_release() if history.release_tags_available() else None
+    )
+    latest_tag = latest_release.tag if latest_release is not None else None
+
+    if (
+        latest_release is not None
+        and latest_release.metadata_available
+        and target_tag == latest_release.tag
+        and _plan_matches_published_release(release_plan, latest_release)
+    ):
+        return []
+
+    published_target = (
+        history.release_by_tag(target_tag) if history.release_tags_available() else None
+    )
+    if (
+        published_target is not None
+        and published_target.metadata_available
+        and _inactive_plan_matches_published_release(release_plan, published_target)
+    ):
+        return []
+
+    if (
+        published_target is not None
+        and published_target.metadata_available
+        and not _plan_matches_published_release(release_plan, published_target)
+    ):
+        return [
+            _release_history_finding(
+                context,
+                f"target_release_tag '{target_tag}' is already published, but "
+                "release-plan.yaml no longer matches that published release. "
+                "Bump target_release_tag or restore the published API entries.",
+                "Restore the release plan to match the published tag, or choose "
+                "the next unpublished target_release_tag for a new release.",
+            )
+        ]
+
+    parsed_target = parse_release_tag(target_tag)
+    parsed_latest = parse_release_tag(latest_tag) if latest_tag else None
+    if (
+        parsed_target is not None
+        and parsed_latest is not None
+        and parsed_target < parsed_latest
+    ):
+        return [
+            _release_history_finding(
+                context,
+                f"target_release_tag '{target_tag}' is lower than latest "
+                f"published release tag '{latest_tag}'.",
+                "Use a target_release_tag greater than the latest published "
+                "release tag for this release line.",
+            )
+        ]
+
+    if (
+        parsed_target is not None
+        and parsed_target.minor == 1
+        and parsed_target.major > 1
+        and history.release_tags_available()
+        and not history.has_cycle(parsed_target.major - 1)
+    ):
+        previous_cycle = f"r{parsed_target.major - 1}.y"
+        return [
+            _release_history_finding(
+                context,
+                f"target_release_tag '{target_tag}' opens release cycle "
+                f"r{parsed_target.major} without any published "
+                f"{previous_cycle} release.",
+                "Publish or target the previous release cycle before opening "
+                "the next cycle.",
+            )
+        ]
+
+    target_metadata_missing = (
+        published_target is not None and not published_target.metadata_available
+    )
+    if release_type != "none" and not target_metadata_missing:
+        new_api_content = _plan_declares_new_api_content(release_plan, context)
+        if new_api_content is False:
+            return [
+                _release_history_finding(
+                    context,
+                    f"target_release_type '{release_type}' cannot start a new "
+                    "release because every planned API entry was already "
+                    "published with the same version and status in a public or "
+                    "maintenance release.",
+                    "Change at least one API entry in a valid way before "
+                    "preparing a new release, or set target_release_type: none "
+                    "if no API publication is intended.",
+                )
+            ]
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# P-036: check-release-plan-terminal-api-status
+# ---------------------------------------------------------------------------
+
+
+def _terminal_api_status_findings(
+    release_plan: dict, context: ValidationContext
+) -> list[dict]:
+    history = context.release_history
+    if history is None:
+        return []
+
+    findings: list[dict] = []
+    for api_name, api_version, api_status in _planned_api_entries(release_plan):
+        terminal_statuses = {
+            status
+            for version, status in history.terminal_api_version_statuses(api_name)
+            if version == api_version
+        }
+        if terminal_statuses and api_status not in terminal_statuses:
+            expected = " or ".join(f"'{status}'" for status in sorted(terminal_statuses))
+            findings.append(
+                make_finding(
+                    engine_rule="check-release-plan-terminal-api-status",
+                    level="error",
+                    message=_prefix_pre_existing_release_plan_condition(
+                        context,
+                        f"API '{api_name}' was already published as version "
+                        f"{api_version}; target_api_status must remain "
+                        f"{expected} for that version.",
+                    ),
+                    path=_RELEASE_PLAN_PATH,
+                    line=1,
+                    api_name=api_name,
+                    suggestion=(
+                        "Keep target_api_status aligned with the published "
+                        "version, or bump target_api_version before changing "
+                        "API status."
+                    ),
+                )
+            )
+    return findings
+
+
+def check_release_plan_terminal_api_status(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Validate status for API versions already in terminal releases."""
+    plan_path = repo_path / _RELEASE_PLAN_PATH
+    release_plan = load_yaml_safe(plan_path)
+    if release_plan is None:
+        return []
+
+    history = context.release_history
+    if history is None:
+        return []
+
+    return _terminal_api_status_findings(release_plan, context)
 
 
 # ---------------------------------------------------------------------------

--- a/validation/orchestrator.py
+++ b/validation/orchestrator.py
@@ -84,6 +84,9 @@ class OrchestratorArgs:
     # empty everywhere else, keeping local/main/working-branch runs offline.
     fallback_canonical_path: str
 
+    # Optional workflow-resolved published release history for P-035+.
+    release_history_path: str
+
     # Optional workflow-resolved active release state for P-033.
     active_release_state: str
     active_release_snapshot_branch: str
@@ -174,6 +177,7 @@ def parse_args() -> OrchestratorArgs:
         output_dir=Path(_env("OUTPUT_DIR", "validation-output")),
         config_path=_env("CONFIG_PATH"),
         fallback_canonical_path=_env("FALLBACK_CANONICAL_PATH"),
+        release_history_path=_env("RELEASE_HISTORY_PATH"),
         active_release_state=_env("ACTIVE_RELEASE_STATE"),
         active_release_snapshot_branch=_env("ACTIVE_RELEASE_SNAPSHOT_BRANCH"),
         active_release_issue_number=_env_optional_int("ACTIVE_RELEASE_ISSUE_NUMBER"),
@@ -547,6 +551,11 @@ def main() -> int:
         icm_tag_exists=args.icm_tag_exists,
         non_release_plan_files_changed=args.non_release_plan_files_changed,
         fallback_canonical_path=args.fallback_canonical_path or None,
+        release_history_path=(
+            Path(args.release_history_path)
+            if args.release_history_path
+            else None
+        ),
         active_release_state=args.active_release_state,
         active_release_snapshot_branch=args.active_release_snapshot_branch,
         active_release_issue_number=args.active_release_issue_number,

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -539,3 +539,28 @@
   suggestion: >-
     Keep exactly one entry for each api_name. If the plan needs a fix,
     submit a dedicated release-plan PR.
+
+# P-035: check-release-plan-published-history
+# Repository-level release-plan consistency against workflow-resolved
+# published release metadata.
+- id: P-035
+  engine: python
+  engine_rule: check-release-plan-published-history
+  short_title: "release-plan must move forward from published history"
+  release_plan_check_only_safe: true
+  conditional_level:
+    default: error
+
+# P-036: check-release-plan-terminal-api-status
+# API versions already published in public or maintenance releases must keep
+# their published status if the same version appears again.
+- id: P-036
+  engine: python
+  engine_rule: check-release-plan-terminal-api-status
+  short_title: "published API versions must keep their status"
+  release_plan_check_only_safe: true
+  conditional_level:
+    default: error
+  suggestion: >-
+    Keep target_api_status aligned with the published version, or bump
+    target_api_version before changing API status.

--- a/validation/scripts/resolve-release-history.py
+++ b/validation/scripts/resolve-release-history.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Resolve published release history for offline validation rules.
+
+The workflow owns GitHub access.  This script uses the release automation
+GitHub client to read published releases and their release-metadata.yaml, then
+writes a compact JSON snapshot consumed by validation.orchestrator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+TOOLING_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(TOOLING_ROOT))
+
+from release_automation.scripts.github_client import GitHubClient, GitHubClientError
+
+
+def _metadata_release(release, metadata: dict[str, Any] | None) -> dict[str, Any]:
+    repo = metadata.get("repository", {}) if isinstance(metadata, dict) else {}
+    apis = metadata.get("apis", []) if isinstance(metadata, dict) else []
+    return {
+        "tag": release.tag_name,
+        "release_type": str(repo.get("release_type") or ""),
+        "prerelease": bool(release.prerelease),
+        "published_at": "",
+        "src_commit_sha": str(repo.get("src_commit_sha") or ""),
+        "metadata_available": isinstance(metadata, dict),
+        "apis": [
+            {
+                "api_name": str(api.get("api_name") or ""),
+                "api_version": str(api.get("api_version") or ""),
+                "api_file_name": str(api.get("api_file_name") or ""),
+            }
+            for api in apis
+            if isinstance(api, dict)
+            and api.get("api_name")
+            and api.get("api_version")
+        ],
+    }
+
+
+def resolve_history(
+    *,
+    repo: str,
+    base_ref: str,
+    token: str | None = None,
+) -> dict[str, Any]:
+    client = GitHubClient(repo=repo, token=token)
+    lookup_status = "complete"
+    published_releases: list[dict[str, Any]] = []
+
+    # Contract for the consumer (validation.context.release_history): a "partial"
+    # snapshot never truncates the release list.  Partial means either the whole
+    # listing failed (empty published_releases) or per-tag metadata was
+    # unavailable (release entries present, metadata_available False).  The tag
+    # list itself is always complete, so tag-only checks may rely on it while
+    # metadata-dependent checks must guard on metadata_available.
+    try:
+        releases = client.get_releases(include_drafts=False)
+    except GitHubClientError as exc:
+        return {
+            "schema_version": 1,
+            "repository": repo,
+            "base_ref": base_ref,
+            "lookup_status": "partial",
+            "lookup_error": str(exc),
+            "published_releases": [],
+        }
+
+    for release in releases:
+        try:
+            metadata = client.get_release_metadata(release.tag_name)
+        except GitHubClientError:
+            metadata = None
+            lookup_status = "partial"
+        if metadata is None:
+            lookup_status = "partial"
+        published_releases.append(_metadata_release(release, metadata))
+
+    return {
+        "schema_version": 1,
+        "repository": repo,
+        "base_ref": base_ref,
+        "lookup_status": lookup_status,
+        "history_scope": {
+            "selection": "published-releases",
+        },
+        "published_releases": published_releases,
+    }
+
+
+def write_outputs(outputs: dict[str, str], target: Path | None) -> None:
+    if target is None:
+        for key, value in outputs.items():
+            print(f"{key}={value}")
+        return
+    with target.open("a", encoding="utf-8") as fh:
+        for key, value in outputs.items():
+            fh.write(f"{key}={value}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+        help="Repository in owner/name form (default: $GITHUB_REPOSITORY).",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default=os.environ.get("GITHUB_BASE_REF", "main"),
+        help="Base ref being validated.",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Path to write release-history JSON. Defaults to RUNNER_TEMP.",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT", ""),
+        help="Path to the GITHUB_OUTPUT file.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        print("::warning::Release-history lookup skipped: repository is unknown")
+        return 0
+
+    output_path = (
+        Path(args.output)
+        if args.output
+        else Path(os.environ.get("RUNNER_TEMP", ".")) / "release-history.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    snapshot = resolve_history(
+        repo=args.repo,
+        base_ref=args.base_ref,
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+    )
+    output_path.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
+
+    write_outputs(
+        {"release_history_path": str(output_path)},
+        Path(args.github_output) if args.github_output else None,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/tests/test_context_builder.py
+++ b/validation/tests/test_context_builder.py
@@ -1,5 +1,6 @@
 """Unit tests for validation.context.context_builder."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -246,6 +247,7 @@ class TestValidationContextToDict:
             "non_release_plan_files_changed",
             "fallback_canonical_path",
             "active_release_state",
+            "release_history",
         }
         assert set(d.keys()) == expected_keys
 
@@ -280,6 +282,37 @@ METADATA_SCHEMA = SCHEMAS_DIR / "release-metadata-schema.yaml"
 
 def _write_yaml(path: Path, data) -> Path:
     path.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return path
+
+
+def _write_release_history(path: Path) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "repository": "camaraproject/QualityOnDemand",
+                "base_ref": "main",
+                "lookup_status": "complete",
+                "published_releases": [
+                    {
+                        "tag": "r4.2",
+                        "release_type": "public-release",
+                        "prerelease": False,
+                        "published_at": "2026-01-15T00:00:00Z",
+                        "src_commit_sha": "a" * 40,
+                        "metadata_available": True,
+                        "apis": [
+                            {
+                                "api_name": "quality-on-demand",
+                                "api_version": "1.0.0",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
     return path
 
 
@@ -336,6 +369,32 @@ class TestBuildValidationContextMetadataFallback:
         assert ctx.active_release_state.state == "planned"
         assert ctx.active_release_state.snapshot_branch == "release-snapshot/r4.3-abc1234"
         assert ctx.active_release_state.release_issue_number == 23
+
+    def test_release_history_path_populates_context(self, tmp_path: Path):
+        history_path = _write_release_history(tmp_path / "release-history.json")
+
+        ctx = build_validation_context(
+            repo_name="camaraproject/QualityOnDemand",
+            event_name="pull_request",
+            ref_name="feature/release-plan",
+            base_ref="main",
+            release_history_path=history_path,
+        )
+
+        assert ctx.release_history is not None
+        assert ctx.release_history.lookup_status == "complete"
+        assert ctx.release_history.latest_release().tag == "r4.2"
+
+    def test_missing_release_history_path_leaves_context_empty(self, tmp_path: Path):
+        ctx = build_validation_context(
+            repo_name="camaraproject/QualityOnDemand",
+            event_name="pull_request",
+            ref_name="feature/release-plan",
+            base_ref="main",
+            release_history_path=tmp_path / "missing-history.json",
+        )
+
+        assert ctx.release_history is None
 
     def test_fallback_populates_context(self, repo_with_metadata):
         ctx = build_validation_context(

--- a/validation/tests/test_orchestrator.py
+++ b/validation/tests/test_orchestrator.py
@@ -40,6 +40,12 @@ def args():
         repo_path=Path("/repo"),
         tooling_path=Path("/tooling"),
         output_dir=Path("/output"),
+        config_path="",
+        fallback_canonical_path="",
+        active_release_state="",
+        active_release_snapshot_branch="",
+        active_release_issue_number=None,
+        release_history_path="",
         repo_name="camaraproject/QualityOnDemand",
         repo_owner="camaraproject",
         event_name="pull_request",
@@ -144,6 +150,7 @@ class TestParseArgs:
         assert result.tooling_path == Path(".tooling")
         assert result.output_dir == Path("validation-output")
         assert result.config_path == ""
+        assert result.release_history_path == ""
         assert result.active_release_state == ""
         assert result.active_release_snapshot_branch == ""
         assert result.active_release_issue_number is None
@@ -157,6 +164,7 @@ class TestParseArgs:
             "VALIDATION_TOOLING_PATH": "/my/tooling",
             "VALIDATION_OUTPUT_DIR": "/my/output",
             "VALIDATION_CONFIG_PATH": "/my/runner/.tooling-config/config/validation-settings.yaml",
+            "VALIDATION_RELEASE_HISTORY_PATH": "/my/repo/validation-output/release-history.json",
             "VALIDATION_ACTIVE_RELEASE_STATE": "snapshot-active",
             "VALIDATION_ACTIVE_RELEASE_SNAPSHOT_BRANCH": "release-snapshot/r4.3-abc1234",
             "VALIDATION_ACTIVE_RELEASE_ISSUE_NUMBER": "23",
@@ -178,6 +186,7 @@ class TestParseArgs:
         assert result.repo_path == Path("/my/repo")
         assert result.repo_name == "camaraproject/QoD"
         assert result.config_path == "/my/runner/.tooling-config/config/validation-settings.yaml"
+        assert result.release_history_path == "/my/repo/validation-output/release-history.json"
         assert result.active_release_state == "snapshot-active"
         assert result.active_release_snapshot_branch == "release-snapshot/r4.3-abc1234"
         assert result.active_release_issue_number == 23

--- a/validation/tests/test_python_checks_release_plan.py
+++ b/validation/tests/test_python_checks_release_plan.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from validation.context import ActiveReleaseState, ApiContext, ValidationContext
+from validation.context.release_history import parse_release_history
 from validation.engines.python_checks.release_plan_checks import (
     ALLOWED_META_RELEASES,
     _check_file_existence,
@@ -19,7 +20,9 @@ from validation.engines.python_checks.release_plan_checks import (
     check_release_plan_active_release_state,
     check_release_plan_api_names_unique,
     check_release_plan_exclusivity,
+    check_release_plan_published_history,
     check_release_plan_semantics,
+    check_release_plan_terminal_api_status,
 )
 
 
@@ -59,12 +62,15 @@ def _make_plan(
     release_track: str = "meta-release",
     meta_release: str | None = "Spring26",
     target_release_type: str = "public-release",
+    target_release_tag: str | None = "r4.3",
     apis: list[dict] | None = None,
 ) -> dict:
     repo: dict = {
         "release_track": release_track,
         "target_release_type": target_release_type,
     }
+    if target_release_tag is not None:
+        repo["target_release_tag"] = target_release_tag
     if meta_release is not None:
         repo["meta_release"] = meta_release
     if apis is None:
@@ -318,6 +324,754 @@ class TestCheckReleasePlanApiNamesUnique:
             "Pre-existing release-plan condition:"
         )
         assert "dedicated release-plan PR" in findings[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# TestCheckReleasePlanPublishedHistory (P-035)
+# ---------------------------------------------------------------------------
+
+
+def _published_release(
+    tag: str,
+    *,
+    release_type: str = "public-release",
+    apis: list[dict] | None = None,
+    metadata_available: bool = True,
+) -> dict:
+    if apis is None:
+        apis = [
+            {
+                "api_name": "quality-on-demand",
+                "api_version": "1.0.0",
+                "api_file_name": "quality-on-demand",
+            }
+        ]
+    return {
+        "tag": tag,
+        "release_type": release_type,
+        "prerelease": release_type.startswith("pre-release"),
+        "published_at": "2026-01-15T00:00:00Z",
+        "src_commit_sha": "a" * 40,
+        "metadata_available": metadata_available,
+        "apis": apis if metadata_available else [],
+    }
+
+
+def _release_history(
+    *releases: dict,
+    lookup_status: str = "complete",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "repository": "camaraproject/QualityOnDemand",
+        "base_ref": "main",
+        "lookup_status": lookup_status,
+        "published_releases": list(releases),
+    }
+
+
+def _context_with_release_history(
+    history: dict,
+    *,
+    release_plan_changed: bool | None = True,
+) -> ValidationContext:
+    return dataclasses.replace(
+        _make_context(),
+        release_plan_changed=release_plan_changed,
+        release_history=parse_release_history(history),
+    )
+
+
+class TestCheckReleasePlanPublishedHistory:
+    def test_no_release_plan(self, tmp_path: Path):
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_absent_history_skips(self, tmp_path: Path):
+        _write_release_plan(tmp_path, _make_plan(target_release_tag="r4.3"))
+
+        assert check_release_plan_published_history(tmp_path, _make_context()) == []
+
+    def test_partial_history_tag_regression_still_errors_when_tags_available(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release("r4.2", metadata_available=False),
+                _published_release("r4.3", metadata_available=False),
+                lookup_status="partial",
+            )
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "lower than latest published release tag 'r4.3'" in findings[0]["message"]
+
+    def test_partial_history_missing_target_metadata_skips_tag_mismatch(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.1.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release("r4.2", metadata_available=False),
+                lookup_status="partial",
+            )
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_parked_after_publish_matching_latest_release_skips(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.1"), _published_release("r4.2"))
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_not_planning_new_release_keeps_published_plan_quiet(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                target_release_type="none",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.1"), _published_release("r4.2"))
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_existing_published_tag_with_changed_api_entries_errors(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.1.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-release-plan-published-history"
+        assert "target_release_tag 'r4.2' is already published" in findings[0]["message"]
+
+    def test_tag_regression_errors(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"), _published_release("r4.3"))
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "lower than latest published release tag 'r4.3'" in findings[0]["message"]
+
+    def test_cycle_opening_without_previous_cycle_errors(self, tmp_path: Path):
+        _write_release_plan(tmp_path, _make_plan(target_release_tag="r4.1"))
+        context = _context_with_release_history(
+            _release_history(_published_release("r2.4"))
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "opens release cycle r4 without any published r3.y release" in findings[0]["message"]
+
+    def test_null_tag_with_non_none_release_type_errors(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag=None,
+                target_release_type="public-release",
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "target_release_tag is required" in findings[0]["message"]
+
+    def test_type_none_with_tag_is_allowed(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="none",
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_public_release_without_new_api_content_errors(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "cannot start a new release" in findings[0]["message"]
+
+    def test_partial_history_missing_terminal_metadata_skips_no_new_content(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release("r4.2", metadata_available=False),
+                lookup_status="partial",
+            )
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_public_release_after_alpha_history_counts_as_new_content(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "qos-profiles",
+                        "target_api_status": "public",
+                        "target_api_version": "1.2.0",
+                    },
+                    {
+                        "api_name": "qos-provisioning",
+                        "target_api_status": "public",
+                        "target_api_version": "0.4.0",
+                    },
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.2.0",
+                    },
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release(
+                    "r3.2",
+                    apis=[
+                        {
+                            "api_name": "qos-profiles",
+                            "api_version": "1.1.0",
+                        },
+                        {
+                            "api_name": "qos-provisioning",
+                            "api_version": "0.3.0",
+                        },
+                        {
+                            "api_name": "quality-on-demand",
+                            "api_version": "1.1.0",
+                        },
+                    ],
+                ),
+                _published_release(
+                    "r4.1",
+                    release_type="pre-release-alpha",
+                    apis=[
+                        {
+                            "api_name": "qos-profiles",
+                            "api_version": "1.2.0-alpha.1",
+                        },
+                        {
+                            "api_name": "qos-provisioning",
+                            "api_version": "0.4.0-alpha.1",
+                        },
+                        {
+                            "api_name": "quality-on-demand",
+                            "api_version": "1.2.0-alpha.1",
+                        },
+                    ],
+                ),
+            )
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_pre_release_alpha_with_only_published_public_content_errors(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                target_release_type="pre-release-alpha",
+                apis=[
+                    {
+                        "api_name": "qos-profiles",
+                        "target_api_status": "public",
+                        "target_api_version": "1.1.0",
+                    },
+                    {
+                        "api_name": "qos-provisioning",
+                        "target_api_status": "public",
+                        "target_api_version": "0.3.0",
+                    },
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.1.0",
+                    },
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release(
+                    "r3.2",
+                    apis=[
+                        {
+                            "api_name": "qos-profiles",
+                            "api_version": "1.1.0",
+                        },
+                        {
+                            "api_name": "qos-provisioning",
+                            "api_version": "0.3.0",
+                        },
+                        {
+                            "api_name": "quality-on-demand",
+                            "api_version": "1.1.0",
+                        },
+                    ],
+                )
+            )
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "cannot start a new release" in findings[0]["message"]
+        assert "Change at least one API entry in a valid way" in findings[0]["suggestion"]
+
+    def test_pre_release_rc_after_rc_history_counts_as_new_content(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="pre-release-rc",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "rc",
+                        "target_api_version": "1.2.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release(
+                    "r4.2",
+                    release_type="pre-release-rc",
+                    apis=[
+                        {
+                            "api_name": "quality-on-demand",
+                            "api_version": "1.2.0-rc.1",
+                        }
+                    ],
+                )
+            )
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_pre_existing_history_condition_prefixes_message(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2")),
+            release_plan_changed=False,
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert findings[0]["message"].startswith(
+            "Pre-existing release-plan condition:"
+        )
+        assert "dedicated release-plan PR" in findings[0]["message"]
+
+    def test_none_unrelated_pr_silences_history_findings(self, tmp_path: Path):
+        # Parked plan, PR did not touch release-plan.yaml: stay silent even
+        # though target_release_tag r4.1 would regress against latest r4.3.
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.1",
+                target_release_type="none",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"), _published_release("r4.3")),
+            release_plan_changed=False,
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_none_changed_tag_regression_errors(self, tmp_path: Path):
+        # Same parked plan, but the PR edits release-plan.yaml: a regressing tag
+        # must not be merged regardless of target_release_type.
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.1",
+                target_release_type="none",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"), _published_release("r4.3")),
+            release_plan_changed=True,
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "lower than latest published release tag 'r4.3'" in findings[0]["message"]
+
+    def test_none_changed_entries_differ_from_published_tag_errors(
+        self, tmp_path: Path
+    ):
+        # Editing a none plan to disagree with the published tag is an error: the
+        # plan must stay in a shape where flipping the release type is valid.
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                target_release_type="none",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.1.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2")),
+            release_plan_changed=True,
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert "target_release_tag 'r4.2' is already published" in findings[0]["message"]
+
+
+class TestCheckReleasePlanTerminalApiStatus:
+    def test_matching_published_release_plan_has_no_history_findings(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+        assert check_release_plan_terminal_api_status(tmp_path, context) == []
+
+    def test_none_unrelated_pr_still_locks_terminal_api_status(self, tmp_path: Path):
+        # P-036 is a factual invariant about a published version: it fires
+        # regardless of target_release_type and regardless of whether the PR
+        # touched release-plan.yaml.
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.2",
+                target_release_type="none",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "alpha",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2")),
+            release_plan_changed=False,
+        )
+
+        findings = check_release_plan_terminal_api_status(tmp_path, context)
+
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-release-plan-terminal-api-status"
+        assert "target_api_status must remain 'public'" in findings[0]["message"]
+
+    def test_no_release_plan(self, tmp_path: Path):
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+        assert check_release_plan_terminal_api_status(tmp_path, context) == []
+
+    def test_absent_history_skips(self, tmp_path: Path):
+        _write_release_plan(tmp_path, _make_plan(target_release_tag="r4.3"))
+
+        assert check_release_plan_terminal_api_status(tmp_path, _make_context()) == []
+
+    def test_partial_history_with_relevant_terminal_metadata_errors(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="pre-release-rc",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "rc",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release("r4.2"),
+                _published_release("r4.3", metadata_available=False),
+                lookup_status="partial",
+            )
+        )
+
+        findings = check_release_plan_terminal_api_status(tmp_path, context)
+
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-release-plan-terminal-api-status"
+        assert "target_api_status must remain 'public'" in findings[0]["message"]
+
+    def test_partial_history_missing_terminal_metadata_skips_status_lock(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="pre-release-rc",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "rc",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(
+                _published_release("r4.2", metadata_available=False),
+                lookup_status="partial",
+            )
+        )
+
+        assert check_release_plan_terminal_api_status(tmp_path, context) == []
+
+    def test_terminal_published_version_with_different_status_errors(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="pre-release-rc",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "rc",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+
+        findings = check_release_plan_terminal_api_status(tmp_path, context)
+
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-release-plan-terminal-api-status"
+        assert findings[0]["api_name"] == "quality-on-demand"
+        assert "API 'quality-on-demand' was already published as version 1.0.0" in (
+            findings[0]["message"]
+        )
+        assert "target_api_status must remain 'public'" in findings[0]["message"]
+        assert "Keep target_api_status aligned" in findings[0]["suggestion"]
+
+    def test_matching_terminal_status_is_allowed(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                target_release_tag="r4.3",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2"))
+        )
+
+        assert check_release_plan_terminal_api_status(tmp_path, context) == []
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_release_automation_workflow.py
+++ b/validation/tests/test_release_automation_workflow.py
@@ -1,0 +1,49 @@
+"""Static checks for release automation workflow wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "release-automation-reusable.yml"
+)
+
+
+def _create_snapshot_steps() -> list[dict]:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["create-snapshot"]["steps"]
+
+
+def _step_by_name(steps: list[dict], name: str) -> dict:
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"step not found: {name}")
+
+
+def test_create_snapshot_passes_release_history_to_pre_snapshot_validation():
+    steps = _create_snapshot_steps()
+    names = [step.get("name") for step in steps]
+
+    assert "Resolve published release history" in names
+    assert names.index("Resolve published release history") < names.index(
+        "Run pre-snapshot validation"
+    )
+
+    resolver = _step_by_name(steps, "Resolve published release history")
+    assert resolver["id"] == "release-history"
+    assert "GH_TOKEN" in resolver["env"]
+    assert "_tooling/validation/scripts/resolve-release-history.py" in resolver["run"]
+    assert '--repo "${{ github.repository }}"' in resolver["run"]
+    assert '--output "${RUNNER_TEMP}/release-history.json"' in resolver["run"]
+
+    validation = _step_by_name(steps, "Run pre-snapshot validation")
+    assert validation["with"]["release_history_path"] == (
+        "${{ steps.release-history.outputs.release_history_path || '' }}"
+    )

--- a/validation/tests/test_release_history.py
+++ b/validation/tests/test_release_history.py
@@ -1,0 +1,155 @@
+"""Unit tests for validation.context.release_history."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from validation.context.release_history import (
+    load_release_history,
+    normalize_api_version_base,
+    parse_release_history,
+    parse_release_tag,
+)
+
+
+def _history_payload(**overrides) -> dict:
+    payload = {
+        "schema_version": 1,
+        "repository": "camaraproject/QualityOnDemand",
+        "base_ref": "main",
+        "lookup_status": "complete",
+        "published_releases": [
+            {
+                "tag": "r4.2",
+                "release_type": "public-release",
+                "prerelease": False,
+                "published_at": "2026-01-15T00:00:00Z",
+                "src_commit_sha": "a" * 40,
+                "metadata_available": True,
+                "apis": [
+                    {
+                        "api_name": "quality-on-demand",
+                        "api_version": "1.0.0",
+                        "api_file_name": "quality-on-demand",
+                    },
+                    {
+                        "api_name": "quality-on-demand",
+                        "api_version": "1.1.0-rc.1",
+                        "api_file_name": "quality-on-demand",
+                    }
+                ],
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_parse_release_tag_orders_camara_tags():
+    assert parse_release_tag("r4.10") > parse_release_tag("r4.2")
+    assert parse_release_tag("r5.1") > parse_release_tag("r4.99")
+    assert parse_release_tag("not-a-release") is None
+
+
+def test_normalize_api_version_base_strips_release_extensions():
+    assert normalize_api_version_base("1.2.3-alpha.4") == "1.2.3"
+    assert normalize_api_version_base("1.2.3-rc.1") == "1.2.3"
+    assert normalize_api_version_base("1.2.3") == "1.2.3"
+
+
+def test_parse_complete_history_snapshot():
+    snapshot = parse_release_history(_history_payload())
+
+    assert snapshot is not None
+    assert snapshot.lookup_status == "complete"
+    assert snapshot.latest_release().tag == "r4.2"
+    assert snapshot.release_by_tag("r4.2").apis[0].api_name == "quality-on-demand"
+
+
+def test_terminal_api_version_statuses_use_only_public_or_maintenance_releases():
+    snapshot = parse_release_history(
+        _history_payload(
+            published_releases=[
+                {
+                    "tag": "r4.2",
+                    "release_type": "public-release",
+                    "metadata_available": True,
+                    "apis": [
+                        {
+                            "api_name": "quality-on-demand",
+                            "api_version": "1.0.0",
+                        }
+                    ],
+                },
+                {
+                    "tag": "r4.3",
+                    "release_type": "pre-release-alpha",
+                    "metadata_available": True,
+                    "apis": [
+                        {
+                            "api_name": "quality-on-demand",
+                            "api_version": "1.1.0-alpha.1",
+                        }
+                    ],
+                },
+            ]
+        )
+    )
+
+    assert snapshot is not None
+    assert snapshot.terminal_api_version_statuses("quality-on-demand") == {
+        ("1.0.0", "public")
+    }
+
+
+def test_partial_history_with_release_entries_has_tag_coverage():
+    snapshot = parse_release_history(
+        _history_payload(
+            lookup_status="partial",
+            published_releases=[
+                {
+                    "tag": "r4.2",
+                    "release_type": "",
+                    "prerelease": False,
+                    "metadata_available": False,
+                    "apis": [],
+                }
+            ],
+        )
+    )
+
+    assert snapshot is not None
+    assert snapshot.release_tags_available() is True
+    assert snapshot.may_have_missing_terminal_metadata() is True
+
+
+def test_partial_history_without_release_entries_has_no_tag_coverage():
+    snapshot = parse_release_history(
+        _history_payload(lookup_status="partial", published_releases=[])
+    )
+
+    assert snapshot is not None
+    assert snapshot.release_tags_available() is False
+    assert snapshot.may_have_missing_terminal_metadata() is False
+
+
+def test_load_release_history_missing_path_returns_none(tmp_path: Path):
+    assert load_release_history(tmp_path / "missing.json") is None
+
+
+def test_load_release_history_invalid_json_returns_none(tmp_path: Path):
+    path = tmp_path / "history.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    assert load_release_history(path) is None
+
+
+def test_load_release_history_from_file(tmp_path: Path):
+    path = tmp_path / "history.json"
+    path.write_text(json.dumps(_history_payload()), encoding="utf-8")
+
+    snapshot = load_release_history(path)
+
+    assert snapshot is not None
+    assert snapshot.repository == "camaraproject/QualityOnDemand"

--- a/validation/tests/test_resolve_release_history.py
+++ b/validation/tests/test_resolve_release_history.py
@@ -1,0 +1,133 @@
+"""Unit tests for validation/scripts/resolve-release-history.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from release_automation.scripts.github_client import GitHubClientError
+
+# validation/scripts/ is not a package — load the module directly.
+_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _ROOT / "validation" / "scripts" / "resolve-release-history.py"
+_spec = importlib.util.spec_from_file_location("resolve_release_history", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+resolve_release_history = importlib.util.module_from_spec(_spec)
+sys.modules["resolve_release_history"] = resolve_release_history
+_spec.loader.exec_module(resolve_release_history)
+
+
+resolve_history = resolve_release_history.resolve_history
+write_outputs = resolve_release_history.write_outputs
+
+
+def _release(tag: str, prerelease: bool = False):
+    return SimpleNamespace(tag_name=tag, prerelease=prerelease)
+
+
+def test_resolve_history_writes_complete_metadata(monkeypatch):
+    class FakeClient:
+        def __init__(self, repo, token=None):
+            self.repo = repo
+            self.token = token
+
+        def get_releases(self, include_drafts=False):
+            return [_release("r4.2")]
+
+        def get_release_metadata(self, tag):
+            assert tag == "r4.2"
+            return {
+                "repository": {
+                    "release_type": "public-release",
+                    "src_commit_sha": "a" * 40,
+                },
+                "apis": [
+                    {
+                        "api_name": "quality-on-demand",
+                        "api_version": "1.0.0",
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(resolve_release_history, "GitHubClient", FakeClient)
+
+    snapshot = resolve_history(
+        repo="camaraproject/QualityOnDemand",
+        base_ref="main",
+        token="token",
+    )
+
+    assert snapshot["lookup_status"] == "complete"
+    assert snapshot["repository"] == "camaraproject/QualityOnDemand"
+    assert snapshot["published_releases"][0]["tag"] == "r4.2"
+    assert snapshot["published_releases"][0]["metadata_available"] is True
+    assert snapshot["published_releases"][0]["apis"][0]["api_name"] == "quality-on-demand"
+
+
+def test_resolve_history_marks_partial_when_metadata_lookup_fails(monkeypatch):
+    class FakeClient:
+        def __init__(self, repo, token=None):
+            pass
+
+        def get_releases(self, include_drafts=False):
+            return [_release("r4.2")]
+
+        def get_release_metadata(self, tag):
+            raise GitHubClientError("boom")
+
+    monkeypatch.setattr(resolve_release_history, "GitHubClient", FakeClient)
+
+    snapshot = resolve_history(repo="camaraproject/QualityOnDemand", base_ref="main")
+
+    assert snapshot["lookup_status"] == "partial"
+    assert snapshot["published_releases"][0]["metadata_available"] is False
+    assert snapshot["published_releases"][0]["apis"] == []
+
+
+def test_resolve_history_marks_partial_when_metadata_is_absent(monkeypatch):
+    class FakeClient:
+        def __init__(self, repo, token=None):
+            pass
+
+        def get_releases(self, include_drafts=False):
+            return [_release("r4.2")]
+
+        def get_release_metadata(self, tag):
+            return None
+
+    monkeypatch.setattr(resolve_release_history, "GitHubClient", FakeClient)
+
+    snapshot = resolve_history(repo="camaraproject/QualityOnDemand", base_ref="main")
+
+    assert snapshot["lookup_status"] == "partial"
+    assert snapshot["published_releases"][0]["metadata_available"] is False
+
+
+def test_write_outputs_appends_github_output(tmp_path: Path):
+    output = tmp_path / "github-output.txt"
+
+    write_outputs({"release_history_path": "/tmp/history.json"}, output)
+
+    assert output.read_text(encoding="utf-8") == (
+        "release_history_path=/tmp/history.json\n"
+    )
+
+
+def test_script_imports_from_outside_tooling_root(tmp_path: Path):
+    env = {**os.environ, "PYTHONPATH": "", "GITHUB_REPOSITORY": ""}
+
+    result = subprocess.run(
+        [sys.executable, str(_MODULE_PATH)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Release-history lookup skipped" in result.stdout

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -88,7 +88,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 33
+        assert counts["python"] == 35
         assert counts["spectral"] == 86
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -353,8 +353,8 @@ class TestMetadataQuality:
         """
         with_suggestions = [r.id for r in all_rules if r.suggestion is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_suggestions) == 24, (
-            f"Expected 24 explicit suggestions (update test if adding "
+        assert len(with_suggestions) == 25, (
+            f"Expected 25 explicit suggestions (update test if adding "
             f"suggestions): {with_suggestions}"
         )
         assert len(with_overrides) == 0, (


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds two release-plan validation rules that check `release-plan.yaml` against the
repository's published release history, so version/status/tag mistakes are caught at
PR time and before `/create-snapshot` instead of during release review.

- **P-035 — repository-level published-history consistency.** Flags a missing tag for
  an active release type, a published tag whose API entries were changed without a
  bump, a tag regression, a cycle opened with no previous cycle, and a release that
  declares no new API content. It is silent for a parked `target_release_type: none`
  plan on a PR that does not touch `release-plan.yaml`, and reports a pre-existing
  condition on unrelated PRs with a suggestion to fix it in a dedicated release-plan
  PR.
- **P-036 — per-API terminal published version/status.** Once an API version is
  published in a public or maintenance release, that version cannot reappear with a
  different status (e.g. an already-public `1.1.0` declared `alpha`). This is an
  invariant, so it applies regardless of `target_release_type`.

#### Which issue(s) this PR fixes:

Part of #232. The issue tracks several rule families; content-drift and
maintenance-release rules remain follow-up work, so this PR does not close it.

#### Special notes for reviewers:

- Offline by design: a workflow step resolves published releases into a compact
  release-history JSON (`release_history_path` / `VALIDATION_RELEASE_HISTORY_PATH`),
  resolved on both the PR and `/create-snapshot` paths, so the Python orchestrator makes
  no GitHub calls. It runs whenever `release-plan.yaml` is present (not only when it
  changed) — which is what lets the rules surface pre-existing conditions on unrelated
  PRs — and partial history runs tag-only checks while skipping metadata-dependent
  conclusions.
- New rule IDs P-035 and P-036; both carry `release_plan_check_only_safe: true` so they
  survive release-plan-only dependency-advance PRs.
- Validated with the full validation test suite and end-to-end against a test repo:
  duplicate / stale / regressing plans fail as expected, a parked `none` plan passes,
  and `/create-snapshot` gates before snapshot creation on a P-036 condition.

#### Changelog input

```
release-note
Add release-plan published-history validation: P-035 (repository-level history consistency) and P-036 (per-API terminal published version/status lock).
```

#### Additional documentation

This section can be blank.

```
docs

```
