### PR TITLE
feat(release-review-pr): add findings-collector checklist item

### DIFF
--- a/release_automation/templates/pr_bodies/release_review_pr.mustache
+++ b/release_automation/templates/pr_bodies/release_review_pr.mustache
@@ -52,6 +52,7 @@ _The following actions and checks are done by a Release Management reviewer befo
 - [ ] Breaking changes are documented and version updates follow SemVer rules
 - [ ] Mandatory release assets are present for each API according to its status
 - [ ] All remaining validation warnings are documented in issues and the reasons for deferral are defensible
+- [ ] Content findings needing a `main` PR are collected as sub-issues of one issue titled `Release {{release_tag}} review findings` (see [Recording review findings](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/readiness/api-readiness-checklist.md#recording-review-findings))
 
 <details>
 <summary><b>Required release assets per API status</b></summary>

--- a/release_automation/tests/test_template_loader.py
+++ b/release_automation/tests/test_template_loader.py
@@ -47,6 +47,7 @@ class TestRenderTemplate:
         assert "Commonalities r3.4" in result
         assert "Mandatory release assets are present for each API according to its status" in result
         assert "All remaining validation warnings are documented in issues and the reasons for deferral are defensible" in result
+        assert "Content findings needing a `main` PR are collected as sub-issues of one issue titled `Release r4.1 review findings`" in result
         assert "Assign the Release Management reviewer(s) as assignee(s) of this PR" in result
         assert "The following actions and checks are done by a Release Management reviewer before approving the PR" in result
         assert "### Valid next actions for codeowners" in result


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds a Release Management Actions checklist item to the Release Review PR template: content findings needing a `main` PR get collected as sub-issues of one issue titled `Release {{release_tag}} review findings`, linking to the convention's documentation. Includes a regression-test assertion covering the new line.

#### Which issue(s) this PR fixes:

Part of camaraproject/ReleaseManagement#650

#### Special notes for reviewers:

A companion PR in `camaraproject/ReleaseManagement` documents the convention this checklist item links to. Wording here is a starting point for discussion per ReleaseManagement#650, not final text to defend.
