### PR TITLE
Prepare tooling 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- **[v0.7.0](#v070)**
 - **[v0.6.0](#v060)**
 - **[v0.5.0](#v050)**
 - **[v0.4.0](#v040)**
@@ -10,6 +11,35 @@
 - **[v0.2.2](#v022)**
 - **[v0.2.1](#v021)**
 - **[v0.2.0](#v020)**
+
+# v0.7.0
+
+## Release Notes
+
+**v0.7.0 is a validation-behavior release for the CAMARA tooling repository.**
+
+This release consolidates the changes that landed on `main` after v0.6.0. It
+adds a YAML parser conformance warning (P-037), locks published release-plan
+attribution, keeps annotation bodies readable, and bumps the checkout action
+used across workflows. The validation-behavior changes are visible to CAMARA API
+repositories.
+
+### Added
+
+* Add YAML parser conformance warning (P-037) by @hdamker in https://github.com/camaraproject/tooling/pull/353
+* Cover info-description marker spacer tolerance by @hdamker in https://github.com/camaraproject/tooling/pull/354
+* Pin P-037 to the YAML-fundamentals and subscriptions regression branches, and add `CHANGELOG.md` and `VERSION.yaml` for the v0.7.0 release PR
+
+### Changed
+
+* Lock published release-plan attribution by @hdamker in https://github.com/camaraproject/tooling/pull/357
+* Bump actions/checkout from 6 to 7 by @dependabot in https://github.com/camaraproject/tooling/pull/355
+
+### Fixed
+
+* Keep colons readable in annotation bodies by @hdamker in https://github.com/camaraproject/tooling/pull/358
+
+**Full Changelog**: https://github.com/camaraproject/tooling/compare/v0.6.0...v0.7.0
 
 # v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ tooling/
 
 ## Release Information
 
-* **`VERSION.yaml`** — records the current numbered tooling release version.
-* **`CHANGELOG.md`** — records numbered release notes and links to GitHub comparisons.
+* **[`VERSION.yaml`](VERSION.yaml)** — records the current numbered tooling release version.
+* **[`CHANGELOG.md`](CHANGELOG.md)** — records numbered release notes and links to GitHub comparisons.
 * **`v1-rc`** — floating lightweight tag covering the validation and release automation framework v1 release candidate. This is the active consumption line for CAMARA API repositories.
-* **Numbered release tags** — immutable tags such as `v0.6.0` mark release points on `main`.
+* **Numbered release tags** — immutable tags such as `v0.7.0` mark release points on `main`.
 * **`v0`** — retired legacy linting tag. It is kept for historical compatibility and is not advanced for new releases.
 * **`main`** — active development branch.
 

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.6.0
+version: 0.7.0

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 92
+  total_tested: 93
   by_engine:
     spectral: 85
     gherkin: 25
@@ -330,6 +330,7 @@ tested_rules:
   P-030: [regression/r4.3-broken-spec-info-description-mandatory]
   P-031: [regression/r4.3-broken-spec-info-description-missing-canonical]
   P-032: [regression/r4.3-broken-spec-test-files]
+  P-037: [regression/r4.3-broken-spec-subscriptions, regression/r4.3-broken-spec-yaml-fundamentals]
   S-002: [regression/r4.3-broken-spec-routing]
   S-003: [regression/r4.3-broken-spec-routing]
   S-005: [regression/r4.3-broken-spec-yaml-fundamentals]


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Prepares the numbered **tooling 0.7.0** release. It consolidates the validation-behavior changes that landed on `main` since v0.6.0:

* `P-037` OpenAPI YAML parser conformance warning (#353)
* Published release-plan attribution lock (#357)
* Colon-readable annotation bodies (#358)
* `actions/checkout` bumped v6 → v7 across workflows (#355)
* Info-description marker spacer-tolerance test coverage (#354)

Changes: `VERSION.yaml` → 0.7.0, a `v0.7.0` `CHANGELOG.md` section, README release-information touch-ups, and a rule-inventory update pinning `P-037` to the regression branches that now exercise it (`total_tested` 92 → 93).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Numbered release PR — `v1-rc` is moved to the released commit after merge. The validation regression canary is green (11/11) against `main`.

`P-037` is advisory (warning, non-blocking). It will newly surface on a few production repos that use flow-style subscription examples; heads-up correction issues have been filed there: camaraproject/ConnectedNetworkType#63, camaraproject/DeviceReachabilityStatus#72, camaraproject/DeviceRoamingStatus#84, camaraproject/DeviceStatus#286.

#### Changelog input

```
 release-note
Prepare tooling 0.7.0 release: consolidates validation-behavior changes since v0.6.0 — P-037 YAML parser conformance warning, published release-plan attribution lock, colon-readable annotation bodies, and actions/checkout v7.
```

#### Additional documentation

This section can be blank.

```
docs
NONE
```
