### PR TITLE
fix(deps): bump fast-uri to patched version in validation/

### DIFF
--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -2079,9 +2079,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Closes Dependabot alert [#31](https://github.com/camaraproject/tooling/security/dependabot/31) by bumping `fast-uri` to a patched version in `validation/`.

| Alert | Package | CVE | Severity |
|---|---|---|---|
| [#31](https://github.com/camaraproject/tooling/security/dependabot/31) | fast-uri | CVE-2026-18446 (host confusion via backslash authority introducer) | High |

`fast-uri` is a single, non-split transitive dependency here. The existing `overrides` entry (`"fast-uri": "^3.1.2"`) already permits the patched 3.1.5, so this is a lockfile-only refresh — no `overrides` change needed.

#### Which issue(s) this PR fixes:

(no separate issue — Dependabot alerts auto-close on merge)

#### Special notes for reviewers:

Verification:

- `npm ci --ignore-scripts` (the CI install command) succeeds against the refreshed lockfile
- 1218/1218 `validation/` unit tests pass
- `npm audit` now reports 0 vulnerabilities (was 1 high before this bump)

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

This section can be blank.

```
docs
NONE
```
