### PR TITLE
Make unused-component detection discriminator-aware

### DIFF
--- a/documentation/validation/faq.md
+++ b/documentation/validation/faq.md
@@ -35,13 +35,13 @@ A tag used on an operation must also be declared in the OpenAPI document's top-l
 
 <a name="s-211-unused-component"></a>
 <details>
-<summary>[S-211] Why is an unused component only a hint?</summary>
+<summary>[S-211] Why is a component reported as unused?</summary>
 
 Applies to: `[S-211] Component may be unused`
 
-The check may not follow every discriminator mapping. A component that looks unused to the check may still be referenced indirectly. The hint is a prompt to verify, not an instruction to remove.
+The check follows regular OpenAPI references and local `discriminator.mapping` targets. It reports a warning when a reusable component is not reached through either mechanism.
 
-**What you do:** confirm the component is genuinely unused — for example, by checking discriminator mappings and any oneOf/anyOf indirection — before removing it. If it is in use indirectly, no change is needed.
+**What you do:** remove the obsolete component, or add the missing `$ref` or discriminator mapping that connects it to the API definition.
 
 </details>
 

--- a/linting/config/.spectral-r3.4.yaml
+++ b/linting/config/.spectral-r3.4.yaml
@@ -69,6 +69,7 @@ rules:
     description: >
       Detects unused OpenAPI components while treating discriminator mapping
       targets as references.
+    formats: ["oas3"]
     resolved: false
     given: "$"
     then:

--- a/linting/config/.spectral-r3.4.yaml
+++ b/linting/config/.spectral-r3.4.yaml
@@ -8,6 +8,7 @@
 # - 03.12.2024: Corrected camara-path-param-id and camara-discriminator-use to handle null values error in example fields
 # - 09.01.2025: Updated info-contact rule
 # - 21.07.2025: Added camara-schema-type-check rule
+# - 16.07.2026: Made unused-component detection discriminator-aware (S-211)
 
 
 extends: "spectral:oas"
@@ -16,6 +17,7 @@ functions:
   - camara-language-avoid-telco
   - camara-security-no-secrets-in-path-or-query-parameters
   - camara-schema-casing-convention
+  - camara-discriminator-aware-unused-component
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -54,12 +56,24 @@ rules:
   oas3-schema: true
   oas3-server-not-example.com: false
   oas3-server-trailing-slash: true
-  oas3-unused-component: true
+  oas3-unused-component: false
   oas3-valid-media-example: true
   oas3-valid-schema-example: true
   # oas3-server-variables: true
 
   # Custom Rules Utilizing Spectral's Built-in Functions and JavaScript Implementations
+
+  camara-discriminator-aware-unused-component:
+    message: "Potentially unused component has been detected."
+    severity: warn
+    description: >
+      Detects unused OpenAPI components while treating discriminator mapping
+      targets as references.
+    resolved: false
+    given: "$"
+    then:
+      function: camara-discriminator-aware-unused-component
+    recommended: true
 
   camara-language-avoid-telco:
     message: "{{error}}"

--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -92,6 +92,7 @@ rules:
     description: >
       Detects unused OpenAPI components while treating discriminator mapping
       targets as references.
+    formats: ["oas3"]
     resolved: false
     given: "$"
     then:

--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -17,6 +17,7 @@
 # - 14.06.2026: Added camara-integer-safe-range rule (S-038)
 # - 08.07.2026: Reworded S-038 description and message to the OpenAPI Format Registry framing
 # - 15.07.2026: Added x-correlator documentation rules (S-039, S-040)
+# - 16.07.2026: Made unused-component detection discriminator-aware (S-211)
 
 
 # Note: @stoplight/spectral-owasp-ruleset is installed via validation/package.json.
@@ -39,6 +40,7 @@ functions:
   - camara-no-numeric-resource-ids
   - camara-integer-safe-range
   - camara-x-correlator-documentation
+  - camara-discriminator-aware-unused-component
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -77,12 +79,24 @@ rules:
   oas3-schema: true
   oas3-server-not-example.com: false
   oas3-server-trailing-slash: true
-  oas3-unused-component: true
+  oas3-unused-component: false
   oas3-valid-media-example: true
   oas3-valid-schema-example: true
   # oas3-server-variables: true
 
   # Custom Rules Utilizing Spectral's Built-in Functions and JavaScript Implementations
