### PR TITLE
feat(validation): add YAML parser conformance warning

### DIFF
--- a/documentation/validation/faq.md
+++ b/documentation/validation/faq.md
@@ -45,6 +45,29 @@ The check may not follow every discriminator mapping. A component that looks unu
 
 </details>
 
+<a name="p-037-yaml-parser-conformance"></a>
+<details>
+<summary>[P-037] Why does YAML parser conformance fail when yamllint passes?</summary>
+
+Applies to: `[P-037] OpenAPI YAML fails parser conformance`
+
+This rule parses each OpenAPI YAML definition with a YAML parser used by
+common JavaScript tooling. It can report a problem even when yamllint, PyYAML,
+or Spectral accepted the same file, because those tools do not all use the same
+YAML parser or the same strictness level.
+
+The message includes the first parser error reported for the file, with the
+source line and column. For example, `deficient indentation` usually means that
+a construct such as a flow mapping or quoted multiline scalar is indented in a
+way that tolerant parsers accepted but stricter YAML parsers reject.
+
+**What you do:** open the reported API definition file at the line shown in the
+message and rewrite the YAML in plain block style. Keep the data unchanged; the
+fix is normally just formatting the affected mapping or scalar so stricter YAML
+parsers can load it.
+
+</details>
+
 ## Test definition problems
 
 <a name="p-006-missing-test-files"></a>

--- a/documentation/validation/faq.md
+++ b/documentation/validation/faq.md
@@ -61,10 +61,17 @@ source line and column. For example, `deficient indentation` usually means that
 a construct such as a flow mapping or quoted multiline scalar is indented in a
 way that tolerant parsers accepted but stricter YAML parsers reject.
 
+YAML flow style is sometimes called "JSON-like" because it uses `{}`, `[]`,
+colons, and commas. It is still YAML syntax, not strict JSON syntax. For
+example, YAML flow collections can allow constructs that JSON does not, while
+multiline flow collections still interact with YAML indentation rules. To avoid
+parser portability problems in OpenAPI examples, prefer plain block-style YAML
+over JSON-like flow-style mappings or sequences.
+
 **What you do:** open the reported API definition file at the line shown in the
 message and rewrite the YAML in plain block style. Keep the data unchanged; the
-fix is normally just formatting the affected mapping or scalar so stricter YAML
-parsers can load it.
+fix is normally just formatting the affected mapping, sequence, or scalar so
+stricter YAML parsers can load it.
 
 </details>
 

--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -43,6 +43,7 @@ from .version_checks import (
     check_server_url_api_name,
     check_server_url_version,
 )
+from .yaml_parser_conformance_checks import check_yaml_parser_conformance
 
 # Ordered registry.  Execution order matches this list.
 # Adding a new check: import the function and append a CheckDescriptor.
@@ -63,6 +64,7 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-cloudevent-via-ref", CheckScope.API, check_cloudevent_via_ref),
     CheckDescriptor("check-conflict-deprecated", CheckScope.API, check_conflict_deprecated),
     CheckDescriptor("check-contextcode-format", CheckScope.API, check_contextcode_format),
