### PR TITLE
fix(validation): migrate P-006/P-007/P-008 severity ramp to target_api_status

### DIFF
--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -59,25 +59,26 @@
 
 # P-006: check-test-files-exist
 #
-# Severity is a function of API maturity and release type:
-#   - default (alpha, wip, any non-rc release): hint
-#   - initial (0.x) + rc/public release: warn
-#   - stable  (>=1.x) + rc/public release: error
+# Severity ramps on target_api_status (the canonical content-ramp field; see
+# severity-assignment-guide.md §2), anchored on the public/stable obligation
+# with overrides only demoting:
+#   - default (stable @ rc/public): error
+#   - draft/alpha (either maturity): hint
+#   - initial (0.x) @ rc/public: warn
 - id: P-006
   engine: python
   engine_rule: check-test-files-exist
   short_title: "Missing test definition file for API"
   documentation_url: "https://github.com/camaraproject/tooling/blob/main/documentation/validation/faq.md#p-006-missing-test-files"
   conditional_level:
-    default: hint
+    default: error
     overrides:
       - condition:
-          target_api_maturity: [stable]
-          target_release_type: [pre-release-rc, public-release]
-        level: error
+          target_api_status: [draft, alpha]
+        level: hint
       - condition:
           target_api_maturity: [initial]
-          target_release_type: [pre-release-rc, public-release]
+          target_api_status: [rc, public]
         level: warn
   suggestion: >-
     Test files are optional for alpha releases but expected before the
@@ -90,29 +91,37 @@
 # Parses the Feature line of .feature files to extract the version
 # (e.g. "Feature: CAMARA API, vwip - Operation foo") and compares
 # against the expected version from info.version.
+#
+# Severity ramps on target_api_status, anchored on the public/stable
+# obligation (warn); initial (0.x) APIs stay at hint throughout.
 - id: P-007
   engine: python
   engine_rule: check-test-file-version
   short_title: "Test file: feature-line version mismatch"
   conditional_level:
-    default: hint
+    default: warn
     overrides:
       - condition:
-          target_api_maturity: [stable]
-          target_release_type: [pre-release-rc, public-release]
-        level: warn
+          target_api_status: [draft, alpha]
+        level: hint
+      - condition:
+          target_api_maturity: [initial]
+        level: hint
 
 # P-008: check-test-directory-exists
+#
+# Severity ramps on target_api_status, anchored on the public/stable
+# obligation (warn); no maturity split.
 - id: P-008
   engine: python
   engine_rule: check-test-directory-exists
   short_title: "Test_definitions directory is missing"
   conditional_level:
-    default: hint
+    default: warn
     overrides:
       - condition:
-          target_release_type: [pre-release-rc, public-release]
-        level: warn
+          target_api_status: [draft, alpha]
+        level: hint
 
 # P-009: check-release-plan-semantics
 - id: P-009

--- a/validation/tests/test_postfilter_levels.py
+++ b/validation/tests/test_postfilter_levels.py
@@ -268,3 +268,84 @@ class TestCompletenessRuleMaturityGrading:
             for s in ("draft", "alpha", "rc", "public")
         ]
         assert levels == sorted(levels), f"{rule_id} severity decreases: {levels}"
