### PR TITLE
Prepare tooling 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- **[v0.9.0](#v090)**
 - **[v0.8.1](#v081)**
 - **[v0.8.0](#v080)**
 - **[v0.7.1](#v071)**
@@ -14,6 +15,38 @@
 - **[v0.2.2](#v022)**
 - **[v0.2.1](#v021)**
 - **[v0.2.0](#v020)**
+
+# v0.9.0
+
+## Release Notes
+
+**v0.9.0 is a minor release for the CAMARA tooling repository.**
+
+This release adds externalDocs validation against Design Guide §5.4 (new rules P-038 and P-039) and a bundler component-renaming-collision check (new rule P-040). It also improves Spectral finding locations with component/schema names and aligns the per-API CHANGELOG's Commonalities/ICM dependency line with `release-metadata.yaml`.
+
+### Added
+
+* Validate `externalDocs.url` and `description` against Design Guide §5.4 — new rules P-038 (repository URL) and P-039 (description) by @hdamker in https://github.com/camaraproject/tooling/pull/410
+* Detect component-renaming collisions from bundling — new rule P-040 by @hdamker in https://github.com/camaraproject/tooling/pull/412
+
+### Changed
+
+* Show the component/schema name in Spectral finding locations (S-211/S-313 and similar) by @hdamker in https://github.com/camaraproject/tooling/pull/404
+* Drop the `@stoplight/spectral-rulesets` pin now that upstream has shipped the null-guard fix by @hdamker in https://github.com/camaraproject/tooling/pull/405
+* Suppress the unactionable S-313 finding on the common pagination `Link` header by @hdamker in https://github.com/camaraproject/tooling/pull/406
+* Suppress the unactionable S-313 finding on SinkCredential discriminator subtype fields by @hdamker in https://github.com/camaraproject/tooling/pull/408
+* Suppress ANSI color in the bundling-failure annotation by @hdamker in https://github.com/camaraproject/tooling/pull/414
+* Align the per-API CHANGELOG's Commonalities/ICM dependency line with `release-metadata.yaml`'s tag+version format by @hdamker in https://github.com/camaraproject/tooling/pull/416
+
+### Dependencies
+
+* Bump @redocly/cli from 2.39.0 to 2.41.0 by @dependabot in https://github.com/camaraproject/tooling/pull/397
+* Bump js-yaml from 5.2.1 to 5.2.2 by @dependabot in https://github.com/camaraproject/tooling/pull/398
+* Bump brace-expansion to a patched version (security) by @hdamker in https://github.com/camaraproject/tooling/pull/400
+* Bump @redocly/cli from 2.41.0 to 2.43.2 by @dependabot in https://github.com/camaraproject/tooling/pull/402
+* Bump fast-uri to a patched version (security) by @hdamker in https://github.com/camaraproject/tooling/pull/403
+
+**Full Changelog**: https://github.com/camaraproject/tooling/compare/v0.8.1...v0.9.0
 
 # v0.8.1
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ tooling/
 * **[`VERSION.yaml`](VERSION.yaml)** — records the current numbered tooling release version.
 * **[`CHANGELOG.md`](CHANGELOG.md)** — records numbered release notes and links to GitHub comparisons.
 * **`v1-rc`** — floating lightweight tag covering the validation and release automation framework v1 release candidate. This is the active consumption line for CAMARA API repositories.
-* **Numbered release tags** — immutable tags such as `v0.8.1` mark release points on `main`.
+* **Numbered release tags** — immutable tags such as `v0.9.0` mark release points on `main`.
 * **`v0`** — retired legacy linting tag. It is kept for historical compatibility and is not advanced for new releases.
 * **`main`** — active development branch.
 

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.8.1
+version: 0.9.0


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Prepares the numbered **tooling 0.9.0** release. It consolidates the changes that landed on `main` since v0.8.1 (milestone https://github.com/camaraproject/tooling/milestone/1, 24 items, 0 open):

* externalDocs validation against Design Guide §5.4 — new rules P-038 (repository URL) and P-039 (description) (#410)
* Bundler component-renaming-collision check — new rule P-040 (#412)
* Show component/schema name in Spectral finding locations (#404)
* Drop the `@stoplight/spectral-rulesets` pin (#405)
* Suppress unactionable S-313 on the common pagination `Link` header (#406)
* Suppress unactionable S-313 on SinkCredential discriminator subtype fields (#408)
* Suppress ANSI color in the bundling-failure annotation (#414)
* Align the per-API CHANGELOG's Commonalities/ICM dependency line with `release-metadata.yaml` (#416)
* Dependency bumps: @redocly/cli 2.39.0→2.43.2 (#397, #402), js-yaml 5.2.1→5.2.2 (#398), brace-expansion and fast-uri security patches (#400, #403)

Changes: `VERSION.yaml` → 0.9.0, a `v0.9.0` `CHANGELOG.md` section, and a README release-information tag touch-up. Two new rule IDs (P-038/P-039) plus a third (P-040) make this a minor release, not a patch.

#### Which issue(s) this PR fixes:

Related to #419

#### Special notes for reviewers:

Numbered release PR — `v1-rc` is moved to the released commit after merge. Both regression canaries are green at HEAD (`b1d6fc2`): Validation Regression 12/12 PASS (run 31169997789), Release Automation Regression green (no RA-scope commits since the last green run). The one workflow-file change in scope (#414, `NO_COLOR` in `validation.yml`) is mechanical with no input/output contract change — canary-only gate accepted per the `v0.7.0`/`v0.8.0` mechanical-change precedent.

#### Changelog input

```release-note
Prepare tooling 0.9.0 release.
```

#### Additional documentation

This section can be blank.

```docs
NONE
```
