### PR TITLE
fix(deps): drop @stoplight/spectral-rulesets pin in validation/

### DIFF
--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -836,49 +836,6 @@
         "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
-    "node_modules/@stoplight/spectral-cli/node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.2.tgz",
-      "integrity": "sha512-JsaNqtxBRfjKTCgQJK+LoOyDhzm9Hhw9kV9U3NalsQMH5ERBJw6IVhYyCZtgHBc5FhjXao2iJnnDfGta07M4wQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asyncapi/specs": "^6.8.0",
-        "@stoplight/better-ajv-errors": "1.0.3",
-        "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.19.4",
-        "@stoplight/spectral-formats": "^1.8.1",
-        "@stoplight/spectral-functions": "^1.9.1",
-        "@stoplight/spectral-runtime": "^1.1.2",
-        "@stoplight/types": "^13.6.0",
-        "@types/json-schema": "^7.0.7",
-        "ajv": "^8.18.0",
-        "ajv-formats": "~2.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "leven": "3.1.0",
-        "lodash": "^4.18.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": "^16.20 || ^18.18 || >= 20.17"
-      }
-    },
-    "node_modules/@stoplight/spectral-cli/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@stoplight/spectral-core": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.0.tgz",
@@ -922,23 +879,6 @@
       },
       "engines": {
         "node": "^12.20 || >=14.13"
-      }
-    },
-    "node_modules/@stoplight/spectral-core/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/@stoplight/spectral-formats": {
@@ -1000,23 +940,6 @@
       },
       "engines": {
         "node": "^16.20 || ^18.18 || >= 20.17"
-      }
-    },
-    "node_modules/@stoplight/spectral-functions/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/@stoplight/spectral-owasp-ruleset": {
@@ -1100,49 +1023,6 @@
         "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
-    "node_modules/@stoplight/spectral-ruleset-bundler/node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.2.tgz",
-      "integrity": "sha512-JsaNqtxBRfjKTCgQJK+LoOyDhzm9Hhw9kV9U3NalsQMH5ERBJw6IVhYyCZtgHBc5FhjXao2iJnnDfGta07M4wQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asyncapi/specs": "^6.8.0",
-        "@stoplight/better-ajv-errors": "1.0.3",
-        "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.19.4",
-        "@stoplight/spectral-formats": "^1.8.1",
-        "@stoplight/spectral-functions": "^1.9.1",
-        "@stoplight/spectral-runtime": "^1.1.2",
-        "@stoplight/types": "^13.6.0",
-        "@types/json-schema": "^7.0.7",
-        "ajv": "^8.18.0",
-        "ajv-formats": "~2.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "leven": "3.1.0",
-        "lodash": "^4.18.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": "^16.20 || ^18.18 || >= 20.17"
-      }
-    },
-    "node_modules/@stoplight/spectral-ruleset-bundler/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@stoplight/spectral-ruleset-migrator": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.1.tgz",
@@ -1188,6 +1068,33 @@
       "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
       "integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@stoplight/spectral-rulesets": {
+      "version": "1.22.7",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.7.tgz",
+      "integrity": "sha512-cT1B6Ly21923lvr235lu7iIgmcnoCTJaN3ANOyTqr4D5GA/4p2k0+yhjhdfj/1ks/Os3kUzSFnFkzpWH7WszFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asyncapi/specs": "6.11.1",
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.23.0",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^8.18.0",
+        "ajv-formats": "~2.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "leven": "3.1.0",
+        "lodash": "^4.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
     },
     "node_modules/@stoplight/spectral-runtime": {
       "version": "1.1.5",
@@ -1406,6 +1313,23 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {

--- a/validation/package.json
+++ b/validation/package.json
@@ -14,7 +14,6 @@
     "js-yaml": "^5.2.2"
   },
   "overrides": {
-    "@stoplight/spectral-rulesets": "1.22.2",
     "lodash": "^4.18.0",
     "postcss": "^8.5.10",
     "protobufjs": "^7.5.8",


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Drops the `@stoplight/spectral-rulesets` pin (`1.22.2`, added in #329) from `validation/package.json` `overrides`. Upstream shipped the null-guard fix ([stoplightio/spectral#2960](https://github.com/stoplightio/spectral/pull/2960)) in `1.22.7`, so the pin is no longer needed; removing it lets the lockfile resolve and hoist a single `1.22.7` copy (previously two nested `1.22.2` copies under `spectral-cli` and `spectral-ruleset-bundler`).

#### Which issue(s) this PR fixes:

Fixes #330

#### Special notes for reviewers:

Dependency-only (`validation/package.json` + lockfile). Verified: `npm ci --ignore-scripts` clean, `npm audit` 0 vulnerabilities, full `validation/` unit suite (1218/1218) passes including the existing `test_spectral_does_not_crash_on_null_value` regression test from #328/#329.

#### Changelog input

```
 release-note
Remove the @stoplight/spectral-rulesets 1.22.2 pin now that upstream has shipped the null-guard fix (1.22.7)
```

#### Additional documentation

This section can be blank.

```
docs

```
