### PR TITLE
Prepare tooling 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- **[v0.7.1](#v071)**
 - **[v0.7.0](#v070)**
 - **[v0.6.0](#v060)**
 - **[v0.5.0](#v050)**
@@ -11,6 +12,36 @@
 - **[v0.2.2](#v022)**
 - **[v0.2.1](#v021)**
 - **[v0.2.0](#v020)**
+
+# v0.7.1
+
+## Release Notes
+
+**v0.7.1 is a patch release for the CAMARA tooling repository.**
+
+This release consolidates the fixes and refinements that landed on `main` after
+v0.7.0: two validation false-negative fixes (feature-file API-name matching and
+hyphenated URL version segments), an S-038 wording alignment and int64 safe-range
+lint refinement, a Release Review PR template change (RM reviewer-assignment
+action and readiness-note rewording), and dependency bumps. No new rule ID.
+
+### Added
+
+* Review PR template: readiness-note fix and RM reviewer-assignment action by @hdamker in https://github.com/camaraproject/tooling/pull/372
+
+### Changed
+
+* Align S-038 wording with the OpenAPI Format Registry framing by @hdamker in https://github.com/camaraproject/tooling/pull/370
+* Bump js-yaml from 5.0.0 to 5.2.1 by @dependabot in https://github.com/camaraproject/tooling/pull/363
+* Bump @redocly/cli from 2.34.0 to 2.37.0 by @dependabot in https://github.com/camaraproject/tooling/pull/364
+* Bump @stoplight/spectral-cli from 6.16.0 to 6.16.1 by @dependabot in https://github.com/camaraproject/tooling/pull/362
+
+### Fixed
+
+* Match feature files to the longest API name in scope by @hdamker in https://github.com/camaraproject/tooling/pull/366
+* Flag hyphenated URL version segments by @hdamker in https://github.com/camaraproject/tooling/pull/369
+
+**Full Changelog**: https://github.com/camaraproject/tooling/compare/v0.7.0...v0.7.1
 
 # v0.7.0
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ tooling/
 * **[`VERSION.yaml`](VERSION.yaml)** — records the current numbered tooling release version.
 * **[`CHANGELOG.md`](CHANGELOG.md)** — records numbered release notes and links to GitHub comparisons.
 * **`v1-rc`** — floating lightweight tag covering the validation and release automation framework v1 release candidate. This is the active consumption line for CAMARA API repositories.
-* **Numbered release tags** — immutable tags such as `v0.7.0` mark release points on `main`.
+* **Numbered release tags** — immutable tags such as `v0.7.1` mark release points on `main`.
 * **`v0`** — retired legacy linting tag. It is kept for historical compatibility and is not advanced for new releases.
 * **`main`** — active development branch.
 

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.7.0
+version: 0.7.1


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Prepares the numbered **tooling 0.7.1** release. It consolidates the fixes and refinements that landed on `main` since v0.7.0:

* Feature-file API-name matcher prefix-collision fix (#366)
* Hyphenated URL version-segment false-negative fix — P-025 / P-004 (#369)
* S-038 wording aligned with the OpenAPI Format Registry framing, plus an int64 safe-range lint refinement (#370)
* Release Review PR template: readiness-note fix and RM reviewer-assignment action (#372)
* Dependency bumps: js-yaml 5.0.0 → 5.2.1 (#363), @redocly/cli 2.34.0 → 2.37.0 (#364), @stoplight/spectral-cli 6.16.0 → 6.16.1 (#362)

Changes: `VERSION.yaml` → 0.7.1, a `v0.7.1` `CHANGELOG.md` section, and a README release-information tag touch-up. No new rule ID.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Numbered release PR — `v1-rc` is moved to the released commit after merge. Both regression canaries are green against `main`, so the gate is the same canary basis used for the 0.7.0 release (no manual E2E): the validation regression canary (11/11) covers the validation and linting changes, and the release-automation regression canary covers the #372 Review PR template change.

#### Changelog input

```
 release-note
Prepare tooling 0.7.1 release: consolidates fixes and refinements since v0.7.0 — feature-file API-name matcher fix, hyphenated URL version-segment fix (P-025/P-004), S-038 wording plus int64 safe-range refinement, Release Review PR template updates, and dependency bumps.
```

#### Additional documentation

This section can be blank.

```
docs
NONE
```
