### PR TITLE
fix(validation): drop S-011 broken-ref cascade artifact, map invalid-ref to S-229

### DIFF
--- a/validation/engines/spectral_adapter.py
+++ b/validation/engines/spectral_adapter.py
@@ -178,6 +178,44 @@ def _normalize_path(source: str, repo_root: Optional[str] = None) -> str:
     return source
 
 
+def _normalize_message(message: str, repo_root: Optional[str] = None) -> str:
+    """Strip repo-root absolute-path prefixes embedded in message text.
+
+    Unlike ``source``, ``message`` is free text where an absolute runner
+    path can appear anywhere in the string (e.g. an ``invalid-ref``
+    diagnostic: ``"... does not exist @ '/home/runner/work/Repo/Repo/code/
+    common/x.yaml'"``), so every occurrence of the root prefix is replaced
+    rather than only a matching start.
+    """
+    if not message or not repo_root:
+        return message
+    root = repo_root.rstrip("/") + "/"
+    return message.replace(root, "")
+
+
+def _is_resolver_artifact(schema_path: Optional[str]) -> bool:
+    """Detect a Spectral resolver-hoisting artifact.
+
+    When a ``$ref`` under ``components.<type>.<Name>.properties.<prop>``
+    points to a missing JSON pointer in a file that otherwise exists,
+    Spectral hoists the external ref into a synthetic
+    ``components.<targetType>`` node in the referencing document and
+    source-maps findings against it to the *target* file. The finding's
+    JSONPath is truncated to that 2-segment container path because the
+    synthetic node has no deeper source map of its own.
+
+    No field-level ``given`` expression can legitimately bottom out at a
+    bare ``components.<container>`` path — every real check descends into
+    a named component or one of its properties — so a finding at exactly
+    that depth is always this hoisting artifact, never a real defect,
+    regardless of which rule produced it.
+    """
+    if not schema_path:
+        return False
+    segments = schema_path.split(".")
+    return len(segments) == 2 and segments[0] == "components"
+
+
 def normalize_finding(raw: dict, repo_root: Optional[str] = None) -> dict:
     """Convert one Spectral JSON finding to the common findings model.
 
@@ -232,7 +270,7 @@ def normalize_finding(raw: dict, repo_root: Optional[str] = None) -> dict:
         "engine": ENGINE_NAME,
         "engine_rule": raw.get("code", "unknown"),
         "level": level,
-        "message": raw.get("message", ""),
+        "message": _normalize_message(raw.get("message", ""), repo_root),
         "path": source,
         "schema_path": schema_path,
         "line": line,
@@ -259,6 +297,8 @@ def parse_spectral_output(
     Returns:
         List of findings conforming to the common findings model.
         Returns an empty list if *raw_json* is empty or not valid JSON.
+        Findings identified as Spectral resolver-hoisting artifacts (see
+        :func:`_is_resolver_artifact`) are dropped.
     """
     if not raw_json.strip():
         return []
