### PR TITLE
fix(rules): suppress unactionable S-313 on SinkCredential subtype fields

### DIFF
--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -486,6 +486,8 @@
     - components.schemas.SubscriptionStarted.properties.initiationDescription
     - components.schemas.SubscriptionUpdated.properties.updateDescription
     - components.schemas.SubscriptionEnded.properties.terminationDescription
+    - components.schemas.AccessTokenCredential.allOf.1.properties.accessToken
+    - components.schemas.PrivateKeyJWTCredential.allOf.1.properties.clientId
 
 # MUTED: muted in linting/config/.spectral-r4.yaml (set to `off`) since
 # 2026-04-28 pending Commonalities#615 (HTTPSettings.headers — remove or


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Adds `AccessTokenCredential.allOf.1.properties.accessToken` and `PrivateKeyJWTCredential.allOf.1.properties.clientId` to S-313's `suppress_schema_paths` allowlist. Both fields are already length-constrained via `maxLength`; no `format`/`pattern`/`enum` fits an opaque bearer token or a client identifier, same class as the other allowlisted fields. The finding only surfaces once a consuming API's release-snapshot bundler (`redocly bundle`) materializes these `SinkCredential` discriminator subtypes as concrete top-level schemas — Commonalities' own lint templates only `$ref` the base `SinkCredential` schema and never reach them.

#### Which issue(s) this PR fixes:

Fixes #407

#### Special notes for reviewers:

Same known-unactionable class as #401/#406 (the pagination `Link` header). Full `validation/tests` suite passes (1218).

#### Changelog input

```
 release-note
Suppressed the unactionable S-313 finding on the SinkCredential discriminator subtype fields (AccessTokenCredential.accessToken, PrivateKeyJWTCredential.clientId).
```

#### Additional documentation

This section can be blank.

```
docs

```
