### PR TITLE
fix(validation): keep colons readable in annotation bodies

### DIFF
--- a/validation/output/annotations.py
+++ b/validation/output/annotations.py
@@ -63,19 +63,20 @@ class AnnotationResult:
 # ---------------------------------------------------------------------------
 
 
-def _sanitize_message(text: str) -> str:
-    """Sanitize a message for use in a workflow command.
+def _sanitize_data(text: str) -> str:
+    """Sanitize command data for use after the workflow command delimiter.
 
-    Workflow commands use ``::`` as delimiters and newlines as
-    terminators.  Both must be escaped in the message body.
+    GitHub Actions command data must escape percent signs and line breaks.
+    Colons are only escaped in command properties, not the annotation body.
     """
     text = text.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
-    # Percent-encode the characters that GitHub Actions interprets specially
-    # in workflow command data: %, \r, \n, and :
-    # Using the documented encoding: https://github.com/actions/toolkit
     text = text.replace("%", "%25")
-    text = text.replace(":", "%3A")
     return text
+
+
+def _sanitize_property(text: str) -> str:
+    """Sanitize a workflow command property value."""
+    return _sanitize_data(text).replace(":", "%3A").replace(",", "%2C")
 
 
 def _build_command(finding: dict) -> str:
@@ -104,9 +105,9 @@ def _build_command(finding: dict) -> str:
     params = f"file={path},line={line}"
     if col is not None:
         params += f",col={col}"
-    params += f",title={_sanitize_message(title)}"
+    params += f",title={_sanitize_property(title)}"
 
-    return f"::{command} {params}::{_sanitize_message(message)}"
+    return f"::{command} {params}::{_sanitize_data(message)}"
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_output_annotations.py
+++ b/validation/tests/test_output_annotations.py
@@ -6,7 +6,8 @@ from validation.output.annotations import (
     ANNOTATION_LIMIT,
     AnnotationResult,
     _build_command,
-    _sanitize_message,
+    _sanitize_data,
+    _sanitize_property,
     generate_annotations,
 )
 from validation.postfilter.engine import PostFilterResult
@@ -56,28 +57,38 @@ def _make_result(findings: list[dict]) -> PostFilterResult:
 
 
 # ---------------------------------------------------------------------------
-# _sanitize_message
+# _sanitize_data
 # ---------------------------------------------------------------------------
 
 
-class TestSanitizeMessage:
+class TestSanitizeData:
     def test_newlines_replaced(self):
-        assert " " in _sanitize_message("line1\nline2")
-        assert "\n" not in _sanitize_message("line1\nline2")
+        assert " " in _sanitize_data("line1\nline2")
+        assert "\n" not in _sanitize_data("line1\nline2")
 
     def test_carriage_return_replaced(self):
-        assert "\r" not in _sanitize_message("a\rb")
+        assert "\r" not in _sanitize_data("a\rb")
 
     def test_crlf_replaced(self):
-        assert "\r\n" not in _sanitize_message("a\r\nb")
+        assert "\r\n" not in _sanitize_data("a\r\nb")
 
-    def test_colons_encoded(self):
-        result = _sanitize_message("key::value")
-        assert "::" not in result
-        assert "%3A" in result
+    def test_colons_unchanged(self):
+        assert _sanitize_data("key::value") == "key::value"
 
     def test_plain_text_unchanged(self):
-        assert _sanitize_message("hello world") == "hello world"
+        assert _sanitize_data("hello world") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_property
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeProperty:
+    def test_colons_encoded(self):
+        result = _sanitize_property("key::value")
+        assert "::" not in result
+        assert "%3A" in result
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +174,7 @@ class TestBuildCommand:
     def test_suggestion_appended(self):
         f = _make_finding(message="Bad path", suggestion="Use kebab-case")
         cmd = _build_command(f)
-        assert "Bad path | Suggestion%3A Use kebab-case" in cmd
+        assert "Bad path | Suggestion: Use kebab-case" in cmd
 
     def test_no_suggestion(self):
         f = _make_finding(message="Bad path")


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Fixes GitHub annotation body escaping so suggestion labels render as `Suggestion:` instead of `Suggestion%3A`.

#### Which issue(s) this PR fixes:

None.

#### Special notes for reviewers:

Scoped to annotation workflow-command formatting and regression tests.

#### Changelog input

```
release-note
Fix GitHub annotation messages so suggestion labels render readable colons.
```

#### Additional documentation

This section can be blank.

```
docs
```