### PR TITLE
Commit README release info with the snapshot, not the review branch

### DIFF
--- a/documentation/validation/release-prs.md
+++ b/documentation/validation/release-prs.md
@@ -12,7 +12,7 @@ The Release PR is a **transparency check** on release content. It helps reviewer
 
 ## What you can change in the Release PR
 
-You may review or refine reviewable release content according to the release process — typically the changelog entry and the README release information.
+You may review or refine reviewable release content according to the release process — the changelog entry. The README release information is a mechanical change committed with the snapshot before the Release PR opens; it is not editable there.
 
 ## What you must not change there
 

--- a/release_automation/docs/repository-setup.md
+++ b/release_automation/docs/repository-setup.md
@@ -44,7 +44,7 @@ Three rulesets protect branches managed by the release automation:
 
 The `camara-release-automation` GitHub App is the bypass actor for all rulesets, allowing the workflow to create and manage these branches while humans are governed by protection rules.
 
-No ruleset is needed for `release-review/**` branches — codeowners push review fixes directly to these branches, and the workflow handles creation and cleanup.
+No ruleset is needed for `release-review/**` branches — codeowners push CHANGELOG review fixes directly to these branches, and the workflow handles creation and cleanup. Validation rule P-012 restricts what may change there to CHANGELOG.md / CHANGELOG/ — README.md is a mechanical change committed with the snapshot, not editable here.
 
 ### Snapshot Branch Protection
 

--- a/release_automation/docs/technical-architecture.md
+++ b/release_automation/docs/technical-architecture.md
@@ -437,11 +437,17 @@ In PLANNED state, only target fields are populated. In SNAPSHOT_ACTIVE/DRAFT_REA
 
 ### 2.10 Release Documentation Generators
 
-Two Python modules generate release documentation on the release-review branch, creating the commits that differentiate it from the snapshot branch.
+Two Python modules generate release documentation. The README updater runs as part of snapshot
+creation, alongside the other mechanical transforms; the CHANGELOG generator runs on the
+release-review branch, creating the single commit that differentiates it from the snapshot
+branch.
 
 #### 2.10.1 README Updater (`readme_updater.py`)
 
-Updates the "Release Information" section in README.md, replacing content between delimiters (`<!-- CAMARA:RELEASE-INFO:START -->` / `<!-- CAMARA:RELEASE-INFO:END -->`).
+Updates the "Release Information" section in README.md, replacing content between delimiters (`<!-- CAMARA:RELEASE-INFO:START -->` / `<!-- CAMARA:RELEASE-INFO:END -->`). Runs during
+`/create-snapshot`, before the snapshot commit — the block is a mechanical change, not
+reviewable content, so it is committed with the snapshot rather than left editable on the
+release-review branch.
 
 **Release state determination** (during `/create-snapshot`):
 
@@ -694,7 +700,7 @@ Synchronizes Release Issue with current derived state. Creates issues when none 
 
 ### 4.5 create-snapshot
 
-Orchestrates the full snapshot creation flow: validate release plan, calculate API versions, create snapshot branch with transformations, generate release-metadata.yaml, create release-review branch with README + CHANGELOG commits, create Release PR.
+Orchestrates the full snapshot creation flow: validate release plan, calculate API versions, create snapshot branch with transformations + README Release Information, generate release-metadata.yaml, create release-review branch with the CHANGELOG commit, create Release PR.
 
 ---
 
@@ -730,17 +736,17 @@ Orchestrates the full snapshot creation flow: validate release plan, calculate A
 │                    ▼                                                    │
 │  8. Create snapshot branch: release-snapshot/r4.1-abc1234              │
 │     - Apply mechanical transformations                                  │
+│     - Update README Release Information section                        │
 │     - Generate release-metadata.yaml                                    │
 │     - Commit + push snapshot branch                                     │
 │                    │                                                    │
 │                    ▼                                                    │
 │  9. Create release-review branch from snapshot HEAD                     │
-│     9a. Update README Release Information section                       │
-│     9b. Generate CHANGELOG draft → CHANGELOG/CHANGELOG-r4.md           │
+│     9a. Generate CHANGELOG draft → CHANGELOG/CHANGELOG-r4.md           │
 │     - Push release-review branch                                        │
 │                    │                                                    │
 │                    ▼                                                    │
-│  10. Create Release PR: release-review → snapshot (2 commits diff)      │
+│  10. Create Release PR: release-review → snapshot (1 commit diff)       │
 │      Title: "Release Review: RepoName r4.1 (RC, Sync26)"               │
 │                    │                                                    │
 │                    ▼                                                    │

--- a/release_automation/scripts/snapshot_creator.py
+++ b/release_automation/scripts/snapshot_creator.py
@@ -300,6 +300,18 @@ class SnapshotCreator:
             if os.path.exists(plan_path):
                 os.remove(plan_path)
 
