### PR TITLE
feat(validation): lock published release-plan attribution

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -310,6 +310,8 @@ jobs:
           commonalities_tag_exists: ${{ steps.detect-deps.outputs.commonalities_tag_exists || '' }}
           icm_tag_exists: ${{ steps.detect-deps.outputs.icm_tag_exists || '' }}
           non_release_plan_files_changed: ${{ steps.detect-changes.outputs.non_release_plan_files_changed || '[]' }}
+          base_release_track: ${{ steps.detect-deps.outputs.base_release_track || '' }}
+          base_meta_release: ${{ steps.detect-deps.outputs.base_meta_release || '' }}
           active_release_state: ${{ steps.derive-release-state.outputs.state || '' }}
           active_release_snapshot_branch: ${{ steps.derive-release-state.outputs.snapshot_branch || '' }}
           active_release_issue_number: ${{ steps.derive-release-state.outputs.release_issue_number || '' }}

--- a/shared-actions/run-validation/action.yml
+++ b/shared-actions/run-validation/action.yml
@@ -70,6 +70,17 @@ inputs:
       the only changed file.  Consumed by P-022 (exclusivity check).
     required: false
     default: '[]'
+  base_release_track:
+    description: >
+      PR-base repository.release_track from release-plan.yaml. Empty when
+      release-plan.yaml was not changed or no base plan was available.
+    required: false
+    default: ''
+  base_meta_release:
+    description: >
+      PR-base repository.meta_release from release-plan.yaml. Empty when absent.
+    required: false
+    default: ''
   active_release_state:
     description: >
       Optional workflow-resolved release state from derive-release-state.
@@ -241,6 +252,8 @@ runs:
         VALIDATION_COMMONALITIES_TAG_EXISTS: ${{ inputs.commonalities_tag_exists }}
         VALIDATION_ICM_TAG_EXISTS: ${{ inputs.icm_tag_exists }}
         VALIDATION_NON_RELEASE_PLAN_FILES_CHANGED: ${{ inputs.non_release_plan_files_changed }}
+        VALIDATION_BASE_RELEASE_TRACK: ${{ inputs.base_release_track }}
+        VALIDATION_BASE_META_RELEASE: ${{ inputs.base_meta_release }}
         VALIDATION_ACTIVE_RELEASE_STATE: ${{ inputs.active_release_state }}
         VALIDATION_ACTIVE_RELEASE_SNAPSHOT_BRANCH: ${{ inputs.active_release_snapshot_branch }}
         VALIDATION_ACTIVE_RELEASE_ISSUE_NUMBER: ${{ inputs.active_release_issue_number }}

--- a/validation/context/context_builder.py
+++ b/validation/context/context_builder.py
@@ -144,12 +144,17 @@ class ValidationContext:
     # None (check did not run or API lookup failed).
     # non_release_plan_files_changed: files co-changed alongside release-plan.yaml
     # in the current PR diff (P-022 exclusivity input).
+    # base_release_track / base_meta_release: PR-base release-plan attribution
+    # fields used by P-035 to detect attribution drift on an already-published
+    # target_release_tag.  None means no PR-base release-plan baseline.
     commonalities_release_changed: bool = False
     icm_release_changed: bool = False
     release_plan_check_only: bool = False
     commonalities_tag_exists: Optional[bool] = None
     icm_tag_exists: Optional[bool] = None
     non_release_plan_files_changed: Tuple[str, ...] = ()
+    base_release_track: Optional[str] = None
+    base_meta_release: Optional[str] = None
 
     # fallback_canonical_path: absolute path to an info-description-templates.yaml
     # fetched by the workflow from Commonalities source at commonalities_release.
