### PR TITLE
fix(rules): suppress unactionable S-313 on the common pagination Link header

### DIFF
--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -477,6 +477,7 @@
     - components.schemas.ErrorInfo.properties.code
     - components.schemas.ErrorInfo.properties.message
     - components.schemas.NetworkAccessIdentifier
+    - components.headers.link.schema
     # CAMARA_event_common.yaml
     - components.schemas.CloudEvent.properties.id
     - components.schemas.CloudEvent.properties.type


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Adds `components.headers.link.schema` to S-313's `suppress_schema_paths` allowlist. The RFC 8288 pagination `Link` header is already length-constrained; no `format`/`pattern`/`enum` fits its `<uri>; rel="…"` values, same as the other ten allowlisted fields.

#### Which issue(s) this PR fixes:

Fixes #401

#### Special notes for reviewers:

Regression fixture recapture on `camaraproject/ReleaseTest` is deferred until after merge to `main`, per the issue. Full `validation/tests` suite passes (1218).

#### Changelog input

```
 release-note
Suppressed the unactionable S-313 finding on the common pagination `Link` header.
```

#### Additional documentation

This section can be blank.

```
docs

```