+    CheckDescriptor("check-yaml-parser-conformance", CheckScope.API, check_yaml_parser_conformance),
     CheckDescriptor(
         "check-info-description-mandatory-missing",
         CheckScope.API,

--- a/validation/engines/python_checks/yaml_parser_conformance_checks.py
+++ b/validation/engines/python_checks/yaml_parser_conformance_checks.py
@@ -1,0 +1,112 @@
+"""YAML parser conformance check.
+
+Runs an explicit ``js-yaml@5`` parser probe for the current API definition file
+and reports parser failures as advisory Validation findings.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import List
+
+from validation.context import ValidationContext
+
+from ._types import make_finding
+
+_ENGINE_RULE = "check-yaml-parser-conformance"
+_EXECUTION_ERROR_RULE = "yaml-parser-conformance-execution-error"
+_VALIDATION_ROOT = Path(__file__).resolve().parents[2]
+_HELPER = _VALIDATION_ROOT / "scripts" / "check-yaml-parser-conformance.mjs"
+_TIMEOUT_SECONDS = 60
+
+
+def check_yaml_parser_conformance(
+    repo_path: Path, context: ValidationContext
+) -> List[dict]:
+    """Check the current API definition with the pinned strict YAML parser.
+
+    API-scoped check — the adapter calls this once per API context. Missing
+    files are left to the existing release-plan/API-file checks.
+    """
+    if not context.apis:
+        return []
+
+    api = context.apis[0]
+    spec_file = api.spec_file or f"code/API_definitions/{api.api_name}.yaml"
+    if not spec_file:
+        return []
+
+    if not (repo_path / spec_file).is_file():
+        return []
+
+    helper_result = _run_helper(repo_path, spec_file)
+    if isinstance(helper_result, dict):
+        return [helper_result]
+
+    findings: List[dict] = []
+    for item in helper_result:
+        reason = str(item.get("reason") or "YAML parser error")
+        path = str(item.get("path") or spec_file)
+        findings.append(
+            make_finding(
+                engine_rule=_ENGINE_RULE,
+                level="warn",
+                message=f"OpenAPI YAML fails parser conformance: {reason}",
+                path=path,
+                line=_positive_int(item.get("line"), 1),
+                api_name=api.api_name,
+                column=_positive_int(item.get("column"), 1),
+            )
+        )
+    return findings
+
+
+def _run_helper(repo_path: Path, spec_file: str) -> list[dict] | dict:
+    try:
+        result = subprocess.run(
+            ["node", str(_HELPER), spec_file],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        return _helper_error(f"YAML parser conformance helper could not run: {exc}")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "no stderr"
+        return _helper_error(
+            f"YAML parser conformance helper failed: {stderr}"
+        )
+
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return _helper_error(
+            f"YAML parser conformance helper returned invalid JSON: {exc}"
+        )
+
+    if not isinstance(payload, list):
+        return _helper_error(
+            "YAML parser conformance helper returned non-list JSON"
+        )
+
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _helper_error(message: str) -> dict:
+    return make_finding(
+        engine_rule=_EXECUTION_ERROR_RULE,
+        level="error",
+        message=message,
+        path="",
+        line=1,
+        api_name=None,
+    )
+
+
+def _positive_int(value: object, default: int) -> int:
+    return value if isinstance(value, int) and value > 0 else default

--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -9,7 +9,8 @@
         "@redocly/cli": "^2.34.0",
         "@stoplight/spectral-cli": "^6.16.0",
         "@stoplight/spectral-owasp-ruleset": "^2.0.0",
-        "gplint": "^2.5.2"
+        "gplint": "^2.5.2",
+        "js-yaml": "^5.0.0"
       },
       "engines": {
         "node": ">=24",
@@ -1429,6 +1430,12 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2985,6 +2992,28 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.0.0.tgz",
+      "integrity": "sha512-GSvaPUbk1U+FMZ7rJzF+F8e5YVtu7KnD40et/5rBXXRBv2jCO9L3qCewvIDDdudC0QycTFlf6EAA+h3kxBsuUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
     },
     "node_modules/jsep": {
       "version": "1.4.0",

--- a/validation/package.json
+++ b/validation/package.json
@@ -10,7 +10,8 @@
     "@redocly/cli": "^2.34.0",
     "@stoplight/spectral-cli": "^6.16.0",
     "@stoplight/spectral-owasp-ruleset": "^2.0.0",
-    "gplint": "^2.5.2"
+    "gplint": "^2.5.2",
+    "js-yaml": "^5.0.0"
   },
   "overrides": {
     "@stoplight/spectral-rulesets": "1.22.2",

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -575,5 +575,6 @@
   conditional_level:
     default: warn
   suggestion: >-
-    Rewrite the invalid YAML in block style or otherwise make the file parse
-    with YAML 1.2-conformant parsers.
+    Prefer block-style YAML for examples. Rewrite invalid JSON-like flow-style
+    YAML mappings or sequences so the file parses with YAML 1.2-conformant
+    parsers.

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -564,3 +564,16 @@
   suggestion: >-
     Keep target_api_status aligned with the published version, or bump
     target_api_version before changing API status.
+
+# P-037: check-yaml-parser-conformance
+# Advisory YAML parser compatibility probe for OpenAPI definition files.
+- id: P-037
+  engine: python
+  engine_rule: check-yaml-parser-conformance
+  short_title: "OpenAPI YAML fails parser conformance"
+  documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-037-yaml-parser-conformance"
+  conditional_level:
+    default: warn
+  suggestion: >-
+    Rewrite the invalid YAML in block style or otherwise make the file parse
+    with YAML 1.2-conformant parsers.

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -14,7 +14,7 @@ version: 1
 generated: 2026-04-07
 
 summary:
-  total_implemented: 145
+  total_implemented: 146
   total_gap: 0
   total_manual: 25
   total_pending: 0
@@ -22,7 +22,7 @@ summary:
   by_engine:
     spectral: 85
     gherkin: 25
-    python: 22
+    python: 23
     yamllint: 13
 
 # ---------------------------------------------------------------------------

--- a/validation/scripts/check-yaml-parser-conformance.mjs
+++ b/validation/scripts/check-yaml-parser-conformance.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { load } from "js-yaml";
+
+function toPositiveInt(value, fallback) {
+  return Number.isInteger(value) && value >= 0 ? value + 1 : fallback;
+}
+
+function findingFor(path, error) {
+  const reason = error.reason || error.message || "YAML parser error";
+  const line = toPositiveInt(error.mark?.line, 1);
+  const column = toPositiveInt(error.mark?.column, 1);
+
+  return {
+    path,
+    line,
+    column,
+    reason,
+    message: `YAML parser rejected the document: ${reason}`,
+  };
+}
+
+const findings = [];
+
+for (const path of process.argv.slice(2)) {
+  try {
+    load(fs.readFileSync(path, "utf8"));
+  } catch (error) {
+    findings.push(findingFor(path, error));
+  }
+}
+
+process.stdout.write(`${JSON.stringify(findings, null, 2)}\n`);

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -88,7 +88,7 @@ class TestStructuralIntegrity:
         counts = {}
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
-        assert counts["python"] == 35
+        assert counts["python"] == 36
         assert counts["spectral"] == 86
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
@@ -353,8 +353,8 @@ class TestMetadataQuality:
         """
         with_suggestions = [r.id for r in all_rules if r.suggestion is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_suggestions) == 25, (
-            f"Expected 25 explicit suggestions (update test if adding "
+        assert len(with_suggestions) == 26, (
+            f"Expected 26 explicit suggestions (update test if adding "
             f"suggestions): {with_suggestions}"
         )
         assert len(with_overrides) == 0, (

--- a/validation/tests/test_yaml_parser_conformance.py
+++ b/validation/tests/test_yaml_parser_conformance.py
@@ -1,0 +1,304 @@
+"""Tests for the YAML parser conformance check (P-037)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+from validation.context import ApiContext, ValidationContext
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_HELPER = _REPO_ROOT / "validation" / "scripts" / "check-yaml-parser-conformance.mjs"
+
+
+def _make_context(api_name: str | None = None) -> ValidationContext:
+    apis = ()
+    if api_name is not None:
+        apis = (
+            ApiContext(
+                api_name=api_name,
+                target_api_version="0.1.0",
+                target_api_status="alpha",
+                target_api_maturity="initial",
+                api_pattern="request-response",
+                spec_file=f"code/API_definitions/{api_name}.yaml",
+            ),
+        )
+    return ValidationContext(
+        repository="TestRepo",
+        branch_type="main",
+        trigger_type="dispatch",
+        profile="advisory",
+        stage="enabled",
+        target_release_type=None,
+        commonalities_release=None,
+        commonalities_version=None,
+        icm_release=None,
+        base_ref=None,
+        is_release_review_pr=False,
+        release_plan_changed=None,
+        pr_number=None,
+        apis=apis,
+        workflow_run_url="",
+        tooling_ref="",
+    )
+
+
+def _write_api_definition(tmp_path: Path, name: str, content: str) -> Path:
+    api_dir = tmp_path / "code" / "API_definitions"
+    api_dir.mkdir(parents=True, exist_ok=True)
+    path = api_dir / f"{name}.yaml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _run_helper(tmp_path: Path, *paths: str) -> list[dict]:
+    result = subprocess.run(
+        ["node", str(_HELPER), *paths],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+_VALID_OPENAPI = """\
+openapi: 3.0.3
+info:
+  title: Test API
+  version: wip
+paths: {}
+"""
+
+_FLOW_MAPPING_INDENTATION = """\
+openapi: 3.0.3
+info:
+  title: Test API
+  version: wip
+paths: {}
+components:
+  schemas:
+    Subscription:
+      example:
+        sinkCredential: {
+          "credentialType": "ACCESSTOKEN",
+          "accessToken": "xxx",
+          "accessTokenExpiresUtc": "2024-02-17T16:23:45Z",
+          "accessTokenType": "bearer"
+        }
+        protocol: HTTP
+"""
+
+_MULTILINE_SINGLE_QUOTED_SCALAR = """\
+openapi: 3.0.3
+info:
+  title: Test API
+  version: wip
+paths: {}
+components:
+  schemas:
+    Event:
+      properties:
+        mediaType:
+          description: 'media-type that describes the event payload
+          encoding, must be "application/json" for CAMARA APIs'
+"""
+
+
+class TestYamlParserConformanceHelper:
+    def test_valid_yaml_has_no_findings(self, tmp_path: Path):
+        _write_api_definition(tmp_path, "sample-service", _VALID_OPENAPI)
+
+        findings = _run_helper(
+            tmp_path,
+            "code/API_definitions/sample-service.yaml",
+        )
+
+        assert findings == []
+
+    def test_flow_mapping_indentation_shape_is_reported(self, tmp_path: Path):
+        _write_api_definition(
+            tmp_path,
+            "sample-service-subscriptions",
+            _FLOW_MAPPING_INDENTATION,
+        )
+
+        findings = _run_helper(
+            tmp_path,
+            "code/API_definitions/sample-service-subscriptions.yaml",
+        )
+
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["path"] == "code/API_definitions/sample-service-subscriptions.yaml"
+        assert finding["line"] > 1
+        assert finding["column"] > 0
+        assert "deficient indentation" in finding["reason"]
+
+    def test_multiline_quoted_scalar_shape_is_reported(self, tmp_path: Path):
+        _write_api_definition(
+            tmp_path,
+            "sample-implicit-events",
+            _MULTILINE_SINGLE_QUOTED_SCALAR,
+        )
+
+        findings = _run_helper(
+            tmp_path,
+            "code/API_definitions/sample-implicit-events.yaml",
+        )
+
+        assert len(findings) == 1
+        assert findings[0]["path"] == "code/API_definitions/sample-implicit-events.yaml"
+        assert "deficient indentation" in findings[0]["reason"]
+
+    def test_multiple_files_emit_one_finding_per_invalid_file(self, tmp_path: Path):
+        _write_api_definition(tmp_path, "sample-service", _VALID_OPENAPI)
+        _write_api_definition(
+            tmp_path,
+            "sample-service-subscriptions",
+            _FLOW_MAPPING_INDENTATION,
+        )
+        _write_api_definition(
+            tmp_path,
+            "sample-implicit-events",
+            _MULTILINE_SINGLE_QUOTED_SCALAR,
+        )
+
+        findings = _run_helper(
+            tmp_path,
+            "code/API_definitions/sample-service.yaml",
+            "code/API_definitions/sample-service-subscriptions.yaml",
+            "code/API_definitions/sample-implicit-events.yaml",
+        )
+
+        assert {
+            finding["path"] for finding in findings
+        } == {
+            "code/API_definitions/sample-service-subscriptions.yaml",
+            "code/API_definitions/sample-implicit-events.yaml",
+        }
+
+
+class TestCheckYamlParserConformance:
+    def test_no_api_context_returns_no_findings(self, tmp_path: Path, monkeypatch):
+        from validation.engines.python_checks import yaml_parser_conformance_checks
+
+        run = Mock()
+        monkeypatch.setattr(yaml_parser_conformance_checks.subprocess, "run", run)
+
+        findings = yaml_parser_conformance_checks.check_yaml_parser_conformance(
+            tmp_path,
+            _make_context(),
+        )
+
+        assert findings == []
+        run.assert_not_called()
+
+    def test_missing_spec_file_returns_no_findings(self, tmp_path: Path, monkeypatch):
+        from validation.engines.python_checks import yaml_parser_conformance_checks
+
+        run = Mock()
+        monkeypatch.setattr(yaml_parser_conformance_checks.subprocess, "run", run)
+
+        findings = yaml_parser_conformance_checks.check_yaml_parser_conformance(
+            tmp_path,
+            _make_context("sample-service"),
+        )
+
+        assert findings == []
+        run.assert_not_called()
+
+    def test_valid_helper_result_returns_no_findings(self, tmp_path: Path, monkeypatch):
+        from validation.engines.python_checks import yaml_parser_conformance_checks
+
+        _write_api_definition(tmp_path, "sample-service", _VALID_OPENAPI)
+        monkeypatch.setattr(
+            yaml_parser_conformance_checks.subprocess,
+            "run",
+            Mock(return_value=subprocess.CompletedProcess([], 0, stdout="[]", stderr="")),
+        )
+
+        findings = yaml_parser_conformance_checks.check_yaml_parser_conformance(
+            tmp_path,
+            _make_context("sample-service"),
+        )
+
+        assert findings == []
+
+    def test_parser_error_is_converted_to_warning(self, tmp_path: Path, monkeypatch):
+        from validation.engines.python_checks import yaml_parser_conformance_checks
+
+        _write_api_definition(
+            tmp_path,
+            "sample-service-subscriptions",
+            _FLOW_MAPPING_INDENTATION,
+        )
+        helper_output = [
+            {
+                "path": "code/API_definitions/sample-service-subscriptions.yaml",
+                "line": 15,
+                "column": 9,
+                "reason": "deficient indentation",
+                "message": "YAML parser rejected the document",
+            }
+        ]
+        monkeypatch.setattr(
+            yaml_parser_conformance_checks.subprocess,
+            "run",
+            Mock(
+                return_value=subprocess.CompletedProcess(
+                    [],
+                    0,
+                    stdout=json.dumps(helper_output),
+                    stderr="",
+                )
+            ),
+        )
+
+        findings = yaml_parser_conformance_checks.check_yaml_parser_conformance(
+            tmp_path,
+            _make_context("sample-service-subscriptions"),
+        )
+
+        assert len(findings) == 1
+        assert findings[0]["engine"] == "python"
+        assert findings[0]["engine_rule"] == "check-yaml-parser-conformance"
+        assert findings[0]["level"] == "warn"
+        assert findings[0]["path"] == "code/API_definitions/sample-service-subscriptions.yaml"
+        assert findings[0]["line"] == 15
+        assert findings[0]["column"] == 9
+        assert findings[0]["api_name"] == "sample-service-subscriptions"
+        assert "deficient indentation" in findings[0]["message"]
+
+    def test_helper_failure_is_visible_as_error(self, tmp_path: Path, monkeypatch):
+        from validation.engines.python_checks import yaml_parser_conformance_checks
+
+        _write_api_definition(tmp_path, "sample-service", _VALID_OPENAPI)
+        monkeypatch.setattr(
+            yaml_parser_conformance_checks.subprocess,
+            "run",
+            Mock(
+                return_value=subprocess.CompletedProcess(
+                    [],
+                    1,
+                    stdout="",
+                    stderr="helper exploded",
+                )
+            ),
+        )
+
+        findings = yaml_parser_conformance_checks.check_yaml_parser_conformance(
+            tmp_path,
+            _make_context("sample-service"),
+        )
+
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "yaml-parser-conformance-execution-error"
+        assert findings[0]["level"] == "error"
+        assert "helper failed" in findings[0]["message"]


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature
tests
documentation

#### What this PR does / why we need it:

Adds an API-scoped Python Validation check that parses each OpenAPI YAML
definition with `js-yaml@5`. Parser failures are reported as advisory `P-037`
warnings with the first parser line and column, while helper execution failures
remain error-level infrastructure findings.

The PR also adds rule metadata, unit tests for the Node helper and Python
check, and FAQ guidance for maintainers who see `P-037` even though yamllint or
Spectral accepted the same file.

Local validation with this branch reports `P-037` warnings at the known
subscription YAML locations in:

- `ConnectedNetworkType`
- `DeviceReachabilityStatus`
- `DeviceRoamingStatus`

#### Which issue(s) this PR fixes:

Fixes #352

#### Special notes for reviewers:

Local checks run:

- `python3 -m pytest validation/tests/test_yaml_parser_conformance.py -q`
- `python3 -m pytest validation/tests/test_rule_metadata_integrity.py -q`
- `python3 -m pytest validation/tests -q`

#### Changelog input

```
release-note
Adds an advisory validation warning for OpenAPI YAML files rejected by stricter YAML parsers.
```

#### Additional documentation

```
docs
documentation/validation/faq.md adds guidance for P-037.
```