+            # Step 9c: Update README Release Information
+            # Mechanical, like the transforms above — committed with the snapshot,
+            # not left editable on the release-review branch.
+            try:
+                self._update_readme(
+                    temp_dir, config, release_plan, api_versions, metadata
+                )
+            except ReadmeUpdateError as e:
+                result.warnings.append(f"README update skipped: {e}")
+            except Exception as e:
+                result.warnings.append(f"README update failed: {e}")
+
             # Step 10: Commit changes
             commit_message = f"Release automation: create snapshot {snapshot_id}"
             git_ops.commit_all(commit_message)
@@ -310,21 +322,7 @@ class SnapshotCreator:
             # Step 12a: Create release-review branch from snapshot
             git_ops.create_branch(release_review_branch, from_ref="HEAD")
 
-            # Step 12b: Update README Release Information
-            try:
-                readme_changed = self._update_readme(
-                    temp_dir, config, release_plan, api_versions, metadata
-                )
-                if readme_changed:
-                    git_ops.commit_all(
-                        f"Update README Release Information for {config.release_tag}"
-                    )
-            except ReadmeUpdateError as e:
-                result.warnings.append(f"README update skipped: {e}")
-            except Exception as e:
-                result.warnings.append(f"README update failed: {e}")
-
-            # Step 12c: Generate CHANGELOG draft
+            # Step 12b: Generate CHANGELOG draft
             api_comparison_baselines: Dict[str, str] = {}
             try:
                 repo_name = self.gh.repo.split("/")[-1]

--- a/release_automation/tests/test_snapshot_creator.py
+++ b/release_automation/tests/test_snapshot_creator.py
@@ -436,6 +436,71 @@ class TestCreateSnapshot:
     @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
     @patch("release_automation.scripts.snapshot_creator.GitOperations")
     @patch("builtins.open", create=True)
