### PR TITLE
fix(deps): bump fast-uri, brace-expansion to patched versions in validation/

### DIFF
--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -1543,9 +1543,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2079,9 +2079,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Closes 4 open Dependabot alerts on transitive dependencies in `validation/` by bumping `fast-uri` and `brace-expansion` to patched versions.

| Alert | Package | CVE | Severity |
|---|---|---|---|
| [#26](https://github.com/camaraproject/tooling/security/dependabot/26) | fast-uri | CVE-2026-16221 (host confusion via literal backslash authority delimiter) | High |
| [#25](https://github.com/camaraproject/tooling/security/dependabot/25) | fast-uri | CVE-2026-13676 (host confusion via failed IDN canonicalization) | High |
| [#24](https://github.com/camaraproject/tooling/security/dependabot/24) | brace-expansion | CVE-2026-13149 (DoS via exponential-time expansion of consecutive non-expanding `{}` groups) | High |
| [#23](https://github.com/camaraproject/tooling/security/dependabot/23) | brace-expansion | CVE-2026-13149 (same CVE, separate resolution under `glob`'s nested `minimatch`) | High |

Both packages are transitive — `fast-uri` under `ajv`, `brace-expansion` under `minimatch` (both the top-level copy and `glob`'s own nested copy). Parent ranges already permit the patched versions, including the existing `fast-uri` `package.json` override from #273, so this is a lockfile-only refresh — no override or direct-dependency change needed.

#### Which issue(s) this PR fixes:

(no separate issue — Dependabot alerts auto-close on merge)

#### Special notes for reviewers:

Verification:

- `npm ci --ignore-scripts` (the CI install command) succeeds against the refreshed lockfile
- `npm audit` reports 0 vulnerabilities
- 1216/1216 `validation/` unit tests pass, including the 57 Spectral/Redocly-engine tests that exercise these packages directly

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

```
docs
NONE
```