+
+  camara-discriminator-aware-unused-component:
+    message: "Potentially unused component has been detected."
+    severity: warn
+    description: >
+      Detects unused OpenAPI components while treating discriminator mapping
+      targets as references.
+    resolved: false
+    given: "$"
+    then:
+      function: camara-discriminator-aware-unused-component
+    recommended: true
 
   camara-language-avoid-telco:
     message: "{{error}}"

--- a/linting/config/.spectral.yaml
+++ b/linting/config/.spectral.yaml
@@ -7,6 +7,7 @@
 # - 09.01.2025: Updated info-contact rule
 # - 21.07.2025: Added camara-schema-type-check rule
 # - 12.01.2026: camara-discriminator-use deprecated
+# - 16.07.2026: Made unused-component detection discriminator-aware (S-211)
 
 
 extends: "spectral:oas"
@@ -14,6 +15,7 @@ functions:
   - camara-reserved-words
   - camara-language-avoid-telco
   - camara-security-no-secrets-in-path-or-query-parameters
+  - camara-discriminator-aware-unused-component
 functionsDir: "./lint_function"
 rules:
   #  Built-in OpenAPI Specification ruleset. Each rule then can be enabled individually.
@@ -52,12 +54,24 @@ rules:
   oas3-schema: true
   oas3-server-not-example.com: false
   oas3-server-trailing-slash: true
-  oas3-unused-component: true
+  oas3-unused-component: false
   oas3-valid-media-example: true
   oas3-valid-schema-example: true
   # oas3-server-variables: true
 
   # Custom Rules Utilizing Spectral's Built-in Functions and JavaScript Implementations
+
+  camara-discriminator-aware-unused-component:
+    message: "Potentially unused component has been detected."
+    severity: warn
+    description: >
+      Detects unused OpenAPI components while treating discriminator mapping
+      targets as references.
+    resolved: false
+    given: "$"
+    then:
+      function: camara-discriminator-aware-unused-component
+    recommended: true
 
   camara-language-avoid-telco:
     message: "{{error}}"

--- a/linting/config/.spectral.yaml
+++ b/linting/config/.spectral.yaml
@@ -67,6 +67,7 @@ rules:
     description: >
       Detects unused OpenAPI components while treating discriminator mapping
       targets as references.
+    formats: ["oas3"]
     resolved: false
     given: "$"
     then:

--- a/linting/config/lint_function/camara-discriminator-aware-unused-component.js
+++ b/linting/config/lint_function/camara-discriminator-aware-unused-component.js
@@ -1,0 +1,108 @@
+// CAMARA Project - support function for Spectral linter
+// Extends Spectral's unused-component detection with discriminator mappings.
+
+const COMPONENT_TYPES = [
+  "schemas",
+  "responses",
+  "parameters",
+  "examples",
+  "requestBodies",
+  "headers",
+  "links",
+  "callbacks",
+];
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function decodePointer(value) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    decoded = value;
+  }
+  return decoded.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+function mappingTargetPath(target, documentSource, schemas) {
+  if (typeof target !== "string") return null;
+
+  const decodedTarget = decodePointer(target.trim());
+  if (decodedTarget.startsWith("#/components/schemas/")) {
+    return `${documentSource}${decodedTarget}`;
+  }
+
+  if (
+    !decodedTarget.includes("/") &&
+    !decodedTarget.includes("#") &&
+    Object.hasOwn(schemas, decodedTarget)
+  ) {
+    return `${documentSource}#/components/schemas/${decodedTarget}`;
+  }
+
+  return null;
+}
+
+function collectDiscriminatorTargets(document, documentSource, schemas) {
+  const targets = new Set();
+  const visited = new WeakSet();
+
+  function walk(value) {
+    if (value === null || typeof value !== "object" || visited.has(value)) return;
+    visited.add(value);
+
+    if (isObject(value.discriminator?.mapping)) {
+      for (const target of Object.values(value.discriminator.mapping)) {
+        const targetPath = mappingTargetPath(target, documentSource, schemas);
+        if (targetPath !== null) targets.add(targetPath);
+      }
+    }
+
+    for (const child of Object.values(value)) walk(child);
+  }
+
+  walk(document);
+  return targets;
+}
+
+export default (document, _options, context) => {
+  const graph = context.documentInventory.graph;
+  if (graph === null) {
+    throw new Error(
+      "camara-discriminator-aware-unused-component requires dependency graph"
+    );
+  }
+
+  const documentSource = context.document.source ?? "";
+  const schemas = isObject(document.components?.schemas)
+    ? document.components.schemas
+    : {};
+  const referenced = new Set(graph.overallOrder().map(decodePointer));
+  for (const target of collectDiscriminatorTargets(
+    document,
+    documentSource,
+    schemas
+  )) {
+    referenced.add(target);
+  }
+
+  const findings = [];
+  for (const type of COMPONENT_TYPES) {
+    const components = document.components?.[type];
+    if (!isObject(components)) continue;
+
+    for (const name of Object.keys(components)) {
+      const componentPath = `${documentSource}#/components/${type}/${name}`;
+      if (!referenced.has(componentPath)) {
+        findings.push({
+          message: "Potentially unused component has been detected",
+          path: [...context.path, "components", type, name],
+        });
+      }
+    }
+  }
+
+  return findings;
+};

