### PR TITLE
fix(validation): scope ReleaseTest canary's concurrency to its own job

### DIFF
--- a/.github/workflows/validation-regression.yml
+++ b/.github/workflows/validation-regression.yml
@@ -35,10 +35,6 @@ on:
       - '.github/workflows/validation-regression.yml'
   workflow_dispatch:
 
-concurrency:
-  group: validation-regression-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 
@@ -50,6 +46,15 @@ jobs:
   regression:
     name: ReleaseTest canary
     runs-on: ubuntu-latest
+    # Scoped to this job, not the whole workflow: a workflow-level
+    # concurrency group cancels every job in the run, including the
+    # commonalities-regression job below, which calls into a reusable
+    # workflow that must not be cancelled mid-push (see its own
+    # concurrency comments). This job only dispatches and diffs, so
+    # cancelling a stale run in favor of a fresher one is safe here.
+    concurrency:
+      group: validation-regression-release-test-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout tooling
         uses: actions/checkout@v7


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`validation-regression.yml`'s workflow-level concurrency group (`cancel-in-progress: true`) cancels the entire run, not just the ReleaseTest job it was originally scoped for. Since that job now shares its run with the CommonalitiesTest job, which calls into a reusable pipeline that pushes to CommonalitiesTest and must not be cancelled mid-push, an overlapping trigger cancelled the whole run including that job — confirmed live in [run 33193270039](https://github.com/camaraproject/tooling/actions/runs/33193270039). This moves the concurrency group onto the `regression` job alone, so the CommonalitiesTest job relies only on the reusable workflow's own internal locks.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

No change to CommonalitiesTest's own logic or locks. `actionlint` and the leak scanner are clean.

#### Changelog input

```
 release-note
Fix a concurrency bug where an overlapping push could cancel the CommonalitiesTest regression pipeline mid-run.
```

#### Additional documentation

This section can be blank.

```
docs

```
