### PR TITLE
fix(validation): fix two P-025 false positives on real-world feature-file lines

### DIFF
--- a/validation/engines/python_checks/version_checks.py
+++ b/validation/engines/python_checks/version_checks.py
@@ -318,25 +318,30 @@ def check_feature_file_url_version(
             continue
 
         for line_number, line in enumerate(lines, start=1):
-            for match in seg_re.finditer(line):
-                actual_segment = match.group(1)
-                if actual_segment.lower() == expected_lower:
-                    continue
-                findings.append(
-                    make_finding(
-                        engine_rule="check-feature-file-url-version",
-                        level="error",
-                        message=(
-                            f"Scenario-step URL version segment "
-                            f"'/{actual_segment}' does not match expected "
-                            f"'/{expected_segment}' (derived from "
-                            f"info.version '{info_version}')"
-                        ),
-                        path=f"{_TEST_DIR}/{feature_file.name}",
-                        line=line_number,
-                        api_name=api.api_name,
-                    )
+            # First match only (tooling#394): the api-name may recur later in
+            # the same line as a resource-collection segment (e.g. a
+            # `qos-profiles` API's own `/qos-profiles/{name}` resource).
+            match = seg_re.search(line)
+            if match is None:
+                continue
+            actual_segment = match.group(1)
+            if actual_segment.lower() == expected_lower:
+                continue
+            findings.append(
+                make_finding(
+                    engine_rule="check-feature-file-url-version",
+                    level="error",
+                    message=(
+                        f"Scenario-step URL version segment "
+                        f"'/{actual_segment}' does not match expected "
+                        f"'/{expected_segment}' (derived from "
+                        f"info.version '{info_version}')"
+                    ),
+                    path=f"{_TEST_DIR}/{feature_file.name}",
+                    line=line_number,
+                    api_name=api.api_name,
                 )
+            )
 
     return findings
 

--- a/validation/engines/python_checks/version_checks.py
+++ b/validation/engines/python_checks/version_checks.py
@@ -318,6 +318,11 @@ def check_feature_file_url_version(
             continue
 
         for line_number, line in enumerate(lines, start=1):
+            # A comment is not a scenario step (e.g. a `# Operation: GET
+            # /{api-name}/{id}` line documenting the raw route) and carries
+            # no version segment to check.
+            if line.lstrip().startswith("#"):
+                continue
             # First match only (tooling#394): the api-name may recur later in
             # the same line as a resource-collection segment (e.g. a
             # `qos-profiles` API's own `/qos-profiles/{name}` resource).

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -577,6 +577,24 @@ class TestCheckFeatureFileUrlVersion:
         ctx = _make_context("qos-profiles", branch_type="main", version="wip")
         assert check_feature_file_url_version(tmp_path, ctx) == []
 
+    def test_main_comment_line_skipped(self, tmp_path: Path):
+        """A ``#`` comment documenting the raw operation (e.g.
+        ``# Operation: GET /network-access-devices/{id}``) is not a scenario
+        step — it carries no version segment at all — and must not be
+        misread as one. Observed on camaraproject/NetworkAccessManagement's
+        ``network-access-devices-getNetworkAccessDevice.feature``."""
+        _write_spec(tmp_path, "network-access-devices", "wip")
+        _write_feature(
+            tmp_path, "network-access-devices.feature",
+            "Feature: Network Access Devices, vwip\n"
+            "  # Operation: GET /network-access-devices/{networkAccessDeviceId}\n"
+            '  Given the resource "/network-access-devices/vwip/network-access-devices/{networkAccessDeviceId}"\n',
+        )
+        ctx = _make_context(
+            "network-access-devices", branch_type="main", version="wip"
+        )
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
     def test_spec_missing_returns_no_findings(self, tmp_path: Path):
         """No spec file => silent skip (filename/presence checks report)."""
         _write_feature(

--- a/validation/tests/test_python_checks_version.py
+++ b/validation/tests/test_python_checks_version.py
@@ -557,6 +557,26 @@ class TestCheckFeatureFileUrlVersion:
         lines = {f["line"] for f in findings}
         assert lines == {2, 3}
 
+    def test_main_same_line_api_name_reused_as_resource_segment(
+        self, tmp_path: Path
+    ):
+        """Regression (tooling#394): the api-name may legitimately reappear
+        later in the same line as a resource-collection segment (e.g. a
+        ``qos-profiles`` API whose ``getQosProfile`` resource path is also
+        named ``qos-profiles``). Only the first ``{api-name}/…`` occurrence
+        per line is the version segment; a second occurrence must not be
+        misread as one. Distinct from ``test_multiple_lines_collect_all_findings``
+        above, which covers separate lines each contributing their own
+        finding — that must keep working unchanged."""
+        _write_spec(tmp_path, "qos-profiles", "wip")
+        _write_feature(
+            tmp_path, "qos-profiles.feature",
+            "Feature: QoS Profiles, vwip\n"
+            '  Given the resource "/qos-profiles/vwip/qos-profiles/{name}"\n',
+        )
+        ctx = _make_context("qos-profiles", branch_type="main", version="wip")
+        assert check_feature_file_url_version(tmp_path, ctx) == []
+
     def test_spec_missing_returns_no_findings(self, tmp_path: Path):
         """No spec file => silent skip (filename/presence checks report)."""
         _write_feature(


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`check_feature_file_url_version` (P-025) and `check_server_url_version` (P-004) share one regex helper that captures the whole path segment following `{api-name}/`. P-004 applies it with `.search()` — first match only. P-025 applied it with `.finditer()` — every match in the line, which misfires when the API name recurs later in the same line as a resource-collection segment (e.g. a `qos-profiles` API whose own resource path is `/qos-profiles/vwip/qos-profiles/{name}`): the correct `vwip` match is found first, but the second, unrelated `{name}` match then gets flagged as a wrong version segment.

Fix (commit 1): P-025 now takes a single `.search()` per line, matching P-004's existing semantics. Every line is still scanned independently (a feature file legitimately repeats the api-name+version pattern across many scenario steps) — only the within-line multiple-match case is removed.

While evaluating the blast radius of the above across all CAMARA API repositories, a second, distinct false positive turned up: P-025 scans every raw line unconditionally, with no notion of "is this an actual step." A `#` comment documenting the raw operation (e.g. `# Operation: GET /network-access-devices/{id}`) is not a scenario step and carries no version segment to check, but still matched the pattern and got flagged.

Fix (commit 2): skip a line early when its stripped content starts with `#`, before running the version-segment check against it.

#### Which issue(s) this PR fixes:

Fixes #394

#### Special notes for reviewers:

- Added `test_main_same_line_api_name_reused_as_resource_segment` (commit 1) and `test_main_comment_line_skipped` (commit 2), each reproducing its exact real-world case (red before the corresponding fix, green after).
- `test_multiple_lines_collect_all_findings` (separate lines, each contributing its own finding) stays green throughout both commits — confirms neither fix touches cross-line scanning.
- Blast-radius check across all locally available CAMARA API repositories (both fixes, run against real repo content): the same-line-reuse false positive was live in `QualityOnDemand` (`qos-profiles`) and `NetworkAccessManagement` (`network-access-devices`, which also carried the comment-line false positive on the same file); one unrelated, genuine version-segment typo remains untouched (`KnowYourCustomer`, `kyc-fill-in.feature:28`, `v0.3rc1` vs expected `v0.3`) — confirming both fixes are precisely scoped, with no findings lost.
- Full `validation/tests` suite: 1218 passed.

#### Changelog input

```
 release-note
Fixed two P-025 false positives: a feature-file scenario step that reuses the API name as a resource-path segment later in the same line, and a comment line documenting the raw operation being misread as a scenario step.
```

#### Additional documentation

This section can be blank.

```
docs

```
