### PR TITLE
docs(validation): record S-039/S-040 as regression-tested in rule inventory

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 93
+  total_tested: 95
   by_engine:
     spectral: 85
     gherkin: 25
@@ -364,6 +364,8 @@ tested_rules:
   S-034: [regression/r4.3-broken-spec-subscriptions]
   S-035: [regression/r4.3-broken-spec-subscriptions]
   S-036: [regression/r4.3-broken-spec-routing]
+  S-039: [regression/r4.3-broken-spec-error-handling]
+  S-040: [regression/r4.3-broken-spec-error-handling]
   S-201: [regression/r4.3-broken-spec-api-metadata]
   S-210: [regression/r4.3-broken-spec-api-metadata]
   S-211: [regression/r4.3-main-baseline]


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Records S-039 (`camara-x-correlator-request-parameter`) and S-040 (`camara-x-correlator-response-header`) as regression-tested in `rule-inventory.yaml`. The `regression/r4.3-broken-spec-error-handling` branch of ReleaseTest now carries deliberate x-correlator documentation defects (edits 7-9 in its `REGRESSION.md`) with the expected findings captured in its fixture, so the two rules added in #376 are pinned by the canary.

#### Which issue(s) this PR fixes:

Follow-up to #376 / #371 (both closed).

#### Special notes for reviewers:

Inventory-only change: two `tested_rules` entries plus the `total_tested` count (93 → 95, matching the map size). The ReleaseTest side is already in place and verified by a capture run.

#### Changelog input

```
release-note
Record S-039/S-040 x-correlator rules as regression-tested in the rule inventory.
```

#### Additional documentation

This section can be blank.
