### PR TITLE
fix(deps): bump brace-expansion to patched version in validation/

### DIFF
--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -2323,15 +2323,15 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {

--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -1543,9 +1543,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Bumps `brace-expansion` to patched versions in `validation/`, closing two Dependabot alerts:

| Alert | Package | CVE | Severity |
|---|---|---|---|
| [#29](https://github.com/camaraproject/tooling/security/dependabot/29) | brace-expansion | CVE-2026-14257 (DoS via unbounded expansion length causing an OOM crash) | High |
| [#30](https://github.com/camaraproject/tooling/security/dependabot/30) | brace-expansion | CVE-2026-69152 (DoS bypassing the CVE-2026-14257 mitigation, via unbounded intermediate arrays) | High |

Two transitive copies of `brace-expansion` exist in `validation/package-lock.json`:

- `glob` → `minimatch@10.x` → `brace-expansion`: 5.0.8 → **5.0.9** (5.0.8 alone closed #29 but not #30, published after this PR opened).
- top-level, via `@stoplight/spectral-core` → `minimatch@3.1.5` → `brace-expansion`: 1.1.16 → **1.1.18**.

Both parent ranges (`^5.0.5` and `^1.1.7` respectively) already permit the patched versions, so this is a lockfile-only refresh — no `overrides` entry needed. An earlier revision of this PR excluded the second copy on the grounds that no patched 1.x release existed; that's no longer true (1.1.17/1.1.18 have since shipped), so it's now in scope too.

#### Which issue(s) this PR fixes:

(no separate issue — Dependabot alerts auto-close on merge)

#### Special notes for reviewers:

Verification:

- `npm ci --ignore-scripts` (the CI install command) succeeds against the refreshed lockfile
- 1218/1218 `validation/` unit tests pass, including the Spectral/Redocly-engine tests that exercise `glob`/`minimatch` directly
- `npm audit` reports no remaining `brace-expansion` findings; the one remaining high-severity finding (`fast-uri`) is unrelated and out of scope for this PR

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

This section can be blank.

```
docs
NONE
```