@@ -276,9 +316,13 @@ def parse_spectral_output(
     findings = []
     for item in data:
         try:
-            findings.append(normalize_finding(item, repo_root=repo_root))
+            finding = normalize_finding(item, repo_root=repo_root)
         except (KeyError, TypeError) as exc:
             logger.warning("Skipping malformed Spectral finding: %s", exc)
+            continue
+        if _is_resolver_artifact(finding["schema_path"]):
+            continue
+        findings.append(finding)
     return findings
 
 

--- a/validation/rules/rule-inventory.yaml
+++ b/validation/rules/rule-inventory.yaml
@@ -14,13 +14,13 @@ version: 1
 generated: 2026-04-07
 
 summary:
-  total_implemented: 149
+  total_implemented: 150
   total_gap: 0
   total_manual: 25
   total_pending: 0
-  total_tested: 96
+  total_tested: 97
   by_engine:
-    spectral: 85
+    spectral: 86
     gherkin: 25
     python: 26
     yamllint: 13
@@ -378,6 +378,7 @@ tested_rules:
   S-223: [regression/r4.3-broken-spec-descriptions]
   S-225: [regression/r4.3-broken-spec-routing]
   S-227: [regression/r4.3-broken-spec-routing]
+  S-229: [regression/r4.3-broken-spec-bundler-collision]
   S-037: [regression/r4.3-broken-spec-schema-constraints]
   S-303: [regression/r4.3-broken-spec-schema-constraints]
   S-306: [regression/r4.3-broken-spec-routing]

--- a/validation/rules/spectral-rules.yaml
+++ b/validation/rules/spectral-rules.yaml
@@ -379,6 +379,14 @@
   engine_rule: typed-enum
   short_title: "enum value does not match schema type"
 
+# S-229 is appended out of alphabetical order (see validation-rules/039) —
+# the S-200 band is no longer strictly alphabetical by engine_rule.
+- id: S-229
+  engine: spectral
+  engine_rule: invalid-ref
+  short_title: "$ref target does not exist"
+  suggestion: "The $ref points to a JSON pointer that does not exist in the target file. Check the pointer name against the target's components section — a schema renamed or removed in a newer Commonalities release is the usual cause. Fix the reference in this API definition; do not edit code/common/."
+
 # ===== OWASP API Security Top 10 2023 (S-300+) =====
 # S-300 (owasp:api1:2023-no-numeric-ids) retired — replaced by S-037
 # (camara-no-numeric-resource-ids) in the custom-rule range. See tooling#282

--- a/validation/tests/test_postfilter_engine.py
+++ b/validation/tests/test_postfilter_engine.py
@@ -707,6 +707,31 @@ class TestRunPostFilter:
         assert result.findings[0]["suggestion"] == "Custom guidance."
         assert result.findings[0]["rule_id"] == "S-018"
 
+    def test_invalid_ref_enriches_to_s229(self, tmp_path: Path):
+        """Spectral's built-in `invalid-ref` maps to S-229 (validation-rules/039):
+        it previously reached the reader via the unmapped pass-through branch
+        with no rule_id, no short_title, and native `error` level."""
+        _write_rules(tmp_path, [{
+            "id": "S-229",
+            "engine": "spectral",
+            "engine_rule": "invalid-ref",
+            "short_title": "$ref target does not exist",
+            "suggestion": "Fix the reference in this API definition.",
+        }])
+        ctx = _make_context()
+        findings = [_make_finding(
+            engine_rule="invalid-ref",
+            level="error",
+            message="'#/components/schemas/Config' does not exist @ 'code/common/x.yaml'",
+        )]
+        result = run_post_filter(findings, ctx, tmp_path)
+
+        f = result.findings[0]
+        assert f["rule_id"] == "S-229"
+        assert f["short_title"] == "$ref target does not exist"
+        assert f["suggestion"] == "Fix the reference in this API definition."
+        assert f["level"] == "error"  # identity-only: engine level preserved
+
     def test_mapped_rule_without_suggestion_preserves_message(self, tmp_path: Path):
         """Rule without suggestion/message_override preserves engine message."""
         _write_rules(tmp_path, [{

--- a/validation/tests/test_rule_metadata_integrity.py
+++ b/validation/tests/test_rule_metadata_integrity.py
@@ -89,7 +89,7 @@ class TestStructuralIntegrity:
         for r in all_rules:
             counts[r.engine] = counts.get(r.engine, 0) + 1
         assert counts["python"] == 39
-        assert counts["spectral"] == 88
+        assert counts["spectral"] == 89
         assert counts["gherkin"] == 25
         assert counts["yamllint"] == 13
 
@@ -353,8 +353,8 @@ class TestMetadataQuality:
         """
         with_suggestions = [r.id for r in all_rules if r.suggestion is not None]
         with_overrides = [r.id for r in all_rules if r.message_override is not None]
-        assert len(with_suggestions) == 29, (
-            f"Expected 29 explicit suggestions (update test if adding "
+        assert len(with_suggestions) == 30, (
+            f"Expected 30 explicit suggestions (update test if adding "
             f"suggestions): {with_suggestions}"
         )
         assert len(with_overrides) == 0, (

--- a/validation/tests/test_spectral_adapter.py
+++ b/validation/tests/test_spectral_adapter.py
@@ -14,6 +14,8 @@ from validation.engines.spectral_adapter import (
     ENGINE_NAME,
     SpectralResult,
     _deduplicate_findings,
+    _is_resolver_artifact,
+    _normalize_message,
     _normalize_path,
     _resolve_spec_files,
     derive_api_name,
@@ -162,6 +164,63 @@ class TestNormalizePath:
         source = "/home/runner/work/RepoExtra/code/api.yaml"
         result = _normalize_path(source, "/home/runner/work/Repo")
         assert result == source
+
+
+# ---------------------------------------------------------------------------
+# TestNormalizeMessage
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMessage:
+    def test_absolute_path_embedded_in_message_stripped(self):
+        message = (
+            "'#/components/schemas/Config' does not exist @ "
+            "'/home/runner/work/Repo/Repo/code/common/CAMARA_event_common.yaml'"
+        )
+        result = _normalize_message(message, "/home/runner/work/Repo/Repo")
+        assert result == (
+            "'#/components/schemas/Config' does not exist @ "
+            "'code/common/CAMARA_event_common.yaml'"
+        )
+
+    def test_no_repo_root_unchanged(self):
+        message = "'#/components/schemas/Config' does not exist @ '/abs/path.yaml'"
+        assert _normalize_message(message, None) == message
+
+    def test_empty_message(self):
+        assert _normalize_message("", "/home/runner/work/Repo/Repo") == ""
+
+    def test_message_without_repo_root_unchanged(self):
+        message = "qualityOnDemand is not kebab-case"
+        assert _normalize_message(message, "/home/runner/work/Repo/Repo") == message
+
+
+# ---------------------------------------------------------------------------
+# TestIsResolverArtifact
+# ---------------------------------------------------------------------------
+
+
+class TestIsResolverArtifact:
+    def test_two_segment_components_path_is_artifact(self):
+        assert _is_resolver_artifact("components.schemas") is True
+
+    def test_two_segment_other_container_is_artifact(self):
+        assert _is_resolver_artifact("components.parameters") is True
+
+    def test_three_segment_path_is_not_artifact(self):
+        assert _is_resolver_artifact("components.schemas.Foo") is False
+
+    def test_five_segment_properties_path_is_not_artifact(self):
+        assert _is_resolver_artifact("components.schemas.Foo.properties.bar") is False
+
+    def test_non_components_two_segment_path_is_not_artifact(self):
+        assert _is_resolver_artifact("paths./test") is False
+
+    def test_none_is_not_artifact(self):
+        assert _is_resolver_artifact(None) is False
+
+    def test_empty_string_is_not_artifact(self):
+        assert _is_resolver_artifact("") is False
 
 
 # ---------------------------------------------------------------------------
@@ -362,6 +421,23 @@ class TestNormalizeFinding:
         assert finding["level"] == "hint"
         assert finding["path"] == "code/common/CAMARA_event_common.yaml"
 
+    def test_message_normalises_embedded_absolute_path(self):
+        """An absolute runner path embedded inside the message text (not
+        just `source`) is stripped when repo_root is provided."""
+        raw = {
+            **SAMPLE_SPECTRAL_FINDING,
+            "code": "invalid-ref",
+            "message": (
+                "'#/components/schemas/Config' does not exist @ "
+                "'/home/runner/work/R/R/code/common/CAMARA_event_common.yaml'"
+            ),
+        }
+        finding = normalize_finding(raw, repo_root="/home/runner/work/R/R")
+        assert finding["message"] == (
+            "'#/components/schemas/Config' does not exist @ "
+            "'code/common/CAMARA_event_common.yaml'"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TestParseSpectralOutput
@@ -462,6 +538,32 @@ class TestParseSpectralOutput:
         assert len(findings) == 1
         assert findings[0]["level"] == "error"
         assert findings[0]["path"] == "code/modules/Services/Services.yaml"
+
+    def test_resolver_artifact_finding_dropped(self):
+        """A finding whose schema_path is a bare 2-segment
+        `components.<container>` (the broken-$ref hoisting artifact,
+        validation-rules/039) is dropped regardless of engine_rule."""
+        artifact_finding = {
+            **SAMPLE_SPECTRAL_FINDING,
+            "code": "camara-properties-descriptions",
+            "path": ["components", "schemas"],
+            "message": '"schemas" property must be truthy',
+        }
+        raw = json.dumps([SAMPLE_SPECTRAL_FINDING, artifact_finding])
+        findings = parse_spectral_output(raw)
+        assert len(findings) == 1
+        assert findings[0]["engine_rule"] == "camara-path-casing-convention"
+
+    def test_non_artifact_components_finding_kept(self):
+        """A genuine 3+-segment components finding survives the guard."""
+        real_finding = {
+            **SAMPLE_SPECTRAL_FINDING,
+            "code": "camara-properties-descriptions",
+            "path": ["components", "schemas", "Foo", "properties", "bar"],
+        }
+        raw = json.dumps([real_finding])
+        findings = parse_spectral_output(raw)
+        assert len(findings) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/validation/tests/test_spectral_s011_components.py
+++ b/validation/tests/test_spectral_s011_components.py
@@ -17,6 +17,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from validation.engines.spectral_adapter import parse_spectral_output
+
 # ---------------------------------------------------------------------------
 # Paths & helpers (copied from test_spectral_gap_rules.py to keep this file
 # self-contained; the helpers are small enough that a shared conftest would
@@ -57,6 +59,41 @@ def _run_spectral(yaml_content: str) -> list[dict]:
     if result.stdout.strip():
         return json.loads(result.stdout)
     return []
+
+
+def _run_spectral_multi_file(entry_content: str, sibling_files: dict[str, str]) -> list[dict]:
+    """Like :func:`_run_spectral`, but writes the entry spec alongside sibling
+    files (e.g. a common-schema file) in the same directory, so a relative
+    `$ref` between them resolves the way it does in a real repo checkout.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        entry_path = Path(tmp_dir) / "entry.yaml"
+        entry_path.write_text(entry_content)
+        for name, content in sibling_files.items():
+            (Path(tmp_dir) / name).write_text(content)
+
+        env = {
+            "PATH": subprocess.os.environ.get("PATH", ""),
+            "NODE_PATH": str(_NODE_MODULES),
+            "HOME": subprocess.os.environ.get("HOME", ""),
+        }
+        result = subprocess.run(
+            [
+                "node",
+                str(_NODE_MODULES / ".bin" / "spectral"),
+                "lint",
+                str(entry_path),
+                "-r", str(_RULESET),
+                "--format", "json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        if result.stdout.strip():
+            return json.loads(result.stdout)
+        return []
 
 
 def _codes(findings: list[dict]) -> set[str]:
@@ -228,4 +265,58 @@ def test_parameter_in_components_missing_description_still_fires_s011():
     assert param_findings, (
         f"S-011 must still fire on components.parameters.* lacking description; "
         f"got S-011 findings = {s011}"
+    )
+
+
+def test_broken_ref_to_existing_common_file_does_not_fire_s011():
+    """Cascade artifact from validation-rules/039: a `$ref` under
+    `components.<type>.<Name>.properties.<prop>` pointing to a missing
+    JSON pointer in a common file that itself exists makes Spectral hoist
+    a synthetic `components.schemas` node and fire S-011 against it. That
+    2-segment finding must be dropped by the adapter's resolver-artifact
+    guard — asserted here through the real adapter pipeline
+    (`parse_spectral_output`), not just raw Spectral output, since the
+    guard lives in the adapter rather than the ruleset.
+    """
+    entry = _BASE_SPEC.replace(
+        '$ref: "#/components/schemas/ErrorInfo"',
+        '$ref: "#/components/schemas/Wrapper"',
+    ) + """\
+components:
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      description: OpenID Connect security scheme
+  schemas:
+    Wrapper:
+      type: object
+      description: Wrapper
+      properties:
+        config:
+          $ref: "./common.yaml#/components/schemas/Config"
+"""
+    common = """\
+components:
+  schemas:
+    Foo:
+      type: object
+      description: Foo
+      properties:
+        bar:
+          type: string
+          description: bar prop
+"""
+    raw_findings = _run_spectral_multi_file(entry, {"common.yaml": common})
+
+    # Sanity check the cascade actually reproduced (else the test proves nothing).
+    raw_s011 = _findings_for(raw_findings, "camara-properties-descriptions")
+    assert any(f.get("path") == ["components", "schemas"] for f in raw_s011), (
+        f"expected reproduction not observed; raw S-011 findings = {raw_s011}"
+    )
+
+    findings = parse_spectral_output(json.dumps(raw_findings))
+    s011 = [f for f in findings if f["engine_rule"] == "camara-properties-descriptions"]
+    assert s011 == [], (
+        f"S-011 must not survive the broken-ref cascade artifact; got {s011}"
     )


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

A `$ref` under `components.<type>.<Name>.properties.<prop>` that points to a missing JSON pointer in a file that otherwise exists makes Spectral hoist the ref into a synthetic `components.<container>` node. `camara-properties-descriptions` (S-011) then fires against that synthetic node, producing a mislocated, misleading finding in the wrong file, while the actual `invalid-ref` error reaches the reader unmapped — no `rule_id`, no `short_title`, and an absolute runner path in the message. This PR drops the artifact via a structural guard on the finding's JSONPath depth, maps `invalid-ref` to a new rule S-229 with a `short_title` and fix `suggestion`, and strips absolute runner paths out of finding messages generally, not just the `source` field.

- One real, correctly-labelled finding per broken `$ref`, instead of a cascade artifact plus an unlabelled error.
- S-229 carries a fix suggestion pointing codeowners at the referencing spec, not the common file.
- Finding messages no longer leak `/home/runner/work/...` runner paths.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #432

#### Special notes for reviewers:

The regression fixture `r4.3-broken-spec-bundler-collision` records this `invalid-ref` case in its unmapped fallback form; recapture is deferred to a follow-up after merge, per the existing branching-model precedent.

#### Changelog input

```
release-note
Drop the S-011 broken-ref cascade artifact and map Spectral's invalid-ref to new rule S-229
```

#### Additional documentation 

This section can be blank.



```
docs

```