--- a/validation/docs/user-documentation-guidelines.md
+++ b/validation/docs/user-documentation-guidelines.md
@@ -314,7 +314,7 @@ Recommended first FAQ entries:
 | `[P-022]` | Why must `release-plan.yaml` change in its own PR? |
 | `[P-023]` | Why does CAMARA Validation say a dependency tag was not found? |
 | `[S-024]`, `[S-307]` | Why do operations need standard error responses? |
-| `[S-211]` | Why is an unused component only a hint? |
+| `[S-211]` | Why is a component reported as unused? |
 | `[S-037]` | Why should resource identifiers not be numeric? |
 | `[S-309]` to `[S-313]` | Why do arrays, integers, and strings need limits? |
 

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -251,13 +251,13 @@ fixes:
 
 proposed_changes:
   - rule_id: S-211
-    engine_rule: oas3-unused-component
-    change: Keep Spectral severity (warn), add conditional_level default=hint in metadata
+    engine_rule: camara-discriminator-aware-unused-component
+    change: Replace the stock rule with discriminator-aware unused-component detection
     reason: >
-      Spectral does not follow discriminator mappings — schemas referenced
-      only via discriminator appear as unused. False positives on subscription
-      event schemas (e.g. EventApiSpecific1, EventSubscriptionStarted).
-      Unused schemas are cosmetic, not harmful.
+      Spectral does not follow discriminator mappings. The custom rule keeps
+      dependency-graph detection for regular references and also counts local
+      discriminator mapping targets, removing false positives without muting
+      genuinely unused components.
     status: done
 
   - rule_id: S-313

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -288,12 +288,10 @@
 
 - id: S-211
   engine: spectral
-  engine_rule: oas3-unused-component
+  engine_rule: camara-discriminator-aware-unused-component
   short_title: "Component may be unused"
-  suggestion: "Spectral does not follow discriminator mappings — verify the schema is truly unused."
+  suggestion: "Remove the component if it is obsolete, or reference it from the API definition."
   documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#s-211-unused-component"
-  conditional_level:
-    default: hint
 
 - id: S-212
   engine: spectral

