### PR TITLE
docs(validation): update S-211 regression coverage in rule inventory

### DIFF
--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -368,7 +368,7 @@ tested_rules:
   S-040: [regression/r4.3-broken-spec-error-handling]
   S-201: [regression/r4.3-broken-spec-api-metadata]
   S-210: [regression/r4.3-broken-spec-api-metadata]
-  S-211: [regression/r4.3-main-baseline]
+  S-211: [regression/r4.3-broken-spec-subscriptions, regression/r4.3-broken-spec-yaml-fundamentals]
   S-215: [regression/r4.3-broken-spec-descriptions]
   S-216: [regression/r4.3-broken-spec-descriptions]
   S-217: [regression/r4.3-broken-spec-routing]


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Updates the S-211 entry in `tested_rules`: after the discriminator-aware rule (#378) the baseline branch no longer produces S-211 findings, so positive firing is now pinned by `regression/r4.3-broken-spec-subscriptions` (two intentionally unreferenced schemas, warn) and `regression/r4.3-broken-spec-yaml-fundamentals` (one unreferenced schema, warn). All 11 regression fixtures have been recaptured accordingly.

#### Which issue(s) this PR fixes:

Follow-up to #378 / #377 (no issue to close).

#### Special notes for reviewers:

One-line inventory change, following the pattern of #379.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.

```
docs

```
