### PR TITLE
fix(validation): shorten regression job names for readability

### DIFF
--- a/.github/workflows/commonalities-regression-sync.yml
+++ b/.github/workflows/commonalities-regression-sync.yml
@@ -49,7 +49,7 @@ permissions:
 jobs:
   # ── Sync: diff-check, sync-common, cherry-pick, mirror-regen ────────────
   sync:
-    name: Diff, sync, cherry-pick, regenerate mirror templates
+    name: Sync
     runs-on: ubuntu-latest
     # Fixed group name rather than one keyed on github.ref: this job is
     # called from several places (the scheduled/dispatch caller, the
@@ -233,7 +233,7 @@ jobs:
 
   # ── Sweep: regression_runner.py against every regression/* branch ──────
   sweep:
-    name: Sweep CommonalitiesTest
+    name: Sweep
     needs: sync
     if: >-
       always() &&

--- a/.github/workflows/commonalities-regression.yml
+++ b/.github/workflows/commonalities-regression.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   sync-and-sweep:
-    name: Sync and sweep
+    name: CommonalitiesTest
     uses: ./.github/workflows/commonalities-regression-sync.yml
     with:
       force: ${{ inputs.force || false }}

--- a/.github/workflows/validation-regression.yml
+++ b/.github/workflows/validation-regression.yml
@@ -48,7 +48,7 @@ env:
 
 jobs:
   regression:
-    name: Regression canary
+    name: ReleaseTest canary
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tooling
@@ -103,7 +103,7 @@ jobs:
           retention-days: 30
 
   commonalities-regression:
-    name: CommonalitiesTest regression (forced)
+    name: CommonalitiesTest
     uses: ./.github/workflows/commonalities-regression-sync.yml
     with:
       force: true


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Renames job names across the three regression workflow files (`validation-regression.yml`, `commonalities-regression.yml`, `commonalities-regression-sync.yml`) so GitHub's Actions graph view shows which repository each job targets. Today "Regression canary" doesn't name ReleaseTest at all, and the CommonalitiesTest pipeline's caller and callee job names both repeat "CommonalitiesTest", so the combined string truncates past recognition in the graph view. Callers now name their target repo; the reusable workflow's own job names drop the now-redundant repeat of it.

No behavior change — `name:` fields only.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

`actionlint` and the leak scanner are clean on all three files.

#### Changelog input

```
 release-note
Improve regression job naming in the Actions UI so each job's target repository is visible without truncation.
```

#### Additional documentation

This section can be blank.

```
docs

```
