### PR TITLE
fix(validation): suppress ANSI color in bundling-failure annotation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -514,6 +514,11 @@ jobs:
         if: always() && steps.validation.outcome == 'success'
         env:
           PATH_NODE_MODULES: ${{ github.workspace }}/.tooling/validation/node_modules/.bin
+          # Redocly forces ANSI color into captured output on this runner
+          # (colorette detects GITHUB_ACTIONS unconditionally); without this,
+          # a trailing color-reset line clobbers the ${err##*$'\n'} extraction
+          # below, making the warning annotation illegible.
+          NO_COLOR: "1"
         run: |
           export PATH="${PATH_NODE_MODULES}:${PATH}"
           mkdir -p validation-output/bundled


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

When a spec fails to bundle, codeowners currently see a warning like `Bundling failed for <spec>.yaml: [39m` — a stray color-code fragment instead of Redocly's actual error message, with no clue what's actually wrong with their spec.

Redocly forces color into its output on GitHub Actions runners even though this step only captures the output and never displays it directly; the trailing color-reset code was overwriting the real error message before it reached the annotation. Adding `NO_COLOR: "1"` to the step stops Redocly from emitting color in the first place, so the annotation now shows the actual bundling error.

Verified on a real GitHub Actions run, not just locally — a previous attempt at this same fix only worked in local testing and hadn't been confirmed against the real runner.

#### Which issue(s) this PR fixes:

Related to #390 (closed on narrower grounds without landing the annotation fix investigated there).

#### Special notes for reviewers:

No test suite covers this workflow step directly; verification was a live Actions run against a spec with an unresolved `$ref`, confirming the annotation now shows Redocly's real message end-to-end.

#### Changelog input

```
release-note
Fixes an illegible bundling-failure warning annotation in CAMARA Validation by suppressing ANSI color in captured Redocly output.
```

#### Additional documentation

This section can be blank.



```
docs

```
