### PR TITLE
fix(validation): rewrite P-016 as a per-field sinkCredential writeOnly check

### DIFF
--- a/validation/engines/python_checks/__init__.py
+++ b/validation/engines/python_checks/__init__.py
@@ -29,7 +29,7 @@ from .release_review_checks import check_release_review_file_restriction
 from .subscription_checks import (
     check_cloudevent_via_ref,
     check_event_type_format,
-    check_sinkcredential_not_in_response,
+    check_sinkcredential_secrets_writeonly,
     check_subscription_filename,
 )
 from .test_checks import (
@@ -60,7 +60,7 @@ CHECKS: list[CheckDescriptor] = [
     CheckDescriptor("check-commonalities-version", CheckScope.API, check_commonalities_version),
     CheckDescriptor("check-subscription-filename", CheckScope.API, check_subscription_filename),
     CheckDescriptor("check-event-type-format", CheckScope.API, check_event_type_format),
-    CheckDescriptor("check-sinkcredential-not-in-response", CheckScope.API, check_sinkcredential_not_in_response),
+    CheckDescriptor("check-sinkcredential-secrets-writeonly", CheckScope.API, check_sinkcredential_secrets_writeonly),
     CheckDescriptor("check-cloudevent-via-ref", CheckScope.API, check_cloudevent_via_ref),
     CheckDescriptor("check-conflict-deprecated", CheckScope.API, check_conflict_deprecated),
     CheckDescriptor("check-contextcode-format", CheckScope.API, check_contextcode_format),

--- a/validation/engines/python_checks/subscription_checks.py
+++ b/validation/engines/python_checks/subscription_checks.py
@@ -20,7 +20,6 @@ from validation.context import ValidationContext
 from ._spec_helpers import (
     collect_schema_properties,
     extract_event_types_from_spec,
-    iter_response_schemas,
     resolve_local_ref,
 )
 from ._types import load_yaml_safe, make_finding
@@ -159,65 +158,104 @@ def check_event_type_format(
 
 
 # ---------------------------------------------------------------------------
-# P-016 (DG-092): check-sinkcredential-not-in-response
+# P-016 (DG-092): check-sinkcredential-secrets-writeonly
 # ---------------------------------------------------------------------------
 
+# Secret sub-fields of the SinkCredential discriminator subtypes that MUST
+# be writeOnly so they are withheld from responses. Response-visible fields
+# (credentialType, accessTokenExpiresUtc, jwksUri) are out of scope — this
+# rule guards against secret leakage, not over-hiding.
+_SINKCREDENTIAL_SECRET_FIELDS = (
+    "accessToken",
+    "accessTokenType",
+    "clientId",
+    "tokenUri",
+)
 
-def check_sinkcredential_not_in_response(
+
+def _is_sinkcredential_subtype(schema_def: dict) -> bool:
+    """Return True if *schema_def* is a SinkCredential discriminator subtype.
+
+    A subtype's ``allOf`` contains an entry whose ``$ref`` last path
+    segment is ``SinkCredential`` (e.g. ``AccessTokenCredential``,
+    ``PrivateKeyJWTCredential``).
+    """
+    all_of = schema_def.get("allOf")
+    if not isinstance(all_of, list):
+        return False
+    for entry in all_of:
+        if not isinstance(entry, dict):
+            continue
+        ref = entry.get("$ref")
+        if isinstance(ref, str) and ref.rsplit("/", 1)[-1] == "SinkCredential":
+            return True
+    return False
+
+
+def check_sinkcredential_secrets_writeonly(
     repo_path: Path, context: ValidationContext
 ) -> List[dict]:
-    """Validate sinkCredential does not appear in subscription responses.
+    """Validate sinkCredential secret fields are writeOnly.
 
-    Event Subscription Guide section 2.2.3: "The sinkCredential MUST
-    NOT be present in POST and GET responses."
+    Event Subscription Guide section 4.3.1 (partial-disclosure model,
+    r4.3): sinkCredential MAY appear in POST/GET responses, but its
+    secret sub-fields — ``accessToken``, ``accessTokenType``
+    (AccessTokenCredential); ``clientId``, ``tokenUri``
+    (PrivateKeyJWTCredential) — MUST be ``writeOnly: true`` so they are
+    withheld from responses.
 
-    Inspects 2xx response schemas for paths containing ``/subscriptions``
-    and checks for ``sinkCredential`` in their properties (including
-    ``allOf`` compositions).
+    Detection is a schema-definition check, not a response traversal:
+    ``sinkCredential`` is typed as the polymorphic base
+    ``SinkCredential``, so a response-schema check resolves to the base
+    and never sees the secrets, which live on the discriminator
+    subtypes (``allOf: [$ref SinkCredential, {props}]``). Scanning
+    ``components.schemas`` for SinkCredential subtypes is path-agnostic
+    — it covers explicit and implicit subscription uniformly (implicit
+    has no ``/subscriptions`` path; ``sinkCredential`` rides inside the
+    ``Resource`` schema) and passes trivially on common-``$ref`` specs
+    with no local subtype.
     """
     api = context.apis[0]
 
-    if api.api_pattern != "explicit-subscription":
+    if api.api_pattern not in ("explicit-subscription", "implicit-subscription"):
         return []
 
     spec = load_yaml_safe(repo_path / api.spec_file)
     if spec is None:
         return []
 
-    findings: List[dict] = []
-    seen_schemas: set[str] = set()
+    schemas = spec.get("components", {}).get("schemas", {})
+    if not isinstance(schemas, dict):
+        return []
 
-    for path, method, status_code, schema in iter_response_schemas(
-        spec, "/subscriptions"
-    ):
-        # Only check 2xx success responses
-        if not status_code.startswith("2"):
+    findings: List[dict] = []
+
+    for schema_name, schema_def in schemas.items():
+        if not isinstance(schema_def, dict):
+            continue
+        if not _is_sinkcredential_subtype(schema_def):
             continue
 
-        # Collect properties from the resolved schema
-        all_props = collect_schema_properties(spec, schema)
-        if "sinkCredential" in all_props:
-            # Deduplicate: same underlying schema may appear in multiple
-            # responses (e.g. POST 201 and GET 200 both use Subscription)
-            schema_id = id(schema)
-            if schema_id in seen_schemas:
+        props = collect_schema_properties(spec, schema_def)
+        for field_name in _SINKCREDENTIAL_SECRET_FIELDS:
+            field_def = props.get(field_name)
+            if field_def is None:
                 continue
-            seen_schemas.add(schema_id)
-
-            findings.append(
-                make_finding(
-                    engine_rule="check-sinkcredential-not-in-response",
-                    level="error",
-                    message=(
-                        f"sinkCredential found in {method.upper()} "
-                        f"{path} {status_code} response schema — "
-                        f"sinkCredential MUST NOT appear in responses"
-                    ),
-                    path=api.spec_file,
-                    line=1,
-                    api_name=api.api_name,
+            if not isinstance(field_def, dict) or field_def.get("writeOnly") is not True:
+                findings.append(
+                    make_finding(
+                        engine_rule="check-sinkcredential-secrets-writeonly",
+                        level="warn",
+                        message=(
+                            f"{schema_name}.{field_name} must be writeOnly: "
+                            f"true — sinkCredential secret fields must not "
+                            f"be exposed in responses"
+                        ),
+                        path=api.spec_file,
+                        line=1,
+                        api_name=api.api_name,
+                    )
                 )
-            )
 
     return findings
 

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -198,25 +198,34 @@
     API template in Commonalities artifacts/api-templates/ (tracked in
     camaraproject/Commonalities#608).
 
-# P-016: check-sinkcredential-not-in-response (DG-092)
-# sinkCredential must not appear in subscription 2xx response schemas.
-#
-# 2026-05-23 MUTED pending Commonalities#638. r4.3 introduced a
-# partial-disclosure model for sinkCredential in Commonalities#633 —
-# secret fields are kept out of responses via per-field `writeOnly: true`,
-# non-secret client-configuration fields are exchanged bidirectionally.
-# The current blanket-ban shape is too broad. Re-enable (drop the muted
-# default) if §2.2.3 is restored, or replace with a per-field writeOnly
-# check if §4.3.1 wins. Tracked in tooling#297. Same mute pattern as
-# S-314 / S-316 vs Commonalities#615.
+# P-016: check-sinkcredential-secrets-writeonly (DG-092)
+# r4.3 (Commonalities#633) replaced the blanket "sinkCredential MUST NOT
+# appear in responses" ban with a partial-disclosure model: sinkCredential
+# MAY appear in POST/GET responses, but its secret sub-fields — accessToken,
+# accessTokenType (AccessTokenCredential); clientId, tokenUri
+# (PrivateKeyJWTCredential) — MUST be writeOnly so they are withheld.
+# credentialType, accessTokenExpiresUtc, and jwksUri are response-visible
+# by design and are not checked. Gated ">=r4.3" because writeOnly on these
+# fields was introduced there (Commonalities 0.8.0) — a pre-0.8.0 API
+# follows the old blanket-ban model and has no writeOnly concept to check.
+# Graded ramp mirrors the r4.3 drift-rule siblings P-026/P-027: warn gives
+# a migration runway for a just-upgraded API whose copied subtypes predate
+# the markers; error at public is the right gate since the escalation only
+# ever hits secret fields no legitimate consumer ever received in a
+# response under any model. Tracked in tooling#297.
 - id: P-016
   engine: python
-  engine_rule: check-sinkcredential-not-in-response
-  short_title: "sinkCredential must not appear in response"
+  engine_rule: check-sinkcredential-secrets-writeonly
+  short_title: "sinkCredential secret fields must be writeOnly"
   applicability:
-    api_pattern: [explicit-subscription]
+    api_pattern: [explicit-subscription, implicit-subscription]
+    commonalities_release: ">=r4.3"
   conditional_level:
-    default: muted
+    default: warn
+    overrides:
+      - condition:
+          target_api_status: [public]
+        level: error
 
 # P-017: check-conflict-deprecated (DG-018)
 # CONFLICT error code is deprecated in Commonalities r4.x.

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -168,7 +168,7 @@ gap_rules:
     rule_id: P-014
 
   - audit_id: DG-092
-    description: sinkCredential not in responses
+    description: sinkCredential secret fields must be writeOnly (not exposed in responses)
     target_engine: python
     status: implemented
     rule_id: P-016

--- a/validation/tests/test_python_checks_subscription.py
+++ b/validation/tests/test_python_checks_subscription.py
@@ -10,7 +10,7 @@ from validation.context import ApiContext, ValidationContext
 from validation.engines.python_checks.subscription_checks import (
     check_cloudevent_via_ref,
     check_event_type_format,
-    check_sinkcredential_not_in_response,
+    check_sinkcredential_secrets_writeonly,
     check_subscription_filename,
 )
 
@@ -237,151 +237,137 @@ class TestCheckEventTypeFormat:
 
 
 # ---------------------------------------------------------------------------
-# P-016: check-sinkcredential-not-in-response
+# P-016: check-sinkcredential-secrets-writeonly
 # ---------------------------------------------------------------------------
 
 
-class TestCheckSinkCredentialNotInResponse:
-    def test_clean_response_ok(self, tmp_path: Path):
-        api_name = "device-status-subscriptions"
-        spec = _subscription_spec_with_response({
-            "id": {"type": "string"},
-            "sink": {"type": "string"},
-        })
-        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
-        ctx = _make_context(api_name=api_name)
-        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+def _sinkcredential_family_spec(
+    access_token_writeonly: bool | None = True,
+    access_token_type_writeonly: bool | None = True,
+    client_id_writeonly: bool | None = True,
+    token_uri_writeonly: bool | None = True,
+) -> dict:
+    """Build a spec with the full SinkCredential discriminator family.
 
-    def test_sinkcredential_in_response_error(self, tmp_path: Path):
-        api_name = "device-status-subscriptions"
-        spec = _subscription_spec_with_response({
-            "id": {"type": "string"},
-            "sink": {"type": "string"},
-            "sinkCredential": {"$ref": "#/components/schemas/SinkCredential"},
-        })
-        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
-        ctx = _make_context(api_name=api_name)
-        findings = check_sinkcredential_not_in_response(tmp_path, ctx)
-        assert len(findings) == 1
-        assert findings[0]["level"] == "error"
-        assert "sinkCredential" in findings[0]["message"]
+    A ``None`` value omits the field's ``writeOnly`` key entirely
+    (missing); a bool value sets it explicitly (including ``False``,
+    present-but-wrong).
+    """
 
-    def test_sinkcredential_in_request_only_ok(self, tmp_path: Path):
-        """sinkCredential in request schema but not in response — OK."""
-        api_name = "device-status-subscriptions"
-        spec = {
-            "openapi": "3.0.3",
-            "info": {"title": "Test", "version": "wip"},
-            "paths": {
-                "/subscriptions": {
-                    "post": {
-                        "requestBody": {
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/SubscriptionRequest"}
-                                }
-                            }
-                        },
-                        "responses": {
-                            "201": {
-                                "content": {
-                                    "application/json": {
-                                        "schema": {"$ref": "#/components/schemas/Subscription"}
-                                    }
-                                }
-                            }
-                        },
-                    }
-                }
-            },
-            "components": {
-                "schemas": {
-                    "SubscriptionRequest": {
-                        "type": "object",
-                        "properties": {
-                            "sink": {"type": "string"},
-                            "sinkCredential": {"type": "object"},
-                        },
-                    },
-                    "Subscription": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "string"},
-                            "sink": {"type": "string"},
-                        },
-                    },
-                }
-            },
-        }
-        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
-        ctx = _make_context(api_name=api_name)
-        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+    def _field(base: dict, writeonly: bool | None) -> dict:
+        if writeonly is not None:
+            base = {**base, "writeOnly": writeonly}
+        return base
 
-    def test_non_subscription_skip(self, tmp_path: Path):
-        ctx = _make_context(api_pattern="request-response")
-        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
-
-    def test_sinkcredential_via_allof_error(self, tmp_path: Path):
-        """sinkCredential inherited via allOf is still caught."""
-        api_name = "device-status-subscriptions"
-        spec = {
-            "openapi": "3.0.3",
-            "info": {"title": "Test", "version": "wip"},
-            "paths": {
-                "/subscriptions": {
-                    "post": {
-                        "responses": {
-                            "201": {
-                                "content": {
-                                    "application/json": {
-                                        "schema": {"$ref": "#/components/schemas/Subscription"}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "components": {
-                "schemas": {
-                    "BaseSubscription": {
-                        "type": "object",
-                        "properties": {
-                            "sinkCredential": {"type": "object"},
-                        },
-                    },
-                    "Subscription": {
-                        "allOf": [
-                            {"$ref": "#/components/schemas/BaseSubscription"},
-                            {
-                                "type": "object",
-                                "properties": {"id": {"type": "string"}},
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Test", "version": "wip"},
+        "paths": {},
+        "components": {
+            "schemas": {
+                "SinkCredential": {
+                    "type": "object",
+                    "properties": {"credentialType": {"type": "string"}},
+                    "discriminator": {"propertyName": "credentialType"},
+                },
+                "AccessTokenCredential": {
+                    "allOf": [
+                        {"$ref": "#/components/schemas/SinkCredential"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "accessToken": _field(
+                                    {"type": "string"}, access_token_writeonly
+                                ),
+                                "accessTokenExpiresUtc": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                },
+                                "accessTokenType": _field(
+                                    {"type": "string"}, access_token_type_writeonly
+                                ),
                             },
-                        ]
-                    },
-                }
-            },
-        }
-        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
-        ctx = _make_context(api_name=api_name)
-        findings = check_sinkcredential_not_in_response(tmp_path, ctx)
-        assert len(findings) == 1
-        assert findings[0]["level"] == "error"
+                        },
+                    ]
+                },
+                "PrivateKeyJWTCredential": {
+                    "allOf": [
+                        {"$ref": "#/components/schemas/SinkCredential"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "clientId": _field(
+                                    {"type": "string"}, client_id_writeonly
+                                ),
+                                "tokenUri": _field(
+                                    {"type": "string"}, token_uri_writeonly
+                                ),
+                                "jwksUri": {
+                                    "type": "string",
+                                    "readOnly": True,
+                                },
+                            },
+                        },
+                    ]
+                },
+            }
+        },
+    }
 
-    def test_missing_spec_file(self, tmp_path: Path):
-        ctx = _make_context()
-        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
 
-    def test_no_subscription_paths_ok(self, tmp_path: Path):
-        """Spec has no /subscriptions path — no findings."""
+class TestCheckSinkCredentialSecretsWriteOnly:
+    def test_clean_subtype_writeonly_present_ok(self, tmp_path: Path):
         api_name = "device-status-subscriptions"
-        spec = {"openapi": "3.0.3", "info": {"title": "Test", "version": "wip"}, "paths": {"/other": {}}}
+        spec = _sinkcredential_family_spec()
         _write_spec(tmp_path, api_name=api_name, spec_content=spec)
         ctx = _make_context(api_name=api_name)
-        assert check_sinkcredential_not_in_response(tmp_path, ctx) == []
+        assert check_sinkcredential_secrets_writeonly(tmp_path, ctx) == []
 
-    def test_external_ref_sinkcredential_detected(self, tmp_path: Path):
-        """sinkCredential with external $ref is still detected by name."""
+    def test_accesstoken_missing_writeonly_one_finding(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _sinkcredential_family_spec(access_token_writeonly=None)
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_sinkcredential_secrets_writeonly(tmp_path, ctx)
+        assert len(findings) == 1
+        assert findings[0]["level"] == "warn"
+        assert "AccessTokenCredential.accessToken" in findings[0]["message"]
+
+    def test_accesstoken_writeonly_false_still_flagged(self, tmp_path: Path):
+        """writeOnly: false is present-but-wrong, not just missing."""
+        api_name = "device-status-subscriptions"
+        spec = _sinkcredential_family_spec(access_token_writeonly=False)
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_sinkcredential_secrets_writeonly(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "accessToken" in findings[0]["message"]
+
+    def test_privatekeyjwt_clientid_tokenuri_coverage(self, tmp_path: Path):
+        api_name = "device-status-subscriptions"
+        spec = _sinkcredential_family_spec(
+            client_id_writeonly=None, token_uri_writeonly=None
+        )
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        findings = check_sinkcredential_secrets_writeonly(tmp_path, ctx)
+        messages = {f["message"] for f in findings}
+        assert len(findings) == 2
+        assert any("PrivateKeyJWTCredential.clientId" in m for m in messages)
+        assert any("PrivateKeyJWTCredential.tokenUri" in m for m in messages)
+
+    def test_response_visible_fields_ignored(self, tmp_path: Path):
+        """credentialType/accessTokenExpiresUtc/jwksUri are never checked."""
+        api_name = "device-status-subscriptions"
+        # All secret fields correctly writeOnly; jwksUri stays readOnly,
+        # not writeOnly — must not be flagged.
+        spec = _sinkcredential_family_spec()
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_sinkcredential_secrets_writeonly(tmp_path, ctx) == []
+
+    def test_common_ref_spec_no_local_subtype_ok(self, tmp_path: Path):
+        """sinkCredential via external $ref, no local subtype schema — no findings."""
         api_name = "device-status-subscriptions"
         spec = _subscription_spec_with_response({
             "id": {"type": "string"},
@@ -391,8 +377,47 @@ class TestCheckSinkCredentialNotInResponse:
         })
         _write_spec(tmp_path, api_name=api_name, spec_content=spec)
         ctx = _make_context(api_name=api_name)
-        findings = check_sinkcredential_not_in_response(tmp_path, ctx)
+        assert check_sinkcredential_secrets_writeonly(tmp_path, ctx) == []
+
+    def test_implicit_subscription_resource_schema_coverage(self, tmp_path: Path):
+        """Implicit subscription has no /subscriptions path — detection
+        is schema-definition based, so the subtype is still caught."""
+        api_name = "device-status"
+        spec = _sinkcredential_family_spec(access_token_writeonly=None)
+        spec["paths"] = {"/resources": {"get": {"responses": {"200": {}}}}}
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name, api_pattern="implicit-subscription")
+        findings = check_sinkcredential_secrets_writeonly(tmp_path, ctx)
         assert len(findings) == 1
+
+    def test_generic_clientid_field_not_subtype_no_false_positive(self, tmp_path: Path):
+        """A clientId field on a schema that is not a SinkCredential
+        subtype (no allOf $ref to SinkCredential) must not be flagged."""
+        api_name = "device-status-subscriptions"
+        spec = {
+            "openapi": "3.0.3",
+            "info": {"title": "Test", "version": "wip"},
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "OAuthClient": {
+                        "type": "object",
+                        "properties": {"clientId": {"type": "string"}},
+                    },
+                }
+            },
+        }
+        _write_spec(tmp_path, api_name=api_name, spec_content=spec)
+        ctx = _make_context(api_name=api_name)
+        assert check_sinkcredential_secrets_writeonly(tmp_path, ctx) == []
+
+    def test_non_subscription_skip(self, tmp_path: Path):
+        ctx = _make_context(api_pattern="request-response")
+        assert check_sinkcredential_secrets_writeonly(tmp_path, ctx) == []
+
+    def test_missing_spec_file(self, tmp_path: Path):
+        ctx = _make_context()
+        assert check_sinkcredential_secrets_writeonly(tmp_path, ctx) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Commonalities r4.3 (camaraproject/Commonalities#633, guide-aligned by #656) replaced the blanket "sinkCredential MUST NOT appear in responses" ban with a partial-disclosure model: `sinkCredential` MAY appear in POST/GET responses, but its secret sub-fields — `accessToken`/`accessTokenType` (`AccessTokenCredential`), `clientId`/`tokenUri` (`PrivateKeyJWTCredential`) — MUST be `writeOnly: true`. P-016 (`check-sinkcredential-not-in-response`) was muted pending this design decision.

Rewrites the check as `check-sinkcredential-secrets-writeonly`: a schema-definition scan for `SinkCredential` discriminator subtypes (`allOf` referencing `SinkCredential`) rather than a response-schema traversal — `sinkCredential` is typed as the polymorphic base, so a response check would resolve to the base and never see the secrets, which live on the subtypes. This also covers implicit subscription uniformly (no `/subscriptions` path) and passes trivially on specs that only reference the common schema (no local subtype to check).

Lifts the mute with a graded severity ramp (`warn` for draft/alpha/rc, `error` at public) gated to `commonalities_release: ">=r4.3"`, so pre-0.8.0 APIs (which predate `writeOnly`) aren't checked at all.

#### Which issue(s) this PR fixes:

Part of #297

#### Special notes for reviewers:

Replaced `TestCheckSinkCredentialNotInResponse` with `TestCheckSinkCredentialSecretsWriteOnly` in `test_python_checks_subscription.py`, covering the clean-subtype case, missing/`false` `writeOnly` on each secret field, response-visible fields being ignored, common-`$ref` specs (no local subtype), implicit-subscription coverage, and a false-positive guard for a generic non-subtype `clientId` field.

The `regression/r4.3-broken-spec-subscriptions` branch on `camaraproject/ReleaseTest` has been reworked to match (its old sinkCredential-in-response defect no longer trips this rule) and pushed; final fixture recapture is pending this PR reaching `validation-framework`.

Test evidence:
- `python3 -m pytest validation/tests -q` — 1180 passed; 3 pre-existing, unrelated `test_yaml_parser_conformance.py` failures (reproduce identically on an unmodified checkout).

#### Changelog input

```
release-note
Rewrote P-016 to check sinkCredential secret fields are writeOnly (r4.3 partial-disclosure model), lifting the mute from #297.
```

#### Additional documentation

This section can be blank.
