### PR TITLE
docs(validation): add codeowner severity guide, contributor guide, and architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ tooling/
 
 Maintained by **Commonalities Working Group**.
 
+To add or modify a CAMARA Validation check, start with the [contributor guide](validation/docs/contributor-guide.md) and the [architecture overview](validation/docs/architecture-overview.md).
+
 * Meetings of the working group are held virtually
   * Schedule: see [Commonalities Working Group wiki page](https://lf-camaraproject.atlassian.net/wiki/x/_QPe)
   * [Registration / Join](https://zoom-lfx.platform.linuxfoundation.org/meeting/91016460698?password=d031b0e3-8d49-49ae-958f-af3213b1e547)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -11,6 +11,7 @@ CAMARA Validation checks API definitions, test files, and release planning files
 - [Find the validation results](validation/where-to-see-results.md)
 - [Fix validation problems on a pull request](validation/pull-requests.md)
 - [Understand error, warning, and hint messages](validation/problem-messages.md)
+- [Understand what a result obligates your team to do](validation/severity-obligations.md)
 - [Read guidance for common validation problems](validation/faq.md)
 
 ### Preparing a release

--- a/documentation/validation/pull-requests.md
+++ b/documentation/validation/pull-requests.md
@@ -32,6 +32,8 @@ When the short message is not enough to act, look up the rule code in the [Valid
 
 Codeowners should not intentionally merge errors to `main` unless the repository has explicitly accepted the resulting release-process risk. The release process at `/create-snapshot` will block until the errors are gone. Warnings and hints are not blocking, but a codeowner reviewing for merge should at least scan the workflow summary and confirm the warnings make sense in context — many of them indicate something that will block a later release type.
 
+For what each severity obligates your team to do, and why the same rule can report differently as your API's status advances, see [What a validation result obligates your team to do](severity-obligations.md).
+
 ## What to open next
 
 - For where each kind of result appears: [Where to see validation results](where-to-see-results.md).
@@ -42,6 +44,7 @@ Codeowners should not intentionally merge errors to `main` unless the repository
 
 - [Where to see validation results](where-to-see-results.md)
 - [Validation problem messages](problem-messages.md)
+- [What a validation result obligates your team to do](severity-obligations.md)
 - [Validation FAQ](faq.md)
 - [Bundled API definitions](bundled-api-definitions.md)
 - [Validation during snapshot creation](release-snapshots.md)

--- a/documentation/validation/severity-obligations.md
+++ b/documentation/validation/severity-obligations.md
@@ -1,0 +1,56 @@
+# What a validation result obligates your team to do
+
+CAMARA Validation reports every problem as an error, a warning, or a hint. This page
+explains what each of those obligates your team to do, and why the same rule can report a
+different severity on your API today than it did last month — with no code change on your
+side.
+
+## What you do
+
+- **Error.** Fix it. Errors block `/create-snapshot`, so an error left on `main` blocks
+  your next release.
+- **Warning.** Fix it, or record why you're not fixing it yet. If your team decides not to
+  fix a warning immediately, open an issue with a copy of the relevant workflow-summary
+  lines and the reason for deferring. That issue is your team's record for later — there is
+  no automated tracking of deferred warnings today.
+- **Hint.** Check it. A hint is not necessarily wrong — some hints exist because the check
+  can't always tell for certain (for example, whether a component is genuinely unused). Read
+  the message, decide, and fix it if it applies.
+
+A passing CAMARA Validation check means no errors blocked the run. It does not mean there
+are no warnings or hints — review those in the workflow summary before merging or before a
+release.
+
+## Why the same rule can report differently over time
+
+Most rules don't have one fixed severity for the life of your API. They get stricter as
+your API matures, tracking the status you declare in `release-plan.yaml` (`draft` → `alpha`
+→ `rc` → `public`):
+
+- Early on, a rule may not fire at all, or only as a hint — so drafting an API doesn't mean
+  wading through a wall of findings.
+- By `rc` — the point where implementers start building against your API — most rules that
+  will eventually block have already become at least a warning.
+- Severity never goes backward as your API matures. If a rule warned at `rc`, it will not
+  quietly drop to a hint at `public`.
+
+This means a finding can move from "hint" to "warning" to "error" between two pull requests
+that don't touch the affected rule at all — because `release-plan.yaml` moved your API's
+status forward. That's expected, not a bug: check your API's current status when a
+severity looks like it jumped.
+
+Some rules are also a little more lenient on a `0.x` (initial) API than on a `1.x+`
+(stable) one, because a stable API can sometimes only fix a problem with a breaking version
+change — an initial API can just fix it in place.
+
+## Where to check a specific rule
+
+If you need to know why a specific rule is reporting at its current severity, open the
+[Validation FAQ](faq.md) entry for that rule code, if one exists. The workflow summary
+always shows the rule code next to each finding.
+
+## Related
+
+- [Validation on pull requests](pull-requests.md) — what to do about a result on your PR
+- [Where to see validation results](where-to-see-results.md)
+- [Validation FAQ](faq.md)

--- a/validation/docs/architecture-overview.md
+++ b/validation/docs/architecture-overview.md
@@ -1,0 +1,68 @@
+# Architecture overview: design documents to implementation
+
+Maps the ReleaseManagement design documents for CAMARA Validation to where each concept
+lives in this repository's implementation. Use this as a bridge, not a replacement for
+either side — read the linked design section for *why*, and the linked source for the
+current *how*.
+
+Design source of truth:
+
+- [Validation Framework — Requirements](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/SupportingDocuments/CAMARA-Validation-Framework-Requirements.md)
+- [Validation Framework — Detailed Design](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/SupportingDocuments/CAMARA-Validation-Framework-Detailed-Design.md)
+
+Both documents may move ahead of the current implementation; where they disagree with the
+code, treat the code as current state and the design docs as intent — file a gap rather
+than assuming either is wrong.
+
+## Pipeline stages
+
+| Design concept | Design doc section | Implementation |
+|---|---|---|
+| Rule metadata model | Detailed Design §1 | `validation/rules/*-rules.yaml`, schema in `validation/schemas/rule-metadata-schema.yaml` |
+| Condition evaluation (applicability, conditional level) | Detailed Design §1.2; Requirements §2.2 | `validation/postfilter/condition_evaluator.py`, `validation/postfilter/level_resolver.py` |
+| Execution contexts (per-repo / per-API) | Requirements §2.3 | `validation/context/context_builder.py` → `ValidationContext` / `ApiContext` |
+| Check inventory across engines | Detailed Design §2; Requirements §4 | `validation/rules/rule-inventory.yaml` (registry) plus each engine's own rule file |
+| Bundling pipeline (`$ref` resolution) | Detailed Design §3; Requirements §6 | `validation/bundling/` |
+| Rule architecture / processing model | Requirements §5 | `validation/orchestrator.py` (chains context → engines → post-filter → output) |
+| Artifact and findings surfacing | Detailed Design §4; Requirements §7–8 | `validation/output/` (annotations, Check Run, PR comment, commit status, workflow summary, diagnostics artifact) |
+| Caller workflow / GitHub App / token resolution | Detailed Design §5; Requirements §9 | `validation/workflows/validation-caller.yml` (template consumed by API repos), `.github/workflows/validation.yml` (this repo's own run), `validation/config/config_gate.py` |
+| Rollout sequencing across API repos | Detailed Design §6 | outside this repo — the caller workflow installed per API repository |
+
+## The four use-case audiences
+
+Requirements §1 defines five use-case groups; each has a corresponding piece of this
+implementation and documentation, not just the pipeline above:
+
+| Audience | Requirements | Where they land here |
+|---|---|---|
+| Contributor | §1.1 | [documentation/validation/](../../documentation/validation/) (task pages), `faq.md` |
+| Codeowner | §1.2 | [documentation/validation/severity-obligations.md](../../documentation/validation/severity-obligations.md) |
+| Release Automation | §1.3 | integration points in `validation/config/config_gate.py` and the reusable workflow's `release-automation` trigger type |
+| Rule developer | §1.4 | [contributor-guide.md](contributor-guide.md) |
+| CAMARA Admin | §1.5 | `.github/workflows/`, App installation/permissions (Detailed Design §5.2, §5.4) |
+
+## Rule metadata: the field vocabulary
+
+Requirements §2.2 and Detailed Design §1 define the rule model in the abstract
+(`applicability`, `conditional_level`, condition fields). The concrete field vocabulary
+and how it is evaluated is authoritative in the schema and evaluator, not the design
+docs — [`rule-metadata-schema.yaml`](../schemas/rule-metadata-schema.yaml) and
+[`condition_evaluator.py`](../postfilter/condition_evaluator.py). When the two disagree
+on a specific field's allowed values, the schema wins; file a design-doc update rather
+than reinterpreting the schema.
+
+## Why this split exists
+
+The design documents describe intent, tradeoffs, and rejected alternatives — useful when
+deciding *whether* to change something. The code and its own docs
+([contributor-guide.md](contributor-guide.md), [regression-testing.md](regression-testing.md))
+describe the current, buildable state — what to change and how to verify it. Keeping them
+separate means a design discussion doesn't need a PR to this repository, and a
+same-shape rule addition doesn't need a design-document round-trip.
+
+## Related
+
+- [contributor-guide.md](contributor-guide.md)
+- [documentation/validation/severity-obligations.md](../../documentation/validation/severity-obligations.md)
+- [regression-testing.md](regression-testing.md)
+- [`rules/README.md`](../rules/README.md)

--- a/validation/docs/contributor-guide.md
+++ b/validation/docs/contributor-guide.md
@@ -1,0 +1,111 @@
+# Contributor guide to CAMARA Validation
+
+For anyone adding or modifying a validation check in the `tooling` repository. This is
+developer/admin documentation — for the user-facing docs contributors and codeowners read
+when validation runs on their PR, see [documentation/validation/](../../documentation/validation/)
+and its own [user-documentation-guidelines.md](user-documentation-guidelines.md).
+
+## Pipeline overview
+
+Every run chains the same five stages (`validation/orchestrator.py`):
+
+```text
+config gate -> context builder -> engines -> post-filter -> output
+```
+
+- **Config gate** (`validation/config/`) decides whether validation runs at all for this
+  trigger (stage: `disabled`/`advisory`/`enabled`).
+- **Context builder** (`validation/context/`) resolves `ValidationContext` (repo/branch/
+  trigger/commonalities-release) and, per API, `ApiContext` (`target_api_status`,
+  `target_api_maturity`, `api_pattern`, …) from `release-plan.yaml` /
+  `release-metadata.yaml`.
+- **Engines** (`validation/engines/`) run the four check engines — Spectral, yamllint,
+  Gherkin/GPLint, and Python — and emit raw findings.
+- **Post-filter** (`validation/postfilter/`) resolves each finding's final severity from
+  rule metadata and the context (see below), and applies applicability/suppression.
+- **Output** (`validation/output/`) renders annotations, the Check Run payload, the PR
+  comment, the commit status, and the workflow-summary/diagnostics artifacts.
+
+For the full design behind this pipeline, see [architecture-overview.md](architecture-overview.md).
+
+## Rule metadata and severity
+
+Every rule is one entry in `validation/rules/*-rules.yaml` (`spectral-rules.yaml`,
+`gherkin-rules.yaml`, `python-rules.yaml`, `yamllint-rules.yaml`), validated against
+[`validation/schemas/rule-metadata-schema.yaml`](../schemas/rule-metadata-schema.yaml).
+Key fields:
+
+- `id` — stable `<engine-prefix>-<nnn>` (`S-`/`G-`/`P-`/`Y-`/`M-`), never reused once
+  assigned (see ID assignment in [`rules/README.md`](../rules/README.md)).
+- `engine` / `engine_rule` — which engine and which native rule/check produced the finding.
+- `applicability` — conditions under which the rule fires at all (AND across fields, OR
+  within an array value).
+- `conditional_level` — `default` plus ordered `overrides` (first match wins) resolving
+  the finding's severity (`error`/`warn`/`hint`/`muted`).
+
+**Severity convention:** write `conditional_level.default` as the rule's `public`/`stable`
+obligation (usually `error`); overrides only *demote* for an earlier `target_api_status`
+or an `initial` API — never escalate above the default. This keeps severity monotonic
+across an API's lifecycle by construction, gives every reader the same anchor to reason
+from, and avoids a rule quietly escalating past what its default implies. P-026/P-027 and
+P-006/P-007/P-008 in `python-rules.yaml` are worked examples to mirror.
+
+## Adding or changing a Python check
+
+Python checks live in `validation/engines/python_checks/`, one module per topic area
+(`test_checks.py`, `subscription_checks.py`, …). Each check function has the signature
+`(repo_path, context) -> List[dict]` and returns findings built with `make_finding()`
+from [`_types.py`](../engines/python_checks/_types.py).
+
+1. Write the check function in the appropriate module (or a new one). Scope it
+   `CheckScope.API` (runs once per API in `context.apis`) or `CheckScope.REPO` (runs once).
+2. Register it in [`python_checks/__init__.py`](../engines/python_checks/__init__.py): import
+   the function and append a `CheckDescriptor("check-kebab-case-name", scope, fn)` to
+   `CHECKS`. Execution order follows list order.
+3. Add a metadata entry to `python-rules.yaml`: new `id` (next free `P-nnn`), `engine:
+   python`, `engine_rule` matching the descriptor name, `conditional_level` per the
+   convention above, and `applicability` if the rule doesn't apply everywhere.
+4. Add or update the `rule-inventory.yaml` entry if the rule was previously tracked as
+   `gap` or `manual`, or add a doc-comment describing intent above the rule block in
+   `python-rules.yaml` (existing rules follow this pattern).
+5. Write tests in `validation/tests/test_python_checks_<area>.py` for the check function
+   itself, and — if the rule's severity shape is non-trivial (splits by status/maturity) —
+   add real-metadata regression tests in
+   [`test_postfilter_levels.py`](../tests/test_postfilter_levels.py) using `_rule_by_id`
+   against the loaded `python-rules.yaml`, mirroring
+   `TestCompletenessRuleMaturityGrading` / `TestTestFileRulesStatusRamp`.
+6. Run the scoped test path: `python3 -m pytest validation/tests/test_python_checks_<area>.py
+   validation/tests/test_postfilter_levels.py validation/tests/test_rule_metadata_integrity.py`.
+
+Adding or changing a Spectral, Gherkin, or yamllint rule follows the same rule-metadata
+step (2–4 above), but the check logic itself lives in that engine's native config
+(`linting/config/.spectral-r4.yaml`, `.gplintrc`, `.yamllint.yaml`) or adapter
+(`validation/engines/*_adapter.py`), not in `python_checks/`.
+
+## Regression testing
+
+Unit tests verify one check in isolation. Regression testing verifies the framework's
+end-to-end verdict against real CAMARA-style API specs on branches in
+`camaraproject/ReleaseTest`, so a rule change doesn't silently start firing where it
+shouldn't or stop firing where it should. Read
+[`regression-testing.md`](regression-testing.md) before touching a rule that has an entry
+in `rule-inventory.yaml`'s `tested_rules` map, and before recapturing any
+`regression-expected.yaml` fixture.
+
+## Documentation to update alongside a rule change
+
+- `rule-inventory.yaml` — `tested_rules` mapping if a regression branch pins the rule;
+  `status` if a `gap`/`manual` rule became `implemented`.
+- A `faq.md` entry under [documentation/validation/](../../documentation/validation/) —
+  only when the rule's severity is context-dependent or its short message alone isn't
+  enough for a contributor to act (see [user-documentation-guidelines.md](user-documentation-guidelines.md)).
+  This is public, user-facing documentation — do not put implementation detail there.
+- [`severity-obligations.md`](../../documentation/validation/severity-obligations.md)
+  only if the change affects the general severity model, not for an individual rule.
+
+## Related
+
+- [architecture-overview.md](architecture-overview.md) — how this implementation maps to the ReleaseManagement design documents
+- [regression-testing.md](regression-testing.md)
+- [`rules/README.md`](../rules/README.md) — rule ID assignment
+- [`schemas/rule-metadata-schema.yaml`](../schemas/rule-metadata-schema.yaml)


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Adds the three documentation pieces tracked under camaraproject/ReleaseManagement#485: a user-facing page explaining what each severity (error/warning/hint) obligates an API team to do and why the same rule can report differently as an API's status advances (`documentation/validation/severity-obligations.md`, linked from the README and `pull-requests.md`); a contributor guide for adding or modifying a validation check (`validation/docs/contributor-guide.md`); and an architecture overview mapping the ReleaseManagement design documents to this repository's implementation modules (`validation/docs/architecture-overview.md`).

#### Which issue(s) this PR fixes:

No tooling issue — implements camaraproject/ReleaseManagement#485.

#### Special notes for reviewers:

The severity-obligations page intentionally avoids rule-metadata internals (`conditional_level`, `override`, engine names) per `user-documentation-guidelines.md`'s scope for the user-facing tree; the contributor guide and architecture overview are the admin/dev-facing counterparts under `validation/docs/`.

#### Changelog input

```
release-note
Added codeowner, contributor, and architecture documentation for CAMARA Validation (ReleaseManagement#485).
```

#### Additional documentation

This section can be blank.
