### PR TITLE
fix(validation): allow Design Guide filter suffixes in parameter casing

### DIFF
--- a/linting/config/.spectral-r4.yaml
+++ b/linting/config/.spectral-r4.yaml
@@ -318,14 +318,17 @@ rules:
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-parameter-name-casing-convention:
-    description: Parameter names (path and query) must be lowerCamelCase.
+    description: >
+      Parameter names (path and query) must be lowerCamelCase. The Design Guide's
+      filtering-operation suffixes (.gte, .gt, .lte, .lt) are allowed as an exact
+      tail on an otherwise lowerCamelCase name.
     message: "{{property}} is not lowerCamelCase: {{error}}"
     severity: warn
     given: $.paths[*][*].parameters[?(@.in != 'header')].name
     then:
       function: pattern
       functionOptions:
-        match: "^[a-z][a-zA-Z0-9]*$"
+        match: "^[a-z][a-zA-Z0-9]*(\\.(gte|gt|lte|lt))?$"
     recommended: true
 
   camara-schema-type-check:

--- a/validation/tests/test_spectral_gap_rules.py
+++ b/validation/tests/test_spectral_gap_rules.py
@@ -292,6 +292,52 @@ class TestGroupA:
         findings = _run_spectral(spec)
         assert "camara-parameter-name-casing-convention" not in _codes(findings)
 
+    @pytest.mark.parametrize("suffix", ["gte", "gt", "lte", "lt"])
+    def test_parameter_name_filter_suffix_passes(self, suffix):
+        # Design Guide §4.3.2 filtering-operation suffixes must not be flagged.
+        spec = _VALID_SPEC.replace(
+            "      summary: Get test",
+            "      parameters:\n"
+            f"        - name: creationDate.{suffix}\n"
+            "          in: query\n"
+            "          required: false\n"
+            "          schema:\n"
+            "            type: string\n"
+            "      summary: Get test",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-parameter-name-casing-convention" not in _codes(findings)
+
+    def test_parameter_name_unrecognized_suffix_fails(self):
+        # Only the four documented filter suffixes are exempted.
+        spec = _VALID_SPEC.replace(
+            "      summary: Get test",
+            "      parameters:\n"
+            "        - name: creationDate.foo\n"
+            "          in: query\n"
+            "          required: false\n"
+            "          schema:\n"
+            "            type: string\n"
+            "      summary: Get test",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-parameter-name-casing-convention" in _codes(findings)
+
+    def test_parameter_name_bad_base_with_valid_suffix_fails(self):
+        # A valid filter suffix does not excuse a badly-cased base name.
+        spec = _VALID_SPEC.replace(
+            "      summary: Get test",
+            "      parameters:\n"
+            "        - name: CreationDate.gte\n"
+            "          in: query\n"
+            "          required: false\n"
+            "          schema:\n"
+            "            type: string\n"
+            "      summary: Get test",
+        )
+        findings = _run_spectral(spec)
+        assert "camara-parameter-name-casing-convention" in _codes(findings)
+
 
 class TestGroupB:
     """Group B: Error code checks."""


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`camara-parameter-name-casing-convention` in the r4 ruleset (`linting/config/.spectral-r4.yaml`) requires query/path parameter names to match `^[a-z][a-zA-Z0-9]*$`, with no allowance for the filtering-operation suffixes the [Design Guide §4.3.2](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Design-Guide.md#432-filtering-operations) requires (`.gte`, `.gt`, `.lte`, `.lt`). Any spec following the Design Guide's own filtering examples verbatim (e.g. `creationDate.gte`) gets a false-positive warning.

Fix: the pattern now allows those four suffixes as an optional exact tail — `^[a-z][a-zA-Z0-9]*(\.(gte|gt|lte|lt))?$`. The base name still has to be lowerCamelCase, and an unrecognized suffix or a badly-cased base name still gets flagged. Scoped to the r4 ruleset only — `.spectral-r3.4.yaml` doesn't define this rule.

#### Which issue(s) this PR fixes:

Fixes #388

#### Special notes for reviewers:

Added test coverage in `validation/tests/test_spectral_gap_rules.py`: all four suffixes passing, an unrecognized suffix still failing, and a badly-cased base name with a valid suffix still failing. Full `validation/tests/` suite (1216 tests) passes locally.

#### Changelog input

```
release-note
Fixed a false-positive warning from the r4 parameter-casing rule on query parameters using the Design Guide's filtering-operation suffixes (.gte, .gt, .lte, .lt).
```

#### Additional documentation

This section can be blank.

```
docs
```
