### PR TITLE
feat(validation): show component name in Spectral finding location

### DIFF
--- a/validation/output/formatting.py
+++ b/validation/output/formatting.py
@@ -12,6 +12,7 @@ Design doc references:
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -260,14 +261,31 @@ def resolve_annotation_title(finding: dict) -> str:
     return message[: _ANNOTATION_TITLE_MAX - 1].rstrip() + "…"
 
 
+# Matches the Spectral-engine ``schema_path`` (a dot-joined JSONPath) for a
+# named OpenAPI component, capturing the component name.
+_COMPONENT_PATH_RE = re.compile(
+    r"^components\.(?:schemas|parameters|responses|requestBodies|headers)\.([^.]+)"
+)
+
+
 def format_finding_location(finding: dict) -> str:
-    """Format a finding's location as ``path:line`` or ``path:line:column``."""
+    """Format a finding's location as ``path:line`` or ``path:line:column``.
+
+    When ``schema_path`` identifies a named OpenAPI component (Spectral-engine
+    findings only), the component name is appended in parens, e.g.
+    ``spec.yaml:42 (QosProfile)``.
+    """
     path = finding.get("path", "")
     line = finding.get("line", 0)
     column = finding.get("column")
     if column is not None:
-        return f"{path}:{line}:{column}"
-    return f"{path}:{line}"
+        location = f"{path}:{line}:{column}"
+    else:
+        location = f"{path}:{line}"
+    match = _COMPONENT_PATH_RE.match(finding.get("schema_path") or "")
+    if match:
+        return f"{location} ({match.group(1)})"
+    return location
 
 
 # Inline-syntax characters that GFM interprets specially.  Backslash is

--- a/validation/tests/test_output_formatting.py
+++ b/validation/tests/test_output_formatting.py
@@ -311,6 +311,16 @@ class TestFormatFindingLocation:
     def test_empty_finding(self):
         assert format_finding_location({}) == ":0"
 
+    def test_component_schema_path_appends_name(self):
+        f = _make_finding(path="spec.yaml", line=42)
+        f["schema_path"] = "components.schemas.QosProfile"
+        assert format_finding_location(f) == "spec.yaml:42 (QosProfile)"
+
+    def test_non_component_schema_path_unchanged(self):
+        f = _make_finding(path="spec.yaml", line=42)
+        f["schema_path"] = "paths./foo.get.parameters.0.schema"
+        assert format_finding_location(f) == "spec.yaml:42"
+
 
 # ---------------------------------------------------------------------------
 # resolve_annotation_title


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Appends the component name to a Spectral-engine finding's rendered location, e.g. `spec.yaml:342 (QosProfile)`, when `schema_path` resolves to a named component. Details and design rationale are in the linked issue.

#### Which issue(s) this PR fixes:

Fixes #399

#### Special notes for reviewers:

Falls back to the current `path:line[:column]` format when `schema_path` is absent or not a named component (e.g. inline schemas). Non-Spectral engines are unaffected. No regression-fixture changes needed.

#### Changelog input

```
release-note
Show the component/schema name in Spectral finding locations (e.g. `(QosProfile)`) when resolvable, making S-211/S-313 and similar hints easier to locate in the spec.
```

#### Additional documentation

This section can be blank.

```
docs
```