+
+
+# ---------------------------------------------------------------------------
+# Regression: P-006/P-007/P-008 (test-file rules) ramp on target_api_status,
+# not target_release_type, anchored on the public/stable obligation with
+# overrides only demoting. See validation-rules/017.
+# ---------------------------------------------------------------------------
+
+
+class TestTestFileRulesStatusRamp:
+    """P-006 splits by maturity; P-007/P-008 grade the same for both."""
+
+    @pytest.mark.parametrize("status", ["draft", "alpha"])
+    def test_p006_hint_pre_alpha_both_maturities(self, status):
+        rule = _rule_by_id("P-006")
+        ctx = _make_context()
+        for maturity in ("stable", "initial"):
+            api = _make_api(target_api_maturity=maturity, target_api_status=status)
+            assert resolve_level(rule, ctx, api) == "hint"
+
+    @pytest.mark.parametrize("status", ["rc", "public"])
+    def test_p006_stable_error_initial_warn(self, status):
+        rule = _rule_by_id("P-006")
+        ctx = _make_context()
+        stable = _make_api(target_api_maturity="stable", target_api_status=status)
+        initial = _make_api(target_api_maturity="initial", target_api_status=status)
+        assert resolve_level(rule, ctx, stable) == "error"
+        assert resolve_level(rule, ctx, initial) == "warn"
+
+    def test_p006_monotonic_both_maturities(self):
+        rule = _rule_by_id("P-006")
+        ctx = _make_context()
+        for maturity in ("stable", "initial"):
+            levels = [
+                _SEVERITY_ORDER[
+                    resolve_level(
+                        rule,
+                        ctx,
+                        _make_api(target_api_maturity=maturity, target_api_status=s),
+                    )
+                ]
+                for s in ("draft", "alpha", "rc", "public")
+            ]
+            assert levels == sorted(levels), f"P-006 ({maturity}) decreases: {levels}"
+
+    @pytest.mark.parametrize("status", ["draft", "alpha"])
+    def test_p007_hint_pre_rc_stable(self, status):
+        rule = _rule_by_id("P-007")
+        ctx = _make_context()
+        api = _make_api(target_api_maturity="stable", target_api_status=status)
+        assert resolve_level(rule, ctx, api) == "hint"
+
+    @pytest.mark.parametrize("status", ["rc", "public"])
+    def test_p007_warn_at_rc_public_stable(self, status):
+        rule = _rule_by_id("P-007")
+        ctx = _make_context()
+        api = _make_api(target_api_maturity="stable", target_api_status=status)
+        assert resolve_level(rule, ctx, api) == "warn"
+
+    @pytest.mark.parametrize("status", ["draft", "alpha", "rc", "public"])
+    def test_p007_initial_stays_hint(self, status):
+        rule = _rule_by_id("P-007")
+        ctx = _make_context()
+        api = _make_api(target_api_maturity="initial", target_api_status=status)
+        assert resolve_level(rule, ctx, api) == "hint"
+
+    @pytest.mark.parametrize("status", ["draft", "alpha"])
+    def test_p008_hint_pre_rc(self, status):
+        rule = _rule_by_id("P-008")
+        ctx = _make_context()
+        for maturity in ("stable", "initial"):
+            api = _make_api(target_api_maturity=maturity, target_api_status=status)
+            assert resolve_level(rule, ctx, api) == "hint"
+
+    @pytest.mark.parametrize("status", ["rc", "public"])
+    def test_p008_warn_at_rc_public(self, status):
+        rule = _rule_by_id("P-008")
+        ctx = _make_context()
+        for maturity in ("stable", "initial"):
+            api = _make_api(target_api_maturity=maturity, target_api_status=status)
+            assert resolve_level(rule, ctx, api) == "warn"


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

**Problem:** P-006, P-007, and P-008 keyed their severity ramp on `target_release_type` — the field that governs release-plan rules — instead of `target_api_status` (`draft` → `alpha` → `rc` → `public`), which is the canonical field for the per-status content ramp. They also expressed severity backwards compared to every other status-ramped rule in this file: starting at `hint` and escalating upward, instead of anchoring on the final (public/stable) severity and only demoting for earlier statuses.

**Fix:** Migrates the three rules onto `target_api_status`:

- P-006 (`check-test-files-exist`)
- P-007 (`check-test-file-version`)
- P-008 (`check-test-directory-exists`)

Each rule's `conditional_level` is rewritten using the anchor convention already used elsewhere in this file (e.g. P-026/P-027): `default` is the rule's public/stable severity, and `overrides` only ever lower it for an earlier status or an initial (0.x) API — never raise it.

**No behavior change.** For every existing API, the severity a rule reports today is exactly the severity it reported before this PR. A new test (`TestTestFileRulesStatusRamp`) pins the full severity matrix per rule against the real rules file to confirm this.

#### Which issue(s) this PR fixes:

No tooling issue — internal severity-model correction identified during the r3.4→r4.3 severity review.

#### Special notes for reviewers:

Added `TestTestFileRulesStatusRamp` to `test_postfilter_levels.py`, pinning the full severity matrix per rule against the real `python-rules.yaml`, mirroring the existing `TestCompletenessRuleMaturityGrading` (S-016/S-307) pattern.

Test evidence:
- `python3 -m pytest validation/tests -q` — 1180 passed; 3 pre-existing, unrelated `test_yaml_parser_conformance.py` failures (reproduce identically on an unmodified checkout).

#### Changelog input

```
release-note
Migrated P-006/P-007/P-008 severity ramp from target_release_type to target_api_status; no behavior change.
```

#### Additional documentation

This section can be blank.