+    def test_release_review_branch_differs_only_by_changelog(
+        self,
+        mock_open,
+        mock_git_ops_class,
+        mock_rmtree,
+        mock_mkdtemp,
+        mock_changelog_cls,
+        snapshot_creator,
+        mock_github_client,
+        sample_release_plan,
+    ):
+        """README is part of the snapshot commit; only CHANGELOG is added
+        on top of it on the release-review branch."""
+        mock_mkdtemp.return_value = "/tmp/test-snapshot"
+
+        mock_git_ops = MagicMock()
+        mock_git_ops_class.return_value = mock_git_ops
+        mock_git_ops.create_pr.return_value = PullRequestInfo(
+            number=42, url="https://github.com/owner/repo/pull/42"
+        )
+        mock_github_client.get_releases.return_value = []
+        mock_github_client.generate_release_notes.return_value = None
+
+        mock_changelog_instance = Mock()
+        mock_changelog_instance.generate_draft.return_value = "# r4.1\n\nContent\n"
+        mock_changelog_instance.write_changelog.return_value = (
+            "CHANGELOG/CHANGELOG-r4.md"
+        )
+        mock_changelog_cls.return_value = mock_changelog_instance
+
+        config = SnapshotConfig(release_tag="r4.1")
+        result = snapshot_creator.create_snapshot(sample_release_plan, config)
+
+        assert result.success is True
+
+        commit_messages = [
+            call.args[0] for call in mock_git_ops.commit_all.call_args_list
+        ]
+        assert commit_messages == [
+            f"Release automation: create snapshot {result.snapshot_id}",
+            "Add CHANGELOG draft for r4.1",
+        ]
+        assert not any("README" in msg for msg in commit_messages)
+
+        # The snapshot commit (README included) happens before the
+        # release-review branch is cut from it; CHANGELOG is added after.
+        method_names = [c[0] for c in mock_git_ops.method_calls]
+        snapshot_commit_index = method_names.index("commit_all")
+        create_review_branch_index = method_names.index(
+            "create_branch", snapshot_commit_index
+        )
+        changelog_commit_index = method_names.index(
+            "commit_all", create_review_branch_index
+        )
+        assert (
+            snapshot_commit_index
+            < create_review_branch_index
+            < changelog_commit_index
+        )
+
+    @patch("release_automation.scripts.snapshot_creator.ChangelogGenerator")
+    @patch("release_automation.scripts.snapshot_creator.tempfile.mkdtemp")
+    @patch("release_automation.scripts.snapshot_creator.shutil.rmtree")
+    @patch("release_automation.scripts.snapshot_creator.GitOperations")
+    @patch("builtins.open", create=True)
     def test_changelog_keeps_release_tag_in_dependency_line(
         self,
         mock_open,

--- a/validation/engines/python_checks/release_review_checks.py
+++ b/validation/engines/python_checks/release_review_checks.py
@@ -1,7 +1,7 @@
 """Release review PR checks.
 
 Validates that release review PRs (targeting release-snapshot branches)
-only modify allowed files (CHANGELOG.md, CHANGELOG/, README.md).
+only modify allowed files (CHANGELOG.md, CHANGELOG/).
 """
 
 from __future__ import annotations
@@ -18,7 +18,9 @@ from ._types import make_finding
 logger = logging.getLogger(__name__)
 
 # Files and directories allowed to change on release review PRs.
-_ALLOWED_PATHS = frozenset({"CHANGELOG.md", "README.md"})
+# README.md is a mechanical change committed with the snapshot — not
+# reviewable content, so it is not on this list.
+_ALLOWED_PATHS = frozenset({"CHANGELOG.md"})
 _ALLOWED_PREFIXES = ("CHANGELOG/",)
 
 
@@ -94,7 +96,7 @@ def check_release_review_file_restriction(
     Only runs when ``context.is_release_review_pr`` is ``True``.
     Returns empty list otherwise.
 
-    Allowed files: CHANGELOG.md, CHANGELOG/*, README.md.
+    Allowed files: CHANGELOG.md, CHANGELOG/*.
     All other files on the snapshot branch are immutable.
     """
     if not context.is_release_review_pr:
@@ -113,8 +115,8 @@ def check_release_review_file_restriction(
                     level="error",
                     message=(
                         f"File '{file_path}' must not be modified on a "
-                        f"release review PR — only CHANGELOG.md, CHANGELOG/, "
-                        f"and README.md are allowed"
+                        f"release review PR — only CHANGELOG.md and CHANGELOG/ "
+                        f"are allowed"
                     ),
                     path=file_path,
                     line=1,

--- a/validation/rules/python-rules.yaml
+++ b/validation/rules/python-rules.yaml
@@ -152,7 +152,7 @@
 - id: P-012
   engine: python
   engine_rule: check-release-review-file-restriction
-  short_title: "Release Review PR: only docs may change"
+  short_title: "Release Review PR: only CHANGELOG may change"
   applicability:
     is_release_review_pr: true
   conditional_level:

--- a/validation/tests/test_python_checks_release_review.py
+++ b/validation/tests/test_python_checks_release_review.py
@@ -52,8 +52,8 @@ class TestIsAllowed:
     def test_changelog_md(self):
         assert _is_allowed("CHANGELOG.md") is True
 
-    def test_readme_md(self):
-        assert _is_allowed("README.md") is True
+    def test_readme_md_rejected(self):
+        assert _is_allowed("README.md") is False
 
     def test_changelog_dir_file(self):
         assert _is_allowed("CHANGELOG/r1.0.md") is True
@@ -82,9 +82,19 @@ class TestCheckReleaseReviewFileRestriction:
         "validation.engines.python_checks.release_review_checks._get_changed_files"
     )
     def test_allowed_files_only(self, mock_changed, tmp_path: Path):
-        mock_changed.return_value = ["CHANGELOG.md", "README.md"]
+        mock_changed.return_value = ["CHANGELOG.md", "CHANGELOG/r1.0.md"]
         ctx = _make_context()
         assert check_release_review_file_restriction(tmp_path, ctx) == []
+
+    @patch(
+        "validation.engines.python_checks.release_review_checks._get_changed_files"
+    )
+    def test_readme_md_disallowed(self, mock_changed, tmp_path: Path):
+        mock_changed.return_value = ["CHANGELOG.md", "README.md"]
+        ctx = _make_context()
+        findings = check_release_review_file_restriction(tmp_path, ctx)
+        assert len(findings) == 1
+        assert "README.md" in findings[0]["message"]
 
     @patch(
         "validation.engines.python_checks.release_review_checks._get_changed_files"


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Reclassifies the README Release-Info block as a mechanical change, not reviewable content.

The block is now written during snapshot creation and committed together with the other
mechanical transforms, before the release-review branch is cut from the snapshot. It is dropped
from the P-012 release-review file-restriction whitelist (`README.md` removed from
`_ALLOWED_PATHS`), so it can no longer be hand-edited on the release-review branch — closing the
gap where such an edit merged into the tag but never reached `main`, because the post-release
sync only ever round-trips the delimited block.

The release-review branch now differs from the snapshot by exactly one commit (CHANGELOG), not
two.

#### Which issue(s) this PR fixes:

Fixes #430

#### Special notes for reviewers:

camaraproject/ReleaseManagement#654 is the matching documentation-only PR, updating the CAMARA
Release Management process docs to describe this same change. Both this PR and the P-012
tightening land together here because API repos pin
the same `@v1-rc` ref for `validation.yml` and `release-automation-reusable.yml` — splitting them
across separate tag moves would fail every release PR in the cohort.

#### Changelog input

```
 release-note
README Release Information is now written during snapshot creation, together with the other
mechanical changes, instead of on the release-review branch. It can no longer be edited there.
```

#### Additional documentation

Updates `release_automation/docs/technical-architecture.md`, `repository-setup.md`, and
`documentation/validation/release-prs.md` to describe README as a mechanical, snapshot-branch
change.

```
docs
```

