### PR TITLE
Prepare tooling 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- **[v0.8.0](#v080)**
 - **[v0.7.1](#v071)**
 - **[v0.7.0](#v070)**
 - **[v0.6.0](#v060)**
@@ -12,6 +13,32 @@
 - **[v0.2.2](#v022)**
 - **[v0.2.1](#v021)**
 - **[v0.2.0](#v020)**
+
+# v0.8.0
+
+## Release Notes
+
+**v0.8.0 is a minor release for the CAMARA tooling repository.**
+
+This release adds x-correlator documentation checks (new rules S-039 and S-040) and rewrites the behavior of three existing rules: discriminator-aware unused-component detection (S-211), a per-field `sinkCredential` writeOnly check (P-016), and S-036 parameter casing to allow the Design-Guide-defined filtering-operation suffixes (`.gte`, `.gt`, `.lte`, `.lt`).
+
+### Added
+
+* Check x-correlator documentation — new rules S-039 (request header undocumented) and S-040 (response header undocumented) by @LarryHu0217 in https://github.com/camaraproject/tooling/pull/376
+
+### Changed
+
+* Make unused-component detection discriminator-aware (S-211) by @LarryHu0217 in https://github.com/camaraproject/tooling/pull/378
+* Migrate P-006/P-007/P-008 severity ramp to `target_api_status` (no behavior change) by @hdamker in https://github.com/camaraproject/tooling/pull/381
+* Rewrite P-016 as a per-field `sinkCredential` writeOnly check by @hdamker in https://github.com/camaraproject/tooling/pull/383
+* Allow Design-Guide-defined filtering-operation suffixes (`.gte`, `.gt`, `.lte`, `.lt`) in S-036 parameter casing by @hdamker in https://github.com/camaraproject/tooling/pull/389
+* Bump @redocly/cli from 2.37.0 to 2.39.0 by @dependabot in https://github.com/camaraproject/tooling/pull/374
+* Bump actions/setup-python from 6 to 7 by @dependabot in https://github.com/camaraproject/tooling/pull/384
+* Bump actions/setup-node from 6 to 7 by @dependabot in https://github.com/camaraproject/tooling/pull/385
+* Bump @stoplight/spectral-cli from 6.16.1 to 6.16.2 by @dependabot in https://github.com/camaraproject/tooling/pull/386
+* Bump fast-uri, brace-expansion to patched versions (security) by @hdamker in https://github.com/camaraproject/tooling/pull/391
+
+**Full Changelog**: https://github.com/camaraproject/tooling/compare/v0.7.1...v0.8.0
 
 # v0.7.1
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ tooling/
 * **[`VERSION.yaml`](VERSION.yaml)** — records the current numbered tooling release version.
 * **[`CHANGELOG.md`](CHANGELOG.md)** — records numbered release notes and links to GitHub comparisons.
 * **`v1-rc`** — floating lightweight tag covering the validation and release automation framework v1 release candidate. This is the active consumption line for CAMARA API repositories.
-* **Numbered release tags** — immutable tags such as `v0.7.1` mark release points on `main`.
+* **Numbered release tags** — immutable tags such as `v0.8.0` mark release points on `main`.
 * **`v0`** — retired legacy linting tag. It is kept for historical compatibility and is not advanced for new releases.
 * **`main`** — active development branch.
 

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.7.1
+version: 0.8.0


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Prepares the numbered **tooling 0.8.0** release. It consolidates the changes that landed on `main` since v0.7.1:

* x-correlator documentation checks — new rules S-039 (request header undocumented) and S-040 (response header undocumented) (#376)
* Unused-component detection made discriminator-aware — S-211 rewrite, gated to OpenAPI only (#378)
* P-006/P-007/P-008 severity ramp migrated to `target_api_status` — no behavior change (#381)
* P-016 rewritten as a per-field `sinkCredential` writeOnly check (#383)
* S-036 parameter casing: allow Design-Guide-defined filtering-operation suffixes (`.gte`, `.gt`, `.lte`, `.lt`) (#389)
* Dependency bumps: @redocly/cli 2.37.0→2.39.0 (#374), actions/setup-python 6→7 (#384), actions/setup-node 6→7 (#385), @stoplight/spectral-cli →6.16.2 (#386), fast-uri/brace-expansion security patches (#391)

Changes: `VERSION.yaml` → 0.8.0, a `v0.8.0` `CHANGELOG.md` section, and a README release-information tag touch-up. Two new rule IDs (S-039/S-040) plus behavior rewrites of S-211, P-016, and S-036 make this a minor release, not a patch.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Numbered release PR — `v1-rc` is moved to the released commit after merge. Both regression canaries are green at HEAD (`247ed6e`): Validation Regression 11/11 PASS, RA Regression green at the last RA-scope-touching commit (`c506a7b`). The `actions/setup-python`/`actions/setup-node` major-version bumps (#384/#385) touch `release-automation-reusable.yml`; the canary-only gate for those two PRs was already reviewed and accepted as sufficient (mechanical version-pin-only bumps, every call site covered, no input changed) — no fresh manual E2E needed for this release.

#### Changelog input

```
 release-note
Prepare tooling 0.8.0 release.
```

#### Additional documentation

This section can be blank.

```
docs
NONE
```