@@ -316,6 +321,8 @@ def build_validation_context(
     commonalities_tag_exists: Optional[bool] = None,
     icm_tag_exists: Optional[bool] = None,
     non_release_plan_files_changed: Tuple[str, ...] = (),
+    base_release_track: Optional[str] = None,
+    base_meta_release: Optional[str] = None,
     fallback_canonical_path: Optional[str] = None,
     active_release_state: str = "",
     active_release_snapshot_branch: str = "",
@@ -417,6 +424,8 @@ def build_validation_context(
         commonalities_tag_exists=commonalities_tag_exists,
         icm_tag_exists=icm_tag_exists,
         non_release_plan_files_changed=non_release_plan_files_changed,
+        base_release_track=base_release_track,
+        base_meta_release=base_meta_release,
         fallback_canonical_path=fallback_canonical_path,
         active_release_state=ActiveReleaseState(
             state=active_release_state,

--- a/validation/context/release_history.py
+++ b/validation/context/release_history.py
@@ -59,6 +59,8 @@ class PublishedRelease:
     src_commit_sha: str
     metadata_available: bool
     apis: Tuple[PublishedReleaseApi, ...]
+    commonalities_release: str = ""
+    icm_release: str = ""
 
     @property
     def parsed_tag(self) -> Optional[ReleaseTag]:
@@ -175,6 +177,8 @@ def _parse_release(raw: Any) -> Optional[PublishedRelease]:
         published_at=str(raw.get("published_at") or ""),
         src_commit_sha=str(raw.get("src_commit_sha") or ""),
         metadata_available=bool(raw.get("metadata_available", False)),
+        commonalities_release=str(raw.get("commonalities_release") or ""),
+        icm_release=str(raw.get("icm_release") or ""),
         apis=apis,
     )
 

--- a/validation/engines/python_checks/release_plan_checks.py
+++ b/validation/engines/python_checks/release_plan_checks.py
@@ -375,6 +375,12 @@ def _plan_matches_published_release(
     return _planned_api_set(release_plan) == _published_api_set(release)
 
 
+def _plan_api_entries_match_published_release(
+    release_plan: dict, release: PublishedRelease
+) -> bool:
+    return _planned_api_set(release_plan) == _published_api_set(release)
+
+
 def _inactive_plan_matches_published_release(
     release_plan: dict, release: PublishedRelease
 ) -> bool:
@@ -393,6 +399,50 @@ def _prefix_pre_existing_release_plan_condition(
             f"{message} Submit the fix in a dedicated release-plan PR."
         )
     return message
+
+
+def _normalized_optional_text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalized_release_tag(value: object) -> str:
+    text = _normalized_optional_text(value)
+    return text.split(maxsplit=1)[0] if text else ""
+
+
+def _plan_dependency_tags(release_plan: dict) -> tuple[str, str]:
+    deps = release_plan.get("dependencies", {})
+    if not isinstance(deps, dict):
+        deps = {}
+    return (
+        _normalized_release_tag(deps.get("commonalities_release")),
+        _normalized_release_tag(deps.get("identity_consent_management_release")),
+    )
+
+
+def _published_dependency_tags(release: PublishedRelease) -> tuple[str, str]:
+    return (
+        _normalized_release_tag(release.commonalities_release),
+        _normalized_release_tag(release.icm_release),
+    )
+
+
+def _base_attribution_available(context: ValidationContext) -> bool:
+    return context.base_release_track is not None
+
+
+def _release_plan_attribution_changed(
+    release_plan: dict, context: ValidationContext
+) -> bool:
+    repo = release_plan.get("repository", {})
+    if not isinstance(repo, dict):
+        repo = {}
+    return (
+        _normalized_optional_text(context.base_release_track)
+        != _normalized_optional_text(repo.get("release_track"))
+        or _normalized_optional_text(context.base_meta_release)
+        != _normalized_optional_text(repo.get("meta_release"))
+    )
 
 
 def _release_history_finding(
@@ -482,6 +532,45 @@ def check_release_plan_published_history(
     if not target_tag:
         return []
 
+    published_target = (
+        history.release_by_tag(target_tag) if history.release_tags_available() else None
+    )
+    if (
+        published_target is not None
+        and published_target.metadata_available
+        and _plan_api_entries_match_published_release(release_plan, published_target)
+    ):
+        if _plan_dependency_tags(release_plan) != _published_dependency_tags(
+            published_target
+        ):
+            return [
+                _release_history_finding(
+                    context,
+                    f"target_release_tag '{target_tag}' is already published, "
+                    "so dependencies must not be changed for this release.",
+                    "Restore the dependency tags published with this release, "
+                    "or start a new release cycle with an unpublished "
+                    "target_release_tag.",
+                )
+            ]
+        if (
+            context.release_plan_changed is True
+            and _base_attribution_available(context)
+            and _release_plan_attribution_changed(release_plan, context)
+        ):
+            return [
+                _release_history_finding(
+                    context,
+                    f"target_release_tag '{target_tag}' is already published, "
+                    "so release_track and meta_release must not be changed for "
+                    "this release.",
+                    "Start a new release cycle in this repository. The "
+                    "inclusion of an already-published release, if approved, "
+                    "is handled by Release Management outside this "
+                    "repository's release-plan.",
+                )
+            ]
+
     latest_release = (
         history.latest_release() if history.release_tags_available() else None
     )
@@ -495,9 +584,6 @@ def check_release_plan_published_history(
     ):
         return []
 
-    published_target = (
-        history.release_by_tag(target_tag) if history.release_tags_available() else None
-    )
     if (
         published_target is not None
         and published_target.metadata_available

--- a/validation/orchestrator.py
+++ b/validation/orchestrator.py
@@ -115,6 +115,8 @@ class OrchestratorArgs:
     commonalities_tag_exists: Optional[bool]
     icm_tag_exists: Optional[bool]
     non_release_plan_files_changed: Tuple[str, ...]
+    base_release_track: Optional[str]
+    base_meta_release: Optional[str]
 
 
 def _env(name: str, default: str = "") -> str:
@@ -206,6 +208,8 @@ def parse_args() -> OrchestratorArgs:
         non_release_plan_files_changed=_env_json_list(
             "NON_RELEASE_PLAN_FILES_CHANGED"
         ),
+        base_release_track=_env("BASE_RELEASE_TRACK") or None,
+        base_meta_release=_env("BASE_META_RELEASE") or None,
     )
 
 
@@ -550,6 +554,8 @@ def main() -> int:
         commonalities_tag_exists=args.commonalities_tag_exists,
         icm_tag_exists=args.icm_tag_exists,
         non_release_plan_files_changed=args.non_release_plan_files_changed,
+        base_release_track=args.base_release_track,
+        base_meta_release=args.base_meta_release,
         fallback_canonical_path=args.fallback_canonical_path or None,
         release_history_path=(
             Path(args.release_history_path)

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -542,11 +542,11 @@
 
 # P-035: check-release-plan-published-history
 # Repository-level release-plan consistency against workflow-resolved
-# published release metadata.
+# published release metadata, including already-published target tag locks.
 - id: P-035
   engine: python
   engine_rule: check-release-plan-published-history
-  short_title: "release-plan must move forward from published history"
+  short_title: "release-plan must stay consistent with published history"
   release_plan_check_only_safe: true
   conditional_level:
     default: error

--- a/validation/scripts/resolve-release-history.py
+++ b/validation/scripts/resolve-release-history.py
@@ -23,6 +23,7 @@ from release_automation.scripts.github_client import GitHubClient, GitHubClientE
 
 def _metadata_release(release, metadata: dict[str, Any] | None) -> dict[str, Any]:
     repo = metadata.get("repository", {}) if isinstance(metadata, dict) else {}
+    deps = metadata.get("dependencies", {}) if isinstance(metadata, dict) else {}
     apis = metadata.get("apis", []) if isinstance(metadata, dict) else []
     return {
         "tag": release.tag_name,
@@ -31,6 +32,10 @@ def _metadata_release(release, metadata: dict[str, Any] | None) -> dict[str, Any
         "published_at": "",
         "src_commit_sha": str(repo.get("src_commit_sha") or ""),
         "metadata_available": isinstance(metadata, dict),
+        "commonalities_release": _release_tag(deps.get("commonalities_release")),
+        "icm_release": _release_tag(
+            deps.get("identity_consent_management_release")
+        ),
         "apis": [
             {
                 "api_name": str(api.get("api_name") or ""),
@@ -43,6 +48,13 @@ def _metadata_release(release, metadata: dict[str, Any] | None) -> dict[str, Any
             and api.get("api_version")
         ],
     }
+
+
+def _release_tag(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    stripped = value.strip()
+    return stripped.split(maxsplit=1)[0] if stripped else ""
 
 
 def resolve_history(

--- a/validation/scripts/resolve-release-plan-deps.py
+++ b/validation/scripts/resolve-release-plan-deps.py
@@ -14,6 +14,8 @@ Outputs (written to the file at $GITHUB_OUTPUT, or --github-output):
     commonalities_tag_exists        'true' | 'false' | ''   (empty = skipped / lookup failed)
     icm_tag_exists                  'true' | 'false' | ''
     release_plan_check_only         'true' | 'false'
+    base_release_track             PR-base repository.release_track, if present
+    base_meta_release               PR-base repository.meta_release, if present
 
 `release_plan_check_only` is 'true' only when commonalities_release advanced:
 that is the dependency whose cached content (code/common/*) is stale under
@@ -120,6 +122,14 @@ def get_dep(plan: dict[str, Any], field: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def get_repo_field(plan: dict[str, Any], field: str) -> str:
+    repo = plan.get("repository") if isinstance(plan, dict) else None
+    if not isinstance(repo, dict):
+        return ""
+    value = repo.get(field)
+    return value if isinstance(value, str) else ""
+
+
 # ---------------------------------------------------------------------------
 # Tag lookup via gh
 # ---------------------------------------------------------------------------
@@ -216,6 +226,8 @@ def resolve(
             outputs[dep.tag_exists_output] = ""
 
     outputs["release_plan_check_only"] = "true" if commonalities_changed else "false"
+    outputs["base_release_track"] = get_repo_field(base_plan, "release_track")
+    outputs["base_meta_release"] = get_repo_field(base_plan, "meta_release")
     return outputs
 
 

--- a/validation/tests/test_context_builder.py
+++ b/validation/tests/test_context_builder.py
@@ -245,6 +245,7 @@ class TestValidationContextToDict:
             "release_plan_check_only",
             "commonalities_tag_exists", "icm_tag_exists",
             "non_release_plan_files_changed",
+            "base_release_track", "base_meta_release",
             "fallback_canonical_path",
             "active_release_state",
             "release_history",

--- a/validation/tests/test_python_checks_release_plan.py
+++ b/validation/tests/test_python_checks_release_plan.py
@@ -336,6 +336,8 @@ def _published_release(
     *,
     release_type: str = "public-release",
     apis: list[dict] | None = None,
+    commonalities_release: str | None = None,
+    icm_release: str | None = None,
     metadata_available: bool = True,
 ) -> dict:
     if apis is None:
@@ -353,6 +355,8 @@ def _published_release(
         "published_at": "2026-01-15T00:00:00Z",
         "src_commit_sha": "a" * 40,
         "metadata_available": metadata_available,
+        "commonalities_release": commonalities_release if metadata_available else None,
+        "icm_release": icm_release if metadata_available else None,
         "apis": apis if metadata_available else [],
     }
 
@@ -374,10 +378,14 @@ def _context_with_release_history(
     history: dict,
     *,
     release_plan_changed: bool | None = True,
+    base_release_track: str | None = None,
+    base_meta_release: str | None = None,
 ) -> ValidationContext:
     return dataclasses.replace(
         _make_context(),
         release_plan_changed=release_plan_changed,
+        base_release_track=base_release_track,
+        base_meta_release=base_meta_release,
         release_history=parse_release_history(history),
     )
 
@@ -468,6 +476,148 @@ class TestCheckReleasePlanPublishedHistory:
         )
 
         assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_published_tag_with_changed_attribution_errors(self, tmp_path: Path):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                release_track="meta-release",
+                meta_release="Sync26",
+                target_release_tag="r4.2",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.0.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2")),
+            release_plan_changed=True,
+            base_release_track="independent",
+            base_meta_release=None,
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert (
+            findings[0]["message"]
+            == "target_release_tag 'r4.2' is already published, so release_track "
+            "and meta_release must not be changed for this release."
+        )
+        assert findings[0]["suggestion"] == (
+            "Start a new release cycle in this repository. The inclusion of an "
+            "already-published release, if approved, is handled by Release "
+            "Management outside this repository's release-plan."
+        )
+
+    def test_parked_published_tag_with_unchanged_attribution_and_dependencies_skips(
+        self, tmp_path: Path
+    ):
+        plan = _make_plan(
+            release_track="independent",
+            meta_release=None,
+            target_release_tag="r4.2",
+            target_release_type="none",
+            apis=[
+                {
+                    "api_name": "quality-on-demand",
+                    "target_api_status": "public",
+                    "target_api_version": "1.0.0",
+                }
+            ],
+        )
+        plan["dependencies"] = {
+            "commonalities_release": "r4.1",
+            "identity_consent_management_release": "r3.1",
+        }
+        _write_release_plan(tmp_path, plan)
+        context = _context_with_release_history(
+            _release_history(
+                _published_release(
+                    "r4.2",
+                    commonalities_release="r4.1",
+                    icm_release="r3.1",
+                )
+            ),
+            release_plan_changed=True,
+            base_release_track="independent",
+            base_meta_release="",
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_unpublished_tag_with_changed_attribution_starts_new_cycle(
+        self, tmp_path: Path
+    ):
+        _write_release_plan(
+            tmp_path,
+            _make_plan(
+                release_track="meta-release",
+                meta_release="Sync26",
+                target_release_tag="r4.3",
+                target_release_type="public-release",
+                apis=[
+                    {
+                        "api_name": "quality-on-demand",
+                        "target_api_status": "public",
+                        "target_api_version": "1.1.0",
+                    }
+                ],
+            ),
+        )
+        context = _context_with_release_history(
+            _release_history(_published_release("r4.2")),
+            release_plan_changed=True,
+            base_release_track="independent",
+            base_meta_release=None,
+        )
+
+        assert check_release_plan_published_history(tmp_path, context) == []
+
+    def test_published_tag_with_dependency_drift_errors(self, tmp_path: Path):
+        plan = _make_plan(
+            target_release_tag="r4.2",
+            target_release_type="public-release",
+            apis=[
+                {
+                    "api_name": "quality-on-demand",
+                    "target_api_status": "public",
+                    "target_api_version": "1.0.0",
+                }
+            ],
+        )
+        plan["dependencies"] = {
+            "commonalities_release": "r5.0",
+            "identity_consent_management_release": "r4.0",
+        }
+        _write_release_plan(tmp_path, plan)
+        context = _context_with_release_history(
+            _release_history(
+                _published_release(
+                    "r4.2",
+                    commonalities_release="r4.1",
+                    icm_release="r3.1",
+                )
+            )
+        )
+
+        findings = check_release_plan_published_history(tmp_path, context)
+
+        assert len(findings) == 1
+        assert (
+            findings[0]["message"]
+            == "target_release_tag 'r4.2' is already published, so dependencies "
+            "must not be changed for this release."
+        )
+        assert findings[0]["suggestion"] == (
+            "Restore the dependency tags published with this release, or start "
+            "a new release cycle with an unpublished target_release_tag."
+        )
 
     def test_not_planning_new_release_keeps_published_plan_quiet(
         self, tmp_path: Path

--- a/validation/tests/test_resolve_release_history.py
+++ b/validation/tests/test_resolve_release_history.py
@@ -45,6 +45,10 @@ def test_resolve_history_writes_complete_metadata(monkeypatch):
                     "release_type": "public-release",
                     "src_commit_sha": "a" * 40,
                 },
+                "dependencies": {
+                    "commonalities_release": "r4.1 (1.2.0)",
+                    "identity_consent_management_release": "r3.1 (1.0.0)",
+                },
                 "apis": [
                     {
                         "api_name": "quality-on-demand",
@@ -65,6 +69,8 @@ def test_resolve_history_writes_complete_metadata(monkeypatch):
     assert snapshot["repository"] == "camaraproject/QualityOnDemand"
     assert snapshot["published_releases"][0]["tag"] == "r4.2"
     assert snapshot["published_releases"][0]["metadata_available"] is True
+    assert snapshot["published_releases"][0]["commonalities_release"] == "r4.1"
+    assert snapshot["published_releases"][0]["icm_release"] == "r3.1"
     assert snapshot["published_releases"][0]["apis"][0]["api_name"] == "quality-on-demand"
 
 

--- a/validation/tests/test_resolve_release_plan_deps.py
+++ b/validation/tests/test_resolve_release_plan_deps.py
@@ -250,7 +250,40 @@ class TestResolve:
             "commonalities_tag_exists": "",
             "icm_tag_exists": "",
             "release_plan_check_only": "false",
+            "base_release_track": "",
+            "base_meta_release": "",
         }
+
+    def test_emits_base_release_plan_attribution(self, tmp_path):
+        """Base release_track/meta_release are passed through for P-035."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        _write_plan(workspace / "release-plan.yaml", "r4.1", "r3.0")
+
+        git_shim = _make_shim(
+            tmp_path,
+            "git",
+            stdout=(
+                "repository:\n"
+                "  release_track: independent\n"
+                "dependencies:\n"
+                "  commonalities_release: r4.1\n"
+                "  identity_consent_management_release: r3.0\n"
+            ),
+            exit_code=0,
+        )
+        gh_shim = _make_shim(tmp_path, "gh", exit_code=0)
+
+        out = resolve(
+            base_ref="main",
+            plan_path="release-plan.yaml",
+            workspace_plan=workspace / "release-plan.yaml",
+            gh_bin=str(gh_shim),
+            git_bin=str(git_shim),
+        )
+
+        assert out["base_release_track"] == "independent"
+        assert out["base_meta_release"] == ""
 
     def test_commonalities_advanced_to_existing_tag(self, tmp_path):
         """Commonalities bump only → check_only true, commonalities_tag_exists 'true'."""


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Extends P-035 so release-plan.yaml remains consistent with an already-published target_release_tag when the planned API entries still match that published release.

The PR adds two published-history subchecks:

- attribution drift: for PR validation, compare repository.release_track and repository.meta_release in the PR head release-plan.yaml against the PR base release-plan.yaml, and reject changes while the plan still points at an already-published target tag;
- dependency drift: retain dependency tags from published release-metadata.yaml in the release-history snapshot, and reject changed dependencies.commonalities_release or dependencies.identity_consent_management_release while the plan still points at that already-published target tag.

Unchanged parked plans remain valid, and a new release cycle using an unpublished target_release_tag is not blocked.

Related to #232.

#### Which issue(s) this PR fixes:

Fixes #356

#### Special notes for reviewers:

Validation run locally:

python3 -m pytest validation/tests -q

Result: 1151 passed.

#### Changelog input

```
 release-note
Extends P-035 release-plan published-history validation to reject attribution and dependency drift for already-published target release tags.
```

#### Additional documentation 

This section can be blank.

```
docs
```