--- a/validation/tests/test_spectral_unused_components.py
+++ b/validation/tests/test_spectral_unused_components.py
@@ -106,6 +106,16 @@ components:
       type: object
 """
 
+_COMPONENTS_ONLY_SPEC = """\
+components:
+  schemas:
+    SharedEvent:
+      type: object
+  responses:
+    SharedResponse:
+      description: OK
+"""
+
 
 @pytest.mark.parametrize("ruleset", _RULESETS, ids=lambda path: path.name)
 def test_discriminator_mapping_counts_as_schema_reference(ruleset: Path):
@@ -120,6 +130,13 @@ def test_regular_refs_still_count_and_other_component_types_are_checked():
 
     assert ["components", "responses", "EventResponse"] not in paths
     assert ["components", "responses", "UnusedResponse"] in paths
+
+
+@pytest.mark.parametrize("ruleset", _RULESETS, ids=lambda path: path.name)
+def test_components_only_documents_are_not_checked(ruleset: Path):
+    paths = _unused_component_paths(_run_spectral(_COMPONENTS_ONLY_SPEC, ruleset))
+
+    assert paths == []
 
 
 def test_plain_schema_name_mapping_counts_as_reference():

--- a/validation/tests/test_spectral_unused_components.py
+++ b/validation/tests/test_spectral_unused_components.py
@@ -1,0 +1,153 @@
+"""Regression tests for discriminator-aware unused-component rule S-211."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_RULESET = _REPO_ROOT / "linting" / "config" / ".spectral-r4.yaml"
+_RULESETS = [
+    _REPO_ROOT / "linting" / "config" / ".spectral.yaml",
+    _REPO_ROOT / "linting" / "config" / ".spectral-r3.4.yaml",
+    _RULESET,
+]
+_NODE_MODULES = _REPO_ROOT / "validation" / "node_modules"
+_RULE = "camara-discriminator-aware-unused-component"
+
+
+def _run_spectral(spec: str, ruleset: Path = _RULESET) -> list[dict]:
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as file:
+        file.write(spec)
+        file.flush()
+        spec_path = Path(file.name)
+
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "NODE_PATH": str(_NODE_MODULES),
+        "HOME": os.environ.get("HOME", ""),
+    }
+    try:
+        result = subprocess.run(
+            [
+                "node",
+                str(_NODE_MODULES / ".bin" / "spectral"),
+                "lint",
+                str(spec_path),
+                "-r",
+                str(ruleset),
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+    finally:
+        spec_path.unlink(missing_ok=True)
+
+    assert result.stdout.strip(), result.stderr
+    return json.loads(result.stdout)
+
+
+def _unused_component_paths(findings: list[dict]) -> list[list[str]]:
+    return [finding["path"] for finding in findings if finding["code"] == _RULE]
+
+
+_SPEC = """\
+openapi: 3.0.3
+info:
+  title: Unused Component Test
+  version: wip
+paths:
+  /events:
+    get:
+      operationId: getEvents
+      responses:
+        "200":
+          $ref: "#/components/responses/EventResponse"
+components:
+  responses:
+    EventResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BaseEvent"
+    UnusedResponse:
+      description: Not referenced
+  schemas:
+    BaseEvent:
+      type: object
+      required:
+        - eventType
+      properties:
+        eventType:
+          type: string
+      discriminator:
+        propertyName: eventType
+        mapping:
+          started: "#/components/schemas/StartedEvent"
+    StartedEvent:
+      allOf:
+        - $ref: "#/components/schemas/BaseEvent"
+        - type: object
+          properties:
+            startedAt:
+              type: string
+    UnusedEvent:
+      type: object
+"""
+
+
+@pytest.mark.parametrize("ruleset", _RULESETS, ids=lambda path: path.name)
+def test_discriminator_mapping_counts_as_schema_reference(ruleset: Path):
+    paths = _unused_component_paths(_run_spectral(_SPEC, ruleset))
+
+    assert ["components", "schemas", "StartedEvent"] not in paths
+    assert ["components", "schemas", "UnusedEvent"] in paths
+
+
+def test_regular_refs_still_count_and_other_component_types_are_checked():
+    paths = _unused_component_paths(_run_spectral(_SPEC))
+
+    assert ["components", "responses", "EventResponse"] not in paths
+    assert ["components", "responses", "UnusedResponse"] in paths
+
+
+def test_plain_schema_name_mapping_counts_as_reference():
+    spec = _SPEC.replace(
+        'started: "#/components/schemas/StartedEvent"',
+        "started: StartedEvent",
+    )
+
+    paths = _unused_component_paths(_run_spectral(spec))
+
+    assert ["components", "schemas", "StartedEvent"] not in paths
+
+
+def test_external_mapping_does_not_mark_same_named_local_schema_as_used():
+    spec = _SPEC.replace(
+        'started: "#/components/schemas/StartedEvent"',
+        'started: "./events.yaml#/components/schemas/StartedEvent"',
+    )
+
+    paths = _unused_component_paths(_run_spectral(spec))
+
+    assert ["components", "schemas", "StartedEvent"] in paths
+
+
+def test_unused_component_findings_are_warnings():
+    findings = [
+        finding for finding in _run_spectral(_SPEC) if finding["code"] == _RULE
+    ]
+
+    assert findings
+    assert {finding["severity"] for finding in findings} == {1}


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Replaces Spectral's stock unused-component rule with a CAMARA rule across the fallback, r3.4, and r4 configurations. The rule preserves dependency-graph detection for regular `$ref` usage and also counts local `discriminator.mapping` targets.

Spectral only adds `$ref` objects to its dependency graph. Discriminator mapping targets are strings, so schemas referenced only through a mapping were incorrectly reported as unused. With those false positives removed, S-211 can return to warning severity without muting genuinely unused components.

#### Which issue(s) this PR fixes:

Fixes #377

#### Special notes for reviewers:

Validation completed:

- `python3 -m pytest validation/tests tooling_lib/tests` (`1221 passed, 4 skipped`)
- `node --check` for every custom lint function
- `git diff --check`

#### Changelog input

```
release-note
Make unused-component detection recognize local discriminator mapping targets.
```

#### Additional documentation

Updates the S-211 rule metadata, inventory entry, and FAQ guidance.

```
docs
Updated S-211 unused-component guidance.
```