### PR TITLE
Review PR template: readiness-note fix and RM reviewer-assignment action

### DIFF
--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -16,7 +16,7 @@ Edit and review this PR before merging it into the release snapshot. After Codeo
 
 ### Codeowner Actions
 
-_Tick each box once done. Release Management review starts when all three boxes are ticked._
+_Tick each box once done. Ticking the last box — "The release is ready for Release Management review" — starts the Release Management review._
 
 - [ ] **Update the CHANGELOG**
 

--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -45,6 +45,9 @@ _Tick each box once done. Ticking the last box — "The release is ready for Rel
 
 ### Release Management Actions
 
+_The following actions and checks are done by a Release Management reviewer before approving the PR:_
+
+- [ ] **Assign the Release Management reviewer(s) as assignee(s) of this PR**
 - [ ] CHANGELOG follows the release documentation rules
 - [ ] Breaking changes are documented and version updates follow SemVer rules
 - [ ] Mandatory release assets are present for each API according to its status

--- a/release_automation/tests/test_template_loader.py
+++ b/release_automation/tests/test_template_loader.py
@@ -47,6 +47,8 @@ class TestRenderTemplate:
         assert "Commonalities r3.4" in result
         assert "Mandatory release assets are present for each API according to its status" in result
         assert "All remaining validation warnings are documented in issues and the reasons for deferral are defensible" in result
+        assert "Assign the Release Management reviewer(s) as assignee(s) of this PR" in result
+        assert "The following actions and checks are done by a Release Management reviewer before approving the PR" in result
         assert "### Valid next actions for codeowners" in result
         assert "Snapshot: [`r4.1-abc1234`]" in result
         assert "<details>" in result


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Two edits to the Release Review PR body template (`release_review_pr.mustache`), both supporting the Release Progress Tracker's Review Queue:

- **Readiness note:** the Codeowner Actions note said review starts "when all three boxes are ticked", but the deferred-validation-warnings box is optional for alpha releases, so that misfires. It now points at the explicit "ready for Release Management review" box.
- **Reviewer assignment:** adds a first Release Management Actions checkbox — "Assign the Release Management reviewer(s) as assignee(s) of this PR" — and an intro line scoping the whole Release Management Actions section to RM reviewers, so codeowners don't take these boxes as their own. The PR assignee is the concrete reviewer surfaced by the Review Queue, so this makes the assignment an explicit review step.

No change to the release automation logic — these are template (instruction) edits only.

#### Which issue(s) this PR fixes:

Companion to camaraproject/project-administration#273 (the Review Queue view); supports the review-distribution mechanism proposed in camaraproject/ReleaseManagement#604. No tooling issue to auto-close.

#### Special notes for reviewers:

- Nothing in the release automation parses these checkboxes — they are the reviewer's manual checklist, so the change is display-only.
- Template render tests (`test_template_loader.py`) updated for the new checkbox.

#### Changelog input

```
release-note
Release Review PR template: gate the review-start note on the explicit readiness box, and add a Release Management action to assign the reviewer(s) as PR assignee(s).
```

#### Additional documentation

```
docs

```
