### PR TITLE
feat(validation): sync CommonalitiesTest regression branches from Commonalities main

### DIFF
--- a/.github/workflows/commonalities-regression-sync.yml
+++ b/.github/workflows/commonalities-regression-sync.yml
@@ -1,0 +1,303 @@
+# CommonalitiesTest Regression Sync — Reusable Workflow
+#
+# Owns the whole pipeline: diff-check Commonalities main against
+# CommonalitiesTest's synced state, sync code/common/ to CommonalitiesTest
+# main, cherry-pick that same commit onto every regression/* branch with no
+# exception, regenerate the mirror branch's templates on the same trigger,
+# then sweep every regression/* branch for a fixture deviation.
+# CommonalitiesTest itself carries no bespoke automation code of its own —
+# this workflow (and validation-regression.yml, which also calls it) is the
+# only place this pipeline lives.
+#
+# The diff-check compares content at specific paths rather than checking
+# whether Commonalities main moved: main can move for reasons outside
+# artifacts/common/ and artifacts/api-templates/, so a SHA comparison alone
+# would be neither necessary nor sufficient. Each sync only runs when its
+# own diff is non-empty; `force` controls one thing — whether the sweep
+# still runs when neither diff fired.
+#
+# The `sync` job runs diff-check, sync, cherry-pick, and mirror-template
+# regeneration as sequential steps in a single job rather than as separate
+# jobs or a matrix. A concurrency group only keeps one run pending at a
+# time — a newer pending request cancels an older one — so several jobs (or
+# matrix instances) sharing a group would cancel each other's queued slot
+# and silently drop work. A single job has exactly one requester per
+# trigger, so it can be queued safely across overlapping triggers.
+
+name: CommonalitiesTest Regression Sync
+
+on:
+  workflow_call:
+    inputs:
+      force:
+        description: >-
+          Run the sweep even when neither diff-check fired. Callers whose
+          trigger has no correlation with Commonalities' content (a tooling
+          push) should pass true unconditionally.
+        type: boolean
+        required: false
+        default: false
+
+env:
+  PYTHON_VERSION: "3.14"
+  TEST_REPO: camaraproject/CommonalitiesTest
+  MIRROR_BRANCH: regression/commonalities-main-mirror
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Sync: diff-check, sync-common, cherry-pick, mirror-regen ────────────
+  sync:
+    name: Diff, sync, cherry-pick, regenerate mirror templates
+    runs-on: ubuntu-latest
+    # Fixed group name rather than one keyed on github.ref: this job is
+    # called from several places (the scheduled/dispatch caller, the
+    # tooling-push job in validation-regression.yml, and any manual
+    # dispatch of either), each with a different ref, but all of them push
+    # to the same CommonalitiesTest branches and must not run at the same
+    # time. cancel-in-progress is false because this job pushes a sequence
+    # (main, then every regression/* branch) — cancelling it midway could
+    # leave main synced but branches not yet cherry-picked, with no later
+    # run able to detect that. Queueing lets a newer trigger wait for the
+    # current run to finish before it reads state.
+    concurrency:
+      group: commonalities-regression-sync-write
+      cancel-in-progress: false
+    outputs:
+      common_changed: ${{ steps.diff-common.outputs.common_changed }}
+      templates_changed: ${{ steps.diff-templates.outputs.templates_changed }}
+    steps:
+      # camara-validation has no contents permission. camara-release-automation
+      # has contents:write and is installed org-wide, so it provides the
+      # token used to push here, even though this is not release automation.
+      # It is registered as a bypass actor on CommonalitiesTest's
+      # code-owner-review ruleset so the direct push to main is allowed.
+      - name: Mint release automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: camaraproject
+          repositories: CommonalitiesTest
+
+      - name: Checkout tooling
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            validation/scripts
+            requirements.txt
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install script dependencies
+        run: pip install --quiet -r requirements.txt
+
+      - name: Checkout Commonalities main
+        uses: actions/checkout@v7
+        with:
+          repository: camaraproject/Commonalities
+          ref: main
+          sparse-checkout: |
+            artifacts/common
+            artifacts/api-templates
+          path: _commonalities
+
+      - name: Record Commonalities HEAD
+        id: commonalities-head
+        run: echo "sha=$(git -C _commonalities rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Full checkouts, not sparse: each clone is reused later in the job to
+      # commit and push, so it needs the complete working tree, including
+      # release-plan.yaml, from the start.
+      - name: Checkout CommonalitiesTest main
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.TEST_REPO }}
+          ref: main
+          path: _test_main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout CommonalitiesTest mirror branch
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.TEST_REPO }}
+          ref: ${{ env.MIRROR_BRANCH }}
+          path: _test_mirror
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Diff common
+        id: diff-common
+        run: |
+          python3 validation/scripts/commonalities_regression_sync.py diff-common \
+            --source _commonalities/artifacts/common \
+            --dest _test_main/code/common \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Diff templates
+        id: diff-templates
+        run: |
+          python3 validation/scripts/commonalities_regression_sync.py diff-templates \
+            --source _commonalities/artifacts/api-templates \
+            --dest _test_mirror/code/API_definitions \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Sync code/common and push to main
+        id: sync-common
+        if: steps.diff-common.outputs.common_changed == 'true'
+        run: |
+          python3 validation/scripts/commonalities_regression_sync.py sync-common \
+            --source _commonalities/artifacts/common \
+            --dest _test_main/code/common \
+            --release-plan _test_main/release-plan.yaml
+
+          cd _test_main
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add code/common/
+          if git diff --cached --quiet; then
+            echo "::error::diff-check reported common_changed=true but nothing to commit"
+            exit 1
+          fi
+          git commit -m "chore: sync common files from Commonalities main@${COMMONALITIES_HEAD:0:7}"
+          git push origin main
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          COMMONALITIES_HEAD: ${{ steps.commonalities-head.outputs.sha }}
+
+      # Reuses the _test_main clone for every branch instead of a separate
+      # checkout per branch. The explicit refspec on `git fetch` is
+      # required: `git fetch origin <branch>` on its own only updates
+      # FETCH_HEAD, not refs/remotes/origin/<branch>, so `origin/<branch>`
+      # would not exist yet for the following checkout.
+      - name: Cherry-pick onto every regression/* branch
+        if: steps.diff-common.outputs.common_changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SYNC_SHA: ${{ steps.sync-common.outputs.sha }}
+        run: |
+          cd _test_main
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCHES=$(gh api "repos/${{ env.TEST_REPO }}/branches" --paginate \
+            --jq '.[].name | select(startswith("regression/"))' | sort)
+          if [ -z "$BRANCHES" ]; then
+            echo "::error::No regression/* branches found on ${{ env.TEST_REPO }}"
+            exit 1
+          fi
+
+          for branch in $BRANCHES; do
+            echo "Cherry-picking onto $branch"
+            git fetch origin "$branch:refs/remotes/origin/$branch"
+            git checkout -B "$branch" "origin/$branch"
+            git cherry-pick -x "$SYNC_SHA"
+            git push origin "$branch"
+          done
+
+      - name: Regenerate mirror templates and push
+        if: steps.diff-templates.outputs.templates_changed == 'true'
+        env:
+          COMMONALITIES_HEAD: ${{ steps.commonalities-head.outputs.sha }}
+        run: |
+          python3 validation/scripts/commonalities_regression_sync.py sync-templates \
+            --source _commonalities/artifacts/api-templates \
+            --dest _test_mirror/code/API_definitions
+
+          cd _test_mirror
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add code/API_definitions/
+          if git diff --cached --quiet; then
+            echo "::error::diff-check reported templates_changed=true but nothing to commit"
+            exit 1
+          fi
+          git commit -m "chore: regenerate templates from Commonalities main@${COMMONALITIES_HEAD:0:7}"
+          git push origin "${{ env.MIRROR_BRANCH }}"
+
+      - name: Record diagnostic trail
+        if: always()
+        run: |
+          {
+            echo "## CommonalitiesTest regression sync"
+            echo ""
+            echo "- Commonalities HEAD: \`${{ steps.commonalities-head.outputs.sha }}\`"
+            echo "- common_changed: \`${{ steps.diff-common.outputs.common_changed }}\`"
+            echo "- templates_changed: \`${{ steps.diff-templates.outputs.templates_changed }}\`"
+            echo "- force: \`${{ inputs.force }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Sweep: regression_runner.py against every regression/* branch ──────
+  sweep:
+    name: Sweep CommonalitiesTest
+    needs: sync
+    if: >-
+      always() &&
+      needs.sync.result == 'success' &&
+      (needs.sync.outputs.common_changed == 'true' ||
+       needs.sync.outputs.templates_changed == 'true' ||
+       inputs.force == true)
+    runs-on: ubuntu-latest
+    # A separate group from the sync job, with cancel-in-progress: true:
+    # this job only dispatches and diffs (same as validation-regression.yml's
+    # canary job), so a stale sweep can be cancelled in favor of a fresher
+    # one. Kept separate from the sync job's lock so a new trigger's sync
+    # phase does not have to wait for a previous run's sweep to finish.
+    concurrency:
+      group: commonalities-regression-sync-sweep
+      cancel-in-progress: true
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install runner dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --quiet -r requirements.txt
+
+      - name: Mint validation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VALIDATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VALIDATION_APP_PRIVATE_KEY }}
+          owner: camaraproject
+          repositories: CommonalitiesTest
+
+      - name: Run regression runner
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python3 validation/scripts/regression_runner.py \
+            --repo ${{ env.TEST_REPO }} \
+            --branch-filter 'regression/*' \
+            --summary-file commonalities-regression-summary.md
+
+      - name: Publish summary
+        if: always()
+        run: |
+          if [ -f commonalities-regression-summary.md ]; then
+            cat commonalities-regression-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::commonalities-regression-summary.md not produced (runner likely failed before writing)"
+          fi
+
+      - name: Upload summary artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: commonalities-regression-summary
+          path: commonalities-regression-summary.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/commonalities-regression.yml
+++ b/.github/workflows/commonalities-regression.yml
@@ -1,0 +1,29 @@
+# Commonalities Regression Testing (canary)
+#
+# Scheduled and manually dispatched sync/cherry-pick/sweep against
+# camaraproject/CommonalitiesTest. Does not touch ReleaseTest, which
+# validation-regression.yml sweeps separately and also calls into the same
+# reusable workflow used here.
+
+name: Commonalities Regression
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: >-
+          Run the sweep even if neither the common nor the templates diff
+          fired (e.g. to re-confirm a fixture after a manual recapture).
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  sync-and-sweep:
+    name: Sync and sweep
+    uses: ./.github/workflows/commonalities-regression-sync.yml
+    with:
+      force: ${{ inputs.force || false }}
+    secrets: inherit

--- a/.github/workflows/validation-regression.yml
+++ b/.github/workflows/validation-regression.yml
@@ -15,6 +15,12 @@
 # The default GITHUB_TOKEN is only used for the initial checkout.
 #
 # See validation/docs/regression-testing.md for the full picture.
+#
+# Also sweeps camaraproject/CommonalitiesTest via the same trigger, forced
+# unconditionally: a tooling push has no correlation with Commonalities'
+# own content, so without `force` the CommonalitiesTest diff-check would
+# almost always come back empty here, and the sweep would essentially
+# never fire from this path.
 
 name: Validation Regression
 
@@ -95,3 +101,10 @@ jobs:
           path: validation-regression-summary.md
           if-no-files-found: warn
           retention-days: 30
+
+  commonalities-regression:
+    name: CommonalitiesTest regression (forced)
+    uses: ./.github/workflows/commonalities-regression-sync.yml
+    with:
+      force: true
+    secrets: inherit

--- a/validation/scripts/commonalities_regression_sync.py
+++ b/validation/scripts/commonalities_regression_sync.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+CAMARA Validation Framework — CommonalitiesTest Regression Sync
+
+Path-scoped content diff and copy/manifest logic for the tooling-owned
+CommonalitiesTest regression pipeline. Each sub-command operates on
+already-checked-out local directories; the calling workflow owns cloning,
+committing, cherry-picking, and pushing.
+
+Sub-commands:
+    diff-common     --source DIR --dest DIR [--github-output FILE]
+    diff-templates  --source DIR --dest DIR [--github-output FILE]
+    sync-common     --source DIR --dest DIR --release-plan FILE
+    sync-templates  --source DIR --dest DIR
+
+diff-* sub-commands write `common_changed=true|false` /
+`templates_changed=true|false` to $GITHUB_OUTPUT (or --github-output) and
+always exit 0 — the diff result is data, not a pass/fail signal.
+
+The diff is a path-scoped content compare, not a HEAD-moved check: the
+Commonalities `main` HEAD can move for reasons entirely outside these
+paths, so a raw SHA comparison is neither necessary nor sufficient for
+"there is something to sync."
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+MANIFEST_FILENAME = ".sync-manifest.yaml"
+
+
+def git_blob_sha(content: bytes) -> str:
+    """SHA-1 matching `git hash-object` / the GitHub Contents API `.sha` field."""
+    header = f"blob {len(content)}\0".encode("ascii")
+    return hashlib.sha1(header + content).hexdigest()
+
+
+def _yaml_files(directory: Path) -> dict[str, Path]:
+    return {
+        p.name: p
+        for p in sorted(directory.glob("*.yaml"))
+        if p.name != MANIFEST_FILENAME
+    }
+
+
+def diff_yaml_dirs(source: Path, dest: Path) -> bool:
+    """True if the `*.yaml` file set or content of `dest` differs from `source`.
+
+    `source` must exist. A missing `dest` counts as changed (nothing synced
+    yet). `.sync-manifest.yaml` in `dest` is not a source file and is ignored.
+    """
+    if not source.is_dir():
+        raise FileNotFoundError(f"source directory not found: {source}")
+    if not dest.is_dir():
+        return True
+
+    source_files = _yaml_files(source)
+    dest_files = _yaml_files(dest)
+
+    if set(source_files) != set(dest_files):
+        return True
+
+    for name, source_path in source_files.items():
+        if source_path.read_bytes() != dest_files[name].read_bytes():
+            return True
+
+    return False
+
+
+def read_commonalities_release(release_plan_path: Path) -> str:
+    """Read `commonalities_release` from a CommonalitiesTest `release-plan.yaml`.
+
+    The synced manifest's `release` field must string-agree with this value
+    (P-021's sync-status check) -- reading it here keeps release-plan.yaml
+    the single place that changes when Commonalities advances its target
+    release, instead of also hardcoding the value into the pipeline.
+    """
+    data = yaml.safe_load(release_plan_path.read_text(encoding="utf-8"))
+    return data["commonalities_release"]
+
+
+def sync_common(source: Path, dest: Path, release_label: str) -> dict[str, str]:
+    """Copy `*.yaml` from `source` into `dest`, replacing `dest`'s current set.
+
+    Writes `.sync-manifest.yaml` in `dest` per the shape the RA sync-common
+    handler already produces (tooling_lib.cache_sync's expected schema).
+    Returns the filename -> git-blob-sha map written into the manifest.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for stale in _yaml_files(dest).values():
+        stale.unlink()
+
+    files: dict[str, str] = {}
+    for name, source_path in sorted(_yaml_files(source).items()):
+        content = source_path.read_bytes()
+        (dest / name).write_bytes(content)
+        files[name] = git_blob_sha(content)
+
+    manifest = {
+        "sources": [
+            {
+                "repository": "Commonalities",
+                "release": release_label,
+                "files": files,
+            }
+        ]
+    }
+    (dest / MANIFEST_FILENAME).write_text(
+        yaml.dump(manifest, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    return files
+
+
+def sync_templates(source: Path, dest: Path) -> list[str]:
+    """Copy `*.yaml` from `source` into `dest`, replacing `dest`'s current set.
+
+    Unsubstituted — a faithful copy including Commonalities' own placeholder
+    markers. Models the fresh mirror, not a published API repository.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for stale in _yaml_files(dest).values():
+        stale.unlink()
+
+    copied = []
+    for name, source_path in sorted(_yaml_files(source).items()):
+        (dest / name).write_bytes(source_path.read_bytes())
+        copied.append(name)
+    return copied
+
+
+def _write_github_output(path: str | None, key: str, value: str) -> None:
+    line = f"{key}={value}\n"
+    if path:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line)
+    else:
+        print(line, end="")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="commonalities_regression_sync.py", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_common_args(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--source", required=True, type=Path)
+        p.add_argument("--dest", required=True, type=Path)
+
+    p_diff_common = sub.add_parser("diff-common")
+    add_common_args(p_diff_common)
+    p_diff_common.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+
+    p_diff_templates = sub.add_parser("diff-templates")
+    add_common_args(p_diff_templates)
+    p_diff_templates.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+
+    p_sync_common = sub.add_parser("sync-common")
+    add_common_args(p_sync_common)
+    p_sync_common.add_argument("--release-plan", required=True, type=Path)
+
+    p_sync_templates = sub.add_parser("sync-templates")
+    add_common_args(p_sync_templates)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "diff-common":
+        changed = diff_yaml_dirs(args.source, args.dest)
+        _write_github_output(args.github_output, "common_changed", "true" if changed else "false")
+        print(f"common_changed={'true' if changed else 'false'}")
+        return 0
+
+    if args.command == "diff-templates":
+        changed = diff_yaml_dirs(args.source, args.dest)
+        _write_github_output(args.github_output, "templates_changed", "true" if changed else "false")
+        print(f"templates_changed={'true' if changed else 'false'}")
+        return 0
+
+    if args.command == "sync-common":
+        release_label = read_commonalities_release(args.release_plan)
+        files = sync_common(args.source, args.dest, release_label=release_label)
+        print(f"synced {len(files)} common file(s) into {args.dest} (release={release_label})")
+        return 0
+
+    if args.command == "sync-templates":
+        copied = sync_templates(args.source, args.dest)
+        print(f"synced {len(copied)} template file(s) into {args.dest}")
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/tests/test_commonalities_regression_sync.py
+++ b/validation/tests/test_commonalities_regression_sync.py
@@ -1,0 +1,208 @@
+"""Unit tests for validation.scripts.commonalities_regression_sync.
+
+Covers pure-logic functions only: content diff (added/removed/modified) and
+copy+manifest writing. Git/gh orchestration is verified manually during
+integration (same convention as test_regression_runner.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _ROOT / "validation" / "scripts" / "commonalities_regression_sync.py"
+_spec = importlib.util.spec_from_file_location("commonalities_regression_sync", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+crs = importlib.util.module_from_spec(_spec)
+sys.modules["commonalities_regression_sync"] = crs
+_spec.loader.exec_module(crs)
+
+
+diff_yaml_dirs = crs.diff_yaml_dirs
+read_commonalities_release = crs.read_commonalities_release
+sync_common = crs.sync_common
+sync_templates = crs.sync_templates
+MANIFEST_FILENAME = crs.MANIFEST_FILENAME
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# diff_yaml_dirs
+# ---------------------------------------------------------------------------
+
+
+def test_diff_identical_dirs_is_unchanged(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    _write(dest / "a.yaml", "a: 1\n")
+
+    assert diff_yaml_dirs(source, dest) is False
+
+
+def test_diff_modified_file_is_changed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    _write(dest / "a.yaml", "a: 2\n")
+
+    assert diff_yaml_dirs(source, dest) is True
+
+
+def test_diff_added_file_is_changed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    _write(source / "b.yaml", "b: 1\n")
+    _write(dest / "a.yaml", "a: 1\n")
+
+    assert diff_yaml_dirs(source, dest) is True
+
+
+def test_diff_removed_file_is_changed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    _write(dest / "a.yaml", "a: 1\n")
+    _write(dest / "b.yaml", "b: 1\n")
+
+    assert diff_yaml_dirs(source, dest) is True
+
+
+def test_diff_ignores_manifest_file_in_dest(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    _write(dest / "a.yaml", "a: 1\n")
+    _write(dest / MANIFEST_FILENAME, "sources: []\n")
+
+    assert diff_yaml_dirs(source, dest) is False
+
+
+def test_diff_missing_dest_dir_is_changed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+
+    assert diff_yaml_dirs(source, dest) is True
+
+
+def test_diff_missing_source_dir_raises(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(dest / "a.yaml", "a: 1\n")
+
+    with pytest.raises(FileNotFoundError):
+        diff_yaml_dirs(source, dest)
+
+
+# ---------------------------------------------------------------------------
+# read_commonalities_release
+# ---------------------------------------------------------------------------
+
+
+def test_read_commonalities_release(tmp_path: Path) -> None:
+    path = tmp_path / "release-plan.yaml"
+    _write(path, "commonalities_release: r4.4\nrelease_track: independent\n")
+
+    assert read_commonalities_release(path) == "r4.4"
+
+
+def test_read_commonalities_release_missing_key_raises(tmp_path: Path) -> None:
+    path = tmp_path / "release-plan.yaml"
+    _write(path, "release_track: independent\n")
+
+    with pytest.raises(KeyError):
+        read_commonalities_release(path)
+
+
+# ---------------------------------------------------------------------------
+# sync_common
+# ---------------------------------------------------------------------------
+
+
+def test_sync_common_copies_files_and_writes_manifest(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "CAMARA_common.yaml", "a: 1\n")
+    _write(source / "CAMARA_event_common.yaml", "b: 1\n")
+    dest.mkdir(parents=True)
+
+    files = sync_common(source, dest, release_label="r4.4")
+
+    assert (dest / "CAMARA_common.yaml").read_text(encoding="utf-8") == "a: 1\n"
+    assert (dest / "CAMARA_event_common.yaml").read_text(encoding="utf-8") == "b: 1\n"
+    assert set(files) == {"CAMARA_common.yaml", "CAMARA_event_common.yaml"}
+
+    manifest = yaml.safe_load((dest / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert manifest["sources"][0]["repository"] == "Commonalities"
+    assert manifest["sources"][0]["release"] == "r4.4"
+    assert manifest["sources"][0]["files"] == files
+
+
+def test_sync_common_removes_stale_dest_file(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    _write(dest / "a.yaml", "a: 1\n")
+    _write(dest / "stale.yaml", "stale: true\n")
+
+    sync_common(source, dest, release_label="r4.4")
+
+    assert not (dest / "stale.yaml").exists()
+
+
+def test_sync_common_manifest_sha_matches_git_hash_object(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    dest.mkdir(parents=True)
+
+    files = sync_common(source, dest, release_label="r4.4")
+
+    # git hash-object semantics: sha1("blob {len}\0" + content)
+    import hashlib
+
+    content = b"a: 1\n"
+    expected = hashlib.sha1(f"blob {len(content)}\0".encode() + content).hexdigest()
+    assert files["a.yaml"] == expected
+
+
+# ---------------------------------------------------------------------------
+# sync_templates
+# ---------------------------------------------------------------------------
+
+
+def test_sync_templates_copies_yaml_files_unsubstituted(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "sample-service.yaml", "externalDocs:\n  url: '{apiRepository}'\n")
+    dest.mkdir(parents=True)
+
+    copied = sync_templates(source, dest)
+
+    assert copied == ["sample-service.yaml"]
+    assert (dest / "sample-service.yaml").read_text(encoding="utf-8") == (
+        "externalDocs:\n  url: '{apiRepository}'\n"
+    )
+
+
+def test_sync_templates_removes_stale_dest_file(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _write(source / "a.yaml", "a: 1\n")
+    _write(dest / "old.yaml", "old: true\n")
+
+    sync_templates(source, dest)
+
+    assert not (dest / "old.yaml").exists()
+    assert (dest / "a.yaml").exists()


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds a tooling-owned pipeline that keeps a dedicated CommonalitiesTest regression repository's `regression/*` branches in sync with Commonalities `main` and sweeps them for validation-rule regressions. Each run diff-checks Commonalities `main` against what's already synced; when `code/common/` changed, it syncs it and cherry-picks the same commit onto every regression branch, and when the templates changed it regenerates one branch's API templates, then runs the existing regression-runner sweep against all of them. `validation-regression.yml` now also calls this pipeline, forced, on its existing regression-canary trigger.

- Automates a sync/cherry-pick/sweep loop that so far only existed as a one-time, hand-run bootstrap.
- Extends the tooling-push regression signal (catch a rule regression before release) to CommonalitiesTest, not just ReleaseTest.
- No new automation code needed in CommonalitiesTest itself.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

New workflow files can't be exercised via `workflow_dispatch` until merged to `main`; validated locally with `pytest` (new unit tests on the diff/copy logic) and `actionlint`. The job that writes to CommonalitiesTest (diff, sync, cherry-pick, template regen) mints a `camara-release-automation` App token rather than `camara-validation`'s, since the validation App currently has no `contents` permission.

#### Changelog input

```
 release-note
Add a tooling-owned pipeline to keep CommonalitiesTest's regression branches synced with Commonalities and swept for validation-rule regressions.
```

#### Additional documentation

This section can be blank.

```
docs

```
