### PR TITLE
fix(validation): match feature files to the longest API name in scope

### DIFF
--- a/validation/context/context_builder.py
+++ b/validation/context/context_builder.py
@@ -174,6 +174,15 @@ class ValidationContext:
     # or unreadable input; history-aware rules fail open in that case.
     release_history: Optional[ReleaseHistorySnapshot] = None
 
+    # all_api_names: every API name in the release scope.  The per-API
+    # dispatch in python_adapter narrows `apis` to a single element via
+    # dataclasses.replace, which leaves this field intact — so API-scoped
+    # feature-file checks can still see sibling API names.  Feature-file→API
+    # matching consults it so the longest matching name wins, e.g.
+    # dedicated-network-areas.feature is claimed by dedicated-network-areas,
+    # not its prefix sibling dedicated-network (tooling#365).
+    all_api_names: Tuple[str, ...] = ()
+
     def to_dict(self) -> dict:
         """Serialize to dict with all keys present.
 
@@ -416,6 +425,7 @@ def build_validation_context(
         release_plan_changed=release_plan_changed,
         pr_number=pr_number,
         apis=api_contexts,
+        all_api_names=tuple(a.api_name for a in api_contexts),
         workflow_run_url=workflow_run_url,
         tooling_ref=tooling_ref,
         commonalities_release_changed=commonalities_release_changed,

--- a/validation/engines/python_checks/test_checks.py
+++ b/validation/engines/python_checks/test_checks.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from validation.context import ValidationContext
 
@@ -17,10 +17,10 @@ from ._types import make_finding
 _TEST_DIR = "code/Test_definitions"
 
 
-def _stem_matches_api(stem: str, api_name: str) -> bool:
-    """Check if a test file stem matches an API name.
+def _stem_anchors_api(stem: str, api_name: str) -> bool:
+    """Check if a test file stem is anchored on an API name.
 
-    Matches:
+    Anchored forms:
     - Exact: ``{api-name}``
     - With version: ``{api-name}.{version}``
     - With suffix: ``{api-name}-{suffix}``
@@ -33,6 +33,35 @@ def _stem_matches_api(stem: str, api_name: str) -> bool:
     if stem.startswith(f"{api_name}-"):
         return True
     return False
+
+
+def _stem_matches_api(
+    stem: str, api_name: str, all_api_names: Sequence[str] = ()
+) -> bool:
+    """Check if a test file stem belongs to ``api_name``.
+
+    A stem belongs to ``api_name`` when it is anchored on it AND no *longer*
+    API name in ``all_api_names`` is also anchored on the same stem — the
+    longest matching API name wins.  This disambiguates sibling APIs whose
+    names share a prefix: ``dedicated-network-areas.feature`` belongs to
+    ``dedicated-network-areas``, not to its prefix sibling
+    ``dedicated-network`` (tooling#365).
+
+    ``all_api_names`` is the full release-scope API-name set (see
+    ``ValidationContext.all_api_names``); it survives the per-API narrowing
+    in ``python_adapter``.  When empty (e.g. a single-API repo), the check
+    degrades to a plain anchor match.  A ``{api-name}-{suffix}`` file whose
+    suffix is not itself an API name (a per-operation split) still matches
+    its base API, since no longer API name is anchored on it.
+    """
+    if not _stem_anchors_api(stem, api_name):
+        return False
+    return not any(
+        other != api_name
+        and len(other) > len(api_name)
+        and _stem_anchors_api(stem, other)
+        for other in all_api_names
+    )
 
 
 def check_test_directory_exists(
@@ -85,7 +114,7 @@ def check_test_files_exist(
         f for f in test_dir.iterdir()
         if f.is_file()
         and f.suffix == ".feature"
-        and _stem_matches_api(f.stem, api.api_name)
+        and _stem_matches_api(f.stem, api.api_name, context.all_api_names)
     ]
 
     if matching:
@@ -199,7 +228,7 @@ def check_test_file_version(
         f for f in test_dir.iterdir()
         if f.is_file()
         and f.suffix == ".feature"
-        and _stem_matches_api(f.stem, api.api_name)
+        and _stem_matches_api(f.stem, api.api_name, context.all_api_names)
     ]
 
     if not matching:

--- a/validation/engines/python_checks/version_checks.py
+++ b/validation/engines/python_checks/version_checks.py
@@ -293,7 +293,7 @@ def check_feature_file_url_version(
         f for f in test_dir.iterdir()
         if f.is_file()
         and f.suffix == ".feature"
-        and _stem_matches_api(f.stem, api.api_name)
+        and _stem_matches_api(f.stem, api.api_name, context.all_api_names)
     ]
     if not matching:
         return []

--- a/validation/tests/test_context_builder.py
+++ b/validation/tests/test_context_builder.py
@@ -239,7 +239,8 @@ class TestValidationContextToDict:
             "target_release_type", "commonalities_release",
             "commonalities_version", "icm_release",
             "base_ref", "is_release_review_pr", "release_plan_changed",
-            "pr_number", "apis", "workflow_run_url", "tooling_ref",
+            "pr_number", "apis", "all_api_names",
+            "workflow_run_url", "tooling_ref",
             # Release-plan validation context (Step 6b outputs)
             "commonalities_release_changed", "icm_release_changed",
             "release_plan_check_only",

--- a/validation/tests/test_python_checks_test.py
+++ b/validation/tests/test_python_checks_test.py
@@ -24,6 +24,7 @@ def _make_context(
     version: str = "1.0.0",
     apis: tuple[ApiContext, ...] | None = None,
     branch_type: str = "main",
+    all_api_names: tuple[str, ...] | None = None,
 ) -> ValidationContext:
     if apis is None:
         api = ApiContext(
@@ -35,6 +36,11 @@ def _make_context(
             spec_file=f"code/API_definitions/{api_name}.yaml",
         )
         apis = (api,)
+    # Mirror the production build: all_api_names covers the whole release
+    # scope.  Tests that emulate the per-API narrowing pass a single api in
+    # `apis` but the full set in `all_api_names`.
+    if all_api_names is None:
+        all_api_names = tuple(a.api_name for a in apis)
     return ValidationContext(
         repository="TestRepo",
         branch_type=branch_type,
@@ -50,6 +56,7 @@ def _make_context(
         release_plan_changed=None,
         pr_number=None,
         apis=apis,
+        all_api_names=all_api_names,
         workflow_run_url="",
         tooling_ref="",
     )
@@ -478,3 +485,66 @@ class TestCheckTestFileVersion:
         findings = check_test_file_version(tmp_path, ctx)
         assert len(findings) == 1
         assert "deleteSession" in findings[0]["path"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: feature-file→API matcher prefix collision (tooling#365)
+# ---------------------------------------------------------------------------
+
+
+class TestSiblingApiPrefixCollision:
+    """A prefix-sibling API must not claim a longer sibling's feature file.
+
+    Constellation from DedicatedNetworks r2.2: ``dedicated-network`` (a
+    prefix of ``dedicated-network-areas``) shared the matcher and
+    over-claimed ``dedicated-network-areas.feature``.  The longest matching
+    API name wins.
+    """
+
+    _BOTH = ("dedicated-network", "dedicated-network-areas")
+
+    def test_p007_shorter_api_does_not_claim_longer_siblings_file(
+        self, tmp_path: Path
+    ):
+        # Areas file correctly targets the areas API (v0.1.0-rc.1).  Under
+        # the base dedicated-network release context (v0.2.0-rc.1) it must
+        # not be version-checked at all.
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "dedicated-network.feature").write_text(
+            "Feature: CAMARA Dedicated Network, v0.2.0-rc.1 - Operation a\n"
+        )
+        (test_dir / "dedicated-network-areas.feature").write_text(
+            "Feature: CAMARA Dedicated Network Areas, v0.1.0-rc.1 - Op b\n"
+        )
+        ctx = _make_context(
+            "dedicated-network", version="0.2.0-rc.1", branch_type="release",
+            all_api_names=self._BOTH,
+        )
+        assert check_test_file_version(tmp_path, ctx) == []
+
+    def test_files_exist_shorter_api_needs_its_own_file(
+        self, tmp_path: Path
+    ):
+        # Only the areas file is present.  The base dedicated-network API
+        # must not borrow it — it has no feature file of its own.
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "dedicated-network-areas.feature").touch()
+        ctx = _make_context(
+            "dedicated-network", all_api_names=self._BOTH,
+        )
+        findings = check_test_files_exist(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-test-files-exist"
+        assert findings[0]["api_name"] == "dedicated-network"
+
+    def test_files_exist_operation_split_still_claimed(
+        self, tmp_path: Path
+    ):
+        # A per-operation split whose suffix is not an API name stays with
+        # the base API — no over-correction.
+        test_dir = _make_test_dir(tmp_path)
+        (test_dir / "dedicated-network-createNetwork.feature").touch()
+        ctx = _make_context(
+            "dedicated-network", all_api_names=self._BOTH,
+        )
+        assert check_test_files_exist(tmp_path, ctx) == []

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -26,6 +26,7 @@ def _make_context(
     api_name: str = "quality-on-demand",
     branch_type: str = "main",
     version: str = "1.0.0",
+    all_api_names: tuple[str, ...] | None = None,
 ) -> ValidationContext:
     api = ApiContext(
         api_name=api_name,
@@ -35,6 +36,10 @@ def _make_context(
         api_pattern="request-response",
         spec_file=f"code/API_definitions/{api_name}.yaml",
     )
+    # all_api_names covers the whole release scope.  Tests that emulate the
+    # per-API narrowing pass a single api but the full sibling set here.
+    if all_api_names is None:
+        all_api_names = (api_name,)
     return ValidationContext(
         repository="TestRepo",
         branch_type=branch_type,
@@ -50,6 +55,7 @@ def _make_context(
         release_plan_changed=None,
         pr_number=None,
         apis=(api,),
+        all_api_names=all_api_names,
         workflow_run_url="",
         tooling_ref="",
     )
@@ -524,3 +530,85 @@ class TestCheckFeatureFileUrlVersion:
         )
         ctx = _make_context("qod", branch_type="main", version="wip")
         assert check_feature_file_url_version(tmp_path, ctx) == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: feature-file→API matcher prefix collision (tooling#365)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFileUrlVersionSiblingCollision:
+    """P-025 must not fire on a sibling API's feature file.
+
+    Constellation from DedicatedNetworks r2.2: two APIs where one name is a
+    prefix of the other, at different versions.  The shorter API
+    (``dedicated-network``, v0.2rc1) must not claim
+    ``dedicated-network-areas.feature`` (v0.1rc1), which belongs to the
+    longer sibling.  The longest matching API name wins.
+    """
+
+    _BOTH = ("dedicated-network", "dedicated-network-areas")
+
+    def test_shorter_api_does_not_claim_longer_siblings_file(
+        self, tmp_path: Path
+    ):
+        # dedicated-network-areas.feature correctly targets the areas API
+        # (v0.1rc1).  Under the base dedicated-network context (v0.2rc1) it
+        # must not be scanned at all — otherwise its /v0.1rc1 steps read as
+        # 11 false P-025 errors.
+        _write_spec(tmp_path, "dedicated-network", "0.2.0-rc.1")
+        _write_feature(
+            tmp_path, "dedicated-network.feature",
+            "Feature: Dedicated Network, v0.2rc1\n"
+            "  When I send a POST to /dedicated-network/v0.2rc1/networks\n",
+        )
+        _write_feature(
+            tmp_path, "dedicated-network-areas.feature",
+            "Feature: Dedicated Network Areas, v0.1rc1\n"
+            "  When I send a POST to /dedicated-network-areas/v0.1rc1/areas\n",
+        )
+        ctx = _make_context(
+            "dedicated-network", branch_type="release", version="0.2.0-rc.1",
+            all_api_names=self._BOTH,
+        )
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
+    def test_longer_sibling_still_validates_its_own_file(
+        self, tmp_path: Path
+    ):
+        # The areas API still owns and validates its own file: a wrong
+        # segment there is a real P-025.
+        _write_spec(tmp_path, "dedicated-network-areas", "0.1.0-rc.1")
+        _write_feature(
+            tmp_path, "dedicated-network-areas.feature",
+            "Feature: Dedicated Network Areas, v0.1rc1\n"
+            "  When I send a POST to /dedicated-network-areas/v0.2rc1/areas\n",
+        )
+        ctx = _make_context(
+            "dedicated-network-areas", branch_type="release",
+            version="0.1.0-rc.1", all_api_names=self._BOTH,
+        )
+        findings = check_feature_file_url_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-feature-file-url-version"
+        assert "dedicated-network-areas.feature" in findings[0]["path"]
+
+    def test_operation_split_file_still_claimed_by_base_api(
+        self, tmp_path: Path
+    ):
+        # A per-operation split file whose suffix is NOT itself an API name
+        # (no dedicated-network-networks API) stays with the base API, so a
+        # wrong segment there is still caught — no over-correction.
+        _write_spec(tmp_path, "dedicated-network", "0.2.0-rc.1")
+        _write_feature(
+            tmp_path, "dedicated-network-networks.feature",
+            "Feature: Dedicated Network, v0.2rc1\n"
+            "  When I send a POST to /dedicated-network/v0.1rc1/networks\n",
+        )
+        ctx = _make_context(
+            "dedicated-network", branch_type="release", version="0.2.0-rc.1",
+            all_api_names=self._BOTH,
+        )
+        findings = check_feature_file_url_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "dedicated-network-networks.feature" in findings[0]["path"]


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`_stem_matches_api` matched a feature-file stem `{api-name}-{suffix}` to `{api-name}`, so when one API name is a prefix of a sibling's (e.g. `dedicated-network` vs `dedicated-network-areas`), the shorter API claimed the sibling's `.feature` file and validated it against the wrong `info.version`. On DedicatedNetworks r2.2 (camaraproject/DedicatedNetworks#128) this surfaced as 11 false P-025 errors + 1 false P-007 hint on `dedicated-network-areas.feature`.

Root cause ran deeper than the matcher: the per-API dispatch in `python_adapter.py` narrows `context.apis` to a single element, so the three feature-file checks never saw sibling API names to disambiguate with.

Fix:
- Add `ValidationContext.all_api_names` — the full release-scope API-name set. It survives the per-API `dataclasses.replace` narrowing, so API-scoped checks can see their siblings.
- The matcher now lets the **longest matching API name win**: a `{api-name}-{suffix}` stem yields to a longer API name in scope that is also anchored on it. Per-operation split files (whose suffix is not itself an API name) still match their base API.
- All three callers consult it: `check-test-file-version` (P-007), `check-feature-file-url-version` (P-025), and `check-test-files-exist`.

#### Which issue(s) this PR fixes:

Fixes #365

#### Special notes for reviewers:

Regression tests use the real DedicatedNetworks constellation (`dedicated-network` + `dedicated-network-areas` at different versions), covering all three callers plus the per-operation-split case (no over-correction). Regression and existing `test_python_checks_*` / `test_context_builder` unit tests pass locally.

#### Changelog input

```
 release-note
Fix feature-file→API matching so a prefix-sibling API no longer claims a longer sibling's test file (eliminates false P-025/P-007 on repos with prefix-related API names).
```

#### Additional documentation

This section can be blank.

```
docs

```
