### PR TITLE
Prepare tooling 0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- **[v0.8.1](#v081)**
 - **[v0.8.0](#v080)**
 - **[v0.7.1](#v071)**
 - **[v0.7.0](#v070)**
@@ -13,6 +14,20 @@
 - **[v0.2.2](#v022)**
 - **[v0.2.1](#v021)**
 - **[v0.2.0](#v020)**
+
+# v0.8.1
+
+## Release Notes
+
+**v0.8.1 is a patch release for the CAMARA tooling repository.**
+
+This release fixes two P-025 false positives found while evaluating the blast radius of the `v0.8.0` S-211 fix: a scenario-step line that reuses the API name as a resource-path segment later in the same line (e.g. `/qos-profiles/vwip/qos-profiles/{name}`), and a `#` comment documenting the raw operation being misread as a scenario step. No new rule ID.
+
+### Fixed
+
+* Fix two P-025 false positives on real-world feature-file lines by @hdamker in https://github.com/camaraproject/tooling/pull/395
+
+**Full Changelog**: https://github.com/camaraproject/tooling/compare/v0.8.0...v0.8.1
 
 # v0.8.0
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ tooling/
 * **[`VERSION.yaml`](VERSION.yaml)** — records the current numbered tooling release version.
 * **[`CHANGELOG.md`](CHANGELOG.md)** — records numbered release notes and links to GitHub comparisons.
 * **`v1-rc`** — floating lightweight tag covering the validation and release automation framework v1 release candidate. This is the active consumption line for CAMARA API repositories.
-* **Numbered release tags** — immutable tags such as `v0.8.0` mark release points on `main`.
+* **Numbered release tags** — immutable tags such as `v0.8.1` mark release points on `main`.
 * **`v0`** — retired legacy linting tag. It is kept for historical compatibility and is not advanced for new releases.
 * **`main`** — active development branch.
 

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.8.0
+version: 0.8.1


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Prepares the numbered **tooling 0.8.1** patch release. It consolidates the fix that landed on `main` since `v0.8.0`:

* Fix two P-025 false positives on real-world feature-file lines — a scenario-step line that reuses the API name as a resource-path segment later in the same line, and a `#` comment documenting the raw operation being misread as a scenario step (#395)

Changes: `VERSION.yaml` → 0.8.1, a `v0.8.1` `CHANGELOG.md` section, and a README release-information tag touch-up. No new rule ID.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Numbered release PR — `v1-rc` is moved to the released commit after merge. Validation Regression canary is green 11/11 at HEAD (run 30030628357). No RA-scope files changed since `v0.8.0`, so the RA Regression canary basis is unchanged — no manual E2E needed.

#### Changelog input

```
 release-note
Prepare tooling 0.8.1 release.
```

#### Additional documentation

This section can be blank.

```
docs
NONE
```
