### PR TITLE
Align the CHANGELOG's Commonalities/ICM dependency line with release-metadata.yaml

### DIFF
--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -340,8 +340,6 @@ class SnapshotCreator:
                     api_versions,
                     metadata,
                     repo_name,
-                    commonalities_version=commonalities_version,
-                    icm_version=icm_version,
                     compare_base=compare_base,
                     api_comparison_baselines=api_comparison_baselines,
                 )
@@ -991,8 +989,6 @@ class SnapshotCreator:
         api_versions: Dict[str, str],
         metadata: Dict[str, Any],
         repo_name: str,
-        commonalities_version: str = "",
-        icm_version: str = "",
         compare_base: Any = COMPARE_BASE_UNSET,
         api_comparison_baselines: Optional[Dict[str, str]] = None,
     ) -> str:
@@ -1020,14 +1016,6 @@ class SnapshotCreator:
             baseline = api_comparison_baselines.get(api.get("api_name", ""))
             if baseline:
                 api["comparison_baseline"] = baseline
-        if commonalities_version:
-            changelog_metadata.setdefault("dependencies", {})[
-                "commonalities_release"
-            ] = commonalities_version
-        if icm_version:
-            changelog_metadata.setdefault("dependencies", {})[
-                "identity_consent_management_release"
-            ] = icm_version
 
         generator = ChangelogGenerator()
         content = generator.generate_draft(

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -431,6 +431,74 @@ class TestCreateSnapshot:
         assert result.release_pr_number == 42
         assert "quality-on-demand" in result.api_versions
 
+    @patch("release_automation.scripts.snapshot_creator.ChangelogGenerator")
+    @patch("release_automation.scripts.snapshot_creator.tempfile.mkdtemp")
+    @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
+    @patch("release_automation.scripts.snapshot_creator.GitOperations")
+    @patch("builtins.open", create=True)
+    def test_changelog_keeps_release_tag_in_dependency_line(
+        self,
+        mock_open,
+        mock_git_ops_class,
+        mock_rmtree,
+        mock_mkdtemp,
+        mock_changelog_cls,
+        snapshot_creator,
+        mock_github_client,
+        mock_metadata_generator,
+        sample_release_plan,
+    ):
+        """CHANGELOG's dependency line states the release tag, not just the version.
+
+        release-metadata.yaml's own dependencies.commonalities_release carries
+        "<tag> (<version>)"; the CHANGELOG draft must reuse that string as-is
+        instead of resolving it down to the bare semantic version.
+        """
+        mock_mkdtemp.return_value = "/tmp/test-snapshot"
+
+        mock_git_ops = MagicMock()
+        mock_git_ops_class.return_value = mock_git_ops
+        mock_git_ops.create_pr.return_value = PullRequestInfo(
+            number=42, url="https://github.com/owner/repo/pull/42"
+        )
+        mock_github_client.get_releases.return_value = []
+        mock_github_client.generate_release_notes.return_value = None
+
+        mock_metadata_generator.generate.return_value = {
+            "repository": {
+                "repository_name": "TestRepo-QoD",
+                "release_tag": "r4.1",
+                "release_type": "pre-release-rc",
+            },
+            "apis": [{"api_name": "quality-on-demand", "api_version": "3.2.0-rc.1"}],
+            "dependencies": {
+                "commonalities_release": "r3.4 (0.7.0-rc.1)",
+                "identity_consent_management_release": "r3.3 (0.5.0-rc.1)",
+            },
+        }
+
+        mock_changelog_instance = Mock()
+        mock_changelog_instance.generate_draft.return_value = "# r4.1\n\nContent\n"
+        mock_changelog_instance.write_changelog.return_value = (
+            "CHANGELOG/CHANGELOG-r4.md"
+        )
+        mock_changelog_cls.return_value = mock_changelog_instance
+
+        config = SnapshotConfig(release_tag="r4.1")
+        snapshot_creator.create_snapshot(sample_release_plan, config)
+
+        draft_metadata = mock_changelog_instance.generate_draft.call_args.kwargs[
+            "metadata"
+        ]
+        assert (
+            draft_metadata["dependencies"]["commonalities_release"]
+            == "r3.4 (0.7.0-rc.1)"
+        )
+        assert (
+            draft_metadata["dependencies"]["identity_consent_management_release"]
+            == "r3.3 (0.5.0-rc.1)"
+        )
+
     @patch("release_automation.scripts.snapshot_creator.tempfile.mkdtemp")
     @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
     @patch("release_automation.scripts.snapshot_creator.GitOperations")
@@ -1371,10 +1439,10 @@ class TestReleaseDocumentation:
         mock_instance.write_changelog.assert_called_once()
 
     @patch("release_automation.scripts.snapshot_creator.ChangelogGenerator")
-    def test_generate_changelog_uses_commonalities_version_only(
+    def test_generate_changelog_keeps_metadata_dependency_display_string(
         self, mock_gen_cls, snapshot_creator, mock_github_client, tmp_path
     ):
-        """CHANGELOG generation uses semantic version instead of metadata display string."""
+        """CHANGELOG generation keeps release-metadata.yaml's tag+version string."""
         mock_github_client.get_releases.return_value = []
         mock_github_client.generate_release_notes.return_value = None
 
@@ -1399,15 +1467,16 @@ class TestReleaseDocumentation:
             {},
             metadata,
             "TestRepo-QoD",
-            commonalities_version="0.7.0-rc.1",
-            icm_version="0.5.0-rc.1",
         )
 
         draft_metadata = mock_instance.generate_draft.call_args.kwargs["metadata"]
-        assert draft_metadata["dependencies"]["commonalities_release"] == "0.7.0-rc.1"
+        assert (
+            draft_metadata["dependencies"]["commonalities_release"]
+            == "r4.1 (0.7.0-rc.1)"
+        )
         assert (
             draft_metadata["dependencies"]["identity_consent_management_release"]
-            == "0.5.0-rc.1"
+            == "r4.1 (0.5.0-rc.1)"
         )
 
     @patch("release_automation.scripts.snapshot_creator.ChangelogGenerator")


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Changes the CHANGELOG's Commonalities/ICM dependency line to reuse the same
`"<tag> (<version>)"` string `release-metadata.yaml` already carries in
`dependencies.commonalities_release` / `identity_consent_management_release`, instead of
resolving it down to the bare semantic version used elsewhere (e.g. `x-camara-commonalities`).
Aligns the two artifacts on the same dependency-release format.

#### Which issue(s) this PR fixes:

Fixes #415

#### Special notes for reviewers:

`ChangelogGenerator.generate_draft()` and `release_section.mustache` are unchanged — the change
removes the now-dead `commonalities_version`/`icm_version` override parameters from
`_generate_changelog()`.

#### Changelog input

```
 Align the per-API CHANGELOG's Commonalities/ICM dependency line with release-metadata.yaml's tag+version format.

```

#### Additional documentation

This section can be blank.

```
docs

```
