### PR TITLE
fix(validation): catch hyphenated URL version segments

### DIFF
--- a/validation/engines/python_checks/version_checks.py
+++ b/validation/engines/python_checks/version_checks.py
@@ -24,26 +24,40 @@ _SEMVER_RE = re.compile(
     r"(?:-(?P<pre>[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*))?$"
 )
 
+_API_NAME_SEGMENT_RE = r"(?P<api_name>[a-z0-9][a-z0-9\-]*)"
+_VERSION_SEGMENT_RE = r"(?P<version>v[^/\"'\s?#]+|wip)"
+_VERSION_SEGMENT_BOUNDARY_RE = r"(?=/|\s|$|[\"'?#])"
+
 # Extracts the version segment from a server URL path.
-# Matches the last path component starting with "v".
+# Matches a complete final path component starting with "v" or the bare
+# "wip" segment after an API-shaped path segment.
 # e.g. "https://example.com/qod/v1" -> "v1"
 #      "{apiRoot}/quality-on-demand/v0.2alpha2" -> "v0.2alpha2"
-_URL_VERSION_RE = re.compile(r"/(?P<version>v[a-z0-9.]+)/?$", re.IGNORECASE)
+#      "{apiRoot}/quality-on-demand/v0.1-eri" -> "v0.1-eri"
+_URL_VERSION_RE = re.compile(
+    rf"/{_API_NAME_SEGMENT_RE}/{_VERSION_SEGMENT_RE}/?(?:[?#].*)?$",
+    re.IGNORECASE,
+)
 
 # Extracts the api-name segment from a server URL (segment before version).
 # e.g. "{apiRoot}/quality-on-demand/v1" -> "quality-on-demand"
-_URL_API_NAME_RE = re.compile(r"/(?P<api_name>[^/]+)/v[a-z0-9.]+/?$", re.IGNORECASE)
+_URL_API_NAME_RE = re.compile(
+    rf"/{_API_NAME_SEGMENT_RE}/(?:v[^/\"'\s?#]+|wip)/?(?:[?#].*)?$",
+    re.IGNORECASE,
+)
 
 # Matches a CAMARA-shaped version segment inside a scenario-step URL path:
 # an api-name segment (lowercase letters/digits/hyphens) followed by
-# either ``v{segment}`` or bare ``wip`` as the next segment. Used by P-025
-# to locate the version-bearing portion of a URL anywhere in a feature-
-# file line (not just at the end of the URL).
+# either ``v{segment}`` or bare ``wip`` as the next segment. The version
+# capture intentionally takes the whole path segment, including malformed
+# values such as ``v0.1-eri``, so P-025 can report a mismatch instead of
+# silently skipping the line.
 # e.g. ``/quality-on-demand/vwip/sessions`` -> captured segment ``vwip``
 #      ``/qod/v1/sessions``                 -> captured ``v1``
 #      ``/device-status/wip/status``        -> captured ``wip``
 _STEP_URL_VERSION_RE = re.compile(
-    r"/[a-z0-9\-]+/(v[a-z0-9.]+|wip)(?=/|\s|$)",
+    rf"/[a-z0-9][a-z0-9\-]*/{_VERSION_SEGMENT_RE}"
+    rf"{_VERSION_SEGMENT_BOUNDARY_RE}",
     re.IGNORECASE,
 )
 
@@ -310,7 +324,7 @@ def check_feature_file_url_version(
 
         for line_number, line in enumerate(lines, start=1):
             for match in _STEP_URL_VERSION_RE.finditer(line):
-                actual_segment = match.group(1)
+                actual_segment = match.group("version")
                 if actual_segment.lower() == expected_lower:
                     continue
                 findings.append(

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -273,6 +273,20 @@ class TestCheckServerUrlVersion:
         assert len(findings) == 1
         assert "no recognisable version" in findings[0]["message"]
 
+    def test_malformed_hyphenated_version_segment_is_error(self, tmp_path: Path):
+        _write_spec(
+            tmp_path, "dedicated-network-areas", "wip",
+            server_urls=["{apiRoot}/dedicated-network-areas/v0.1-eri"],
+        )
+        ctx = _make_context(
+            "dedicated-network-areas", branch_type="main", version="wip"
+        )
+        findings = check_server_url_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "v0.1-eri" in findings[0]["message"]
+        assert "vwip" in findings[0]["message"]
+        assert "no recognisable version" not in findings[0]["message"]
+
     def test_no_servers(self, tmp_path: Path):
         _write_spec(tmp_path, "qod", "1.0.0")
         ctx = _make_context("qod")
@@ -430,6 +444,24 @@ class TestCheckFeatureFileUrlVersion:
         assert len(findings) == 1
         assert "/v1" in findings[0]["message"]
         assert "/vwip" in findings[0]["message"]
+
+    def test_main_hyphenated_version_segment_is_error(self, tmp_path: Path):
+        _write_spec(tmp_path, "dedicated-network-areas", "wip")
+        _write_feature(
+            tmp_path, "dedicated-network-areas.feature",
+            "Feature: Dedicated Network Areas, vwip\n"
+            "  Given the resource "
+            '"/dedicated-network-areas/v0.1-eri/retrieve-service-areas"\n',
+        )
+        ctx = _make_context(
+            "dedicated-network-areas", branch_type="main", version="wip"
+        )
+        findings = check_feature_file_url_version(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "check-feature-file-url-version"
+        assert "/v0.1-eri" in findings[0]["message"]
+        assert "/vwip" in findings[0]["message"]
+        assert findings[0]["line"] == 2
 
     def test_release_matching_version_passes(self, tmp_path: Path):
         _write_spec(tmp_path, "qod", "1.0.0")


### PR DESCRIPTION
#### What type of PR is this?

bug


#### What this PR does / why we need it:

Updates URL version-segment matching so validation captures the complete version path segment after an API-shaped segment, including malformed values such as `v0.1-eri`.

This makes P-025 report malformed feature-file URL versions instead of silently skipping them, and makes P-004 report malformed server URL version segments as mismatches rather than as missing/unrecognisable versions.


#### Which issue(s) this PR fixes:

Fixes #367

#### Special notes for reviewers:

The change keeps URLs without any version-like segment in the existing “no recognisable version” path. The new behavior only applies when the segment is version-like (`v...` or `wip`) but malformed or unexpected.


#### Changelog input

```
 release-note
NONE
```

#### Additional documentation 

This section can be blank.


```
docs
NONE
```
