### PR TITLE
docs(rules): register P-040 tested_rules and strip leaked DEC- ids

### DIFF
--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -294,11 +294,11 @@
     schema. See implicit-events API template in Commonalities
     artifacts/api-templates/.
 
-# P-021: check-common-cache-sync (DEC-027/030)
+# P-021: check-common-cache-sync
 # Safety check: code/common/ files must match the sync manifest written
 # by the RA sync-common handler.  Suppressed on bump PRs via the
-# three-step consistency model (DEC-029).  Version-gated to repos
-# adopting $ref consumption (>=r4.2).
+# three-step consistency model.  Version-gated to repos adopting $ref
+# consumption (>=r4.2).
 - id: P-021
   engine: python
   engine_rule: check-common-cache-sync

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -18,7 +18,7 @@ summary:
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 95
+  total_tested: 96
   by_engine:
     spectral: 85
     gherkin: 25
@@ -205,8 +205,7 @@ gap_rules:
     status: implemented
     rule_id: P-020
 
-  - audit_id: DEC-027
-    description: "Common file cache sync safety check — code/common/ must match sync manifest from Commonalities artifacts"
+  - description: "Common file cache sync safety check — code/common/ must match sync manifest from Commonalities artifacts"
     target_engine: python
     status: implemented
     rule_id: P-021
@@ -331,6 +330,7 @@ tested_rules:
   P-031: [regression/r4.3-broken-spec-info-description-missing-canonical]
   P-032: [regression/r4.3-broken-spec-test-files]
   P-037: [regression/r4.3-broken-spec-subscriptions, regression/r4.3-broken-spec-yaml-fundamentals]
+  P-040: [regression/r4.3-broken-spec-bundler-collision]
   S-002: [regression/r4.3-broken-spec-routing]
   S-003: [regression/r4.3-broken-spec-routing]
   S-005: [regression/r4.3-broken-spec-yaml-fundamentals]


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Registers `P-040` in `tested_rules` (pinned by the new `regression/r4.3-broken-spec-bundler-collision` branch on `camaraproject/ReleaseTest`) and bumps `total_tested` from 95 to 96 — a step from the "adding a new regression branch" checklist in `validation/docs/regression-testing.md` that was missed when that branch was added.

Also strips a couple of stray internal tracking-ID references left in `P-021`'s comment and `audit_id` field in `python-rules.yaml` and `rule-inventory.yaml` — unrelated to the checklist gap, found while editing the same file.

#### Which issue(s) this PR fixes:

N/A — standalone documentation correction, no linked issue.

#### Special notes for reviewers:

Full `validation/` test suite passes (1245 passed); nothing depends on the removed `audit_id` field or comment text.

#### Changelog input

```
release-note
Registers P-040 in the rule-inventory tested_rules mapping; no functional change.
```

#### Additional documentation

This section can be blank.



```
docs

```
